### PR TITLE
Remove DontSendCanceledChatEvents mention in canceled message debug m…

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -599,7 +599,7 @@ public class DiscordSRV extends JavaPlugin implements Listener {
 
         // return if event canceled
         if (getConfig().getBoolean("DontSendCanceledChatEvents") && cancelled) {
-            debug("User " + player.getName() + " sent a message but it was not delivered to Discord because the chat event was canceled and DontSendCanceledChatEvents is true");
+            debug("User " + player.getName() + " sent a message but it was not delivered to Discord because the chat event was canceled");
             return;
         }
 


### PR DESCRIPTION
…essage

Since so many people take things into their own hands and set that to true when they shouldn't/are told NOT to do, easy solution is to just not mention it in the first place.

Credit to @burturt