### PR TITLE
Changed code generation logic

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/objects/managers/AccountLinkManager.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/managers/AccountLinkManager.java
@@ -67,10 +67,14 @@ public class AccountLinkManager {
     }
 
     public String generateCode(UUID playerUuid) {
-        int code = 0;
-        while (code < 1000) code = DiscordSRV.getPlugin().getRandom().nextInt(10000);
-        linkingCodes.put(String.valueOf(code), playerUuid);
-        return String.valueOf(code);
+        String codeString;
+        do {
+            // What if all 10000 keys are taken?
+            // It's really inefficient if many codes have already been generated
+            int code = DiscordSRV.getPlugin().getRandom().nextInt(10000);
+            codeString = String.format("%04d", code);
+        } while (linkingCodes.putIfAbsent(codeString, playerUuid) != null);
+        return codeString;
     }
 
     public String process(String linkCode, String discordId) {


### PR DESCRIPTION
In the previous code, there was 10% chance it'll loop again.
By introducing my changes, there's `10000 / linkingCodes.size()` % chance to loop again, but it also removes the possibility of overwriting currently existing codes.
It could be improved by generating a set of codes that aren't used and then randomly selecting one. Especially with max 10000 entries this shouldn't add much overhead.

It also allows link codes to start with zero, i.e. "0000" and "0001" will be valid codes.