### PR TITLE
fix DoNotSendPhrasesActsAsWhitelist in case insensitive

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/objects/log4j/ConsoleAppender.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/log4j/ConsoleAppender.java
@@ -115,10 +115,8 @@ public class ConsoleAppender extends AbstractAppender {
         // if line contains a blocked phrase don't send it
         boolean doNotSendActsAsWhitelist = DiscordSRV.config().getBoolean("DiscordConsoleChannelDoNotSendPhrasesActsAsWhitelist");
         List<String> phrases = DiscordSRV.config().getStringList("DiscordConsoleChannelDoNotSendPhrases");
-        for (String phrase : phrases) {
-            if (line.toLowerCase().contains(phrase.toLowerCase()) == !doNotSendActsAsWhitelist) {
-                return;
-            }
+        if (phrases.stream().map(String::toLowerCase).anyMatch(line.toLowerCase()::contains) == !doNotSendActsAsWhitelist) {
+            return;
         }
 
         // queue final message


### PR DESCRIPTION
Hi, the `DiscordConsoleChannelDoNotSendPhrasesActsAsWhitelist` option broke again in v1.16.9

Same issue as #382

Please merge it if it's okay. Thank you.