### PR TITLE
Achievements > advancements

### DIFF
--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -6,7 +6,7 @@ BotToken: "BOTTOKEN"
 
 # Channel links from game to Discord
 # syntax is Channels: {"in-game channel name": "numerical channel ID from Discord", "another in-game channel name": "another numerical channel ID from Discord"}
-# The first channel pair specified in this config option will be the "main" channel, used for sending player joins/quits/deaths/advancements/etc
+# The first channel pair specified in this config option will be the "main" channel, used for sending player joins/quits/deaths/achievements/etc
 #
 Channels: {"global": "000000000000000000"}
 

--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -6,7 +6,7 @@ BotToken: "BOTTOKEN"
 
 # Channel links from game to Discord
 # syntax is Channels: {"in-game channel name": "numerical channel ID from Discord", "another in-game channel name": "another numerical channel ID from Discord"}
-# The first channel pair specified in this config option will be the "main" channel, used for sending player joins/quits/deaths/achievements/etc
+# The first channel pair specified in this config option will be the "main" channel, used for sending player joins/quits/deaths/advancements/etc
 #
 Channels: {"global": "000000000000000000"}
 

--- a/src/main/resources/messages/de.yml
+++ b/src/main/resources/messages/de.yml
@@ -152,7 +152,7 @@ MinecraftPlayerDeathMessageFormat: ":skull: **%deathmessage%**"
 # %date%:        aktuelles Datum mit Uhrzeit
 # PlaceholderAPI Platzhalter werden auch unterstützt
 #
-MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% hat die Errungenschaft %achievement% erhalten!**"
+MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% hat den Fortschritt %achievement% erreicht!**"
 
 # Discord-Channelbeschreibung
 # Dies sind die Optionen, um die Channelbeschreibung von Chat und Konsole automatisch auf Serverdaten zu aktualisieren.

--- a/src/main/resources/messages/en.yml
+++ b/src/main/resources/messages/en.yml
@@ -136,18 +136,18 @@ MinecraftPlayerLeaveMessageFormat: ":heavy_minus_sign: **%displayname% left the 
 #
 MinecraftPlayerDeathMessageFormat: ":skull: **%deathmessage%**"
 
-# Minecraft -> Discord achievement messages
+# Minecraft -> Discord advancement messages
 #
 # Available placeholders:
-# %achievement%: message content
+# %achievement%: title of the advancement
 # %displayname%: display name from things like nicknames
 # %username%:    raw player username
 # %world%:       the name of the world the user is in
-# %worldalias%:   alias of world player is in via Multiverse-Core
+# %worldalias%:  alias of world player is in via Multiverse-Core
 # %date%:        current date & time
 # PlaceholderAPI placeholders are also supported
 #
-MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% has just earned the achievement %achievement%!**"
+MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% has made the advancement %achievement%!**"
 
 # Channel topic updater messages
 # This is all the stuff related to automatically updating the chat or console channel's topics with server information

--- a/src/main/resources/messages/en.yml
+++ b/src/main/resources/messages/en.yml
@@ -136,10 +136,10 @@ MinecraftPlayerLeaveMessageFormat: ":heavy_minus_sign: **%displayname% left the 
 #
 MinecraftPlayerDeathMessageFormat: ":skull: **%deathmessage%**"
 
-# Minecraft -> Discord advancement messages
+# Minecraft -> Discord achievement messages
 #
 # Available placeholders:
-# %achievement%: title of the advancement
+# %achievement%: message content
 # %displayname%: display name from things like nicknames
 # %username%:    raw player username
 # %world%:       the name of the world the user is in

--- a/src/main/resources/messages/en.yml
+++ b/src/main/resources/messages/en.yml
@@ -136,10 +136,10 @@ MinecraftPlayerLeaveMessageFormat: ":heavy_minus_sign: **%displayname% left the 
 #
 MinecraftPlayerDeathMessageFormat: ":skull: **%deathmessage%**"
 
-# Minecraft -> Discord achievement messages
+# Minecraft -> Discord achievement/advancement messages
 #
 # Available placeholders:
-# %achievement%: message content
+# %achievement%: title of the achievement/advancement
 # %displayname%: display name from things like nicknames
 # %username%:    raw player username
 # %world%:       the name of the world the user is in

--- a/src/main/resources/messages/es.yml
+++ b/src/main/resources/messages/es.yml
@@ -145,7 +145,7 @@ MinecraftPlayerDeathMessageFormat: ":skull: **%deathmessage%**"
 # %date%:        fecha & tiempo actual
 # PlaceholderAPI placeholders tambien son compatibles
 #
-MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% ha conseguido el logro: %achievement%!**"
+MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% ha conseguido el progreso %achievement%!**"
 
 # Mensajes de actualización del tema del canal
 # Esto es todo lo relacionado con la actualización automática de los temas del chat o del canal de la consola con información del servidor

--- a/src/main/resources/messages/fr.yml
+++ b/src/main/resources/messages/fr.yml
@@ -145,7 +145,7 @@ MinecraftPlayerDeathMessageFormat: ":skull: **%deathmessage%**"
 # %date%:        date et heure actuelle
 # PlaceholderAPI les placeholders sont compatibles
 #
-MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% vient de remporter le succès %achievement%!**"
+MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% a réalisé le progrès %achievement%!**"
 
 # Messages de mise à jour des informations du canal
 # Il s'agit de toutes les choses liées à la mise à jour automatique des sujets du canal de discussion ou de la console avec les informations du serveur

--- a/src/main/resources/messages/ja.yml
+++ b/src/main/resources/messages/ja.yml
@@ -147,7 +147,7 @@ MinecraftPlayerDeathMessageFormat: ":skull: **%deathmessage%**"
 # %date%:        現在の日付と時間
 # PlaceholderAPIプレースホルダもサポートされています
 #
-MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% さんが、実績 %achievement% を得ました！**"
+MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% は進捗 %achievement% を達成した！**"
 
 # チャンネルトピックメッセージ
 # チャットチャンネルやコンソールチャンネルのトピックをサーバー情報で自動的に更新することに関連する設定です

--- a/src/main/resources/messages/ko.yml
+++ b/src/main/resources/messages/ko.yml
@@ -148,7 +148,7 @@ MinecraftPlayerDeathMessageFormat: ":skull: **%deathmessage%**"
 # %date%:        현재 시각 및 날짜
 # PlaceholderAPI 변수(placeholders) 또한 지원됩니다.
 #
-MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% 님이 도전과제 %achievement%를 달성하셨습니다!**"
+MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname%이(가) %achievement% 발전 과제를 달성했습니다!**"
 
 # 채널 토픽 업데이트 메세지
 # 여기에서는 채널 토픽 업데이트에 관련된 내용을 설정 하실 수 있습니다.

--- a/src/main/resources/messages/nl.yml
+++ b/src/main/resources/messages/nl.yml
@@ -147,7 +147,7 @@ MinecraftPlayerDeathMessageFormat: ":skull: **%deathmessage%**"
 # %date%:        Huidige datum en tijd.
 # PlaceholderAPI placeholders zijn ook ondersteund
 #
-MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% heeft een achievement gehaald %achievement%!**"
+MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% heeft vooruitgang %achievement% behaald!**"
 
 # Channel 'topic' updater berichten
 # Dit is alles dat te maken heeft met het automatisch updaten van de 'topic's van de console en chat kanalen.

--- a/src/main/resources/messages/ru.yml
+++ b/src/main/resources/messages/ru.yml
@@ -147,7 +147,7 @@ MinecraftPlayerDeathMessageFormat: ":skull: **%deathmessage%**"
 # %date%:        текущие время и дата
 # Также поддерживаются PlaceholderAPI шаблоны
 #
-MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% только что получил достижение %achievement%!**"
+MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% получил достижение %achievement%!**"
 
 # Сообщения тем каналов
 # Все эти опции помогут вам задать тему канала чата или консоли со всевозможной серверной информацией


### PR DESCRIPTION
Minecraft 1.12+ uses _advancements_ instead of _achievements_, therefore the messages in DiscordSRV should be updated too. 

I did not change any underlying code, as I feel this is not worthy of breaking every admin's config.