### PR TITLE
Respect invisibility plugins

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerAchievementsListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerAchievementsListener.java
@@ -45,6 +45,9 @@ public class PlayerAchievementsListener implements Listener {
         // return if achievement or player objects are fucking knackered because this can apparently happen for some reason
         if (event == null || event.getAchievement() == null || event.getPlayer() == null) return;
 
+        // respect invisibility plugins
+        if (PlayerUtil.isVanished(event.getPlayer())) return;
+
         // turn "SHITTY_ACHIEVEMENT_NAME" into "Shitty Achievement Name"
         String achievementName = PrettyUtil.beautify(event.getAchievement());
 

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerAdvancementDoneListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerAdvancementDoneListener.java
@@ -21,6 +21,7 @@ package github.scarsz.discordsrv.listeners;
 import github.scarsz.discordsrv.DiscordSRV;
 import github.scarsz.discordsrv.util.DiscordUtil;
 import github.scarsz.discordsrv.util.LangUtil;
+import github.scarsz.discordsrv.util.PlayerUtil;
 import github.scarsz.discordsrv.util.PluginUtil;
 import github.scarsz.discordsrv.util.TimeUtil;
 import org.apache.commons.lang3.StringUtils;
@@ -46,6 +47,9 @@ public class PlayerAdvancementDoneListener implements Listener {
 
         // return if advancement or player objects are fucking knackered because this can apparently happen for some reason
         if (event.getAdvancement() == null || event.getAdvancement().getKey().getKey().contains("recipe/") || event.getPlayer() == null) return;
+
+        // respect invisibility plugins
+        if (PlayerUtil.isVanished(event.getPlayer())) return;
 
         try {
             Object craftAdvancement = ((Object) event.getAdvancement()).getClass().getMethod("getHandle").invoke(event.getAdvancement());

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerDeathListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerDeathListener.java
@@ -21,6 +21,7 @@ package github.scarsz.discordsrv.listeners;
 import github.scarsz.discordsrv.DiscordSRV;
 import github.scarsz.discordsrv.util.DiscordUtil;
 import github.scarsz.discordsrv.util.LangUtil;
+import github.scarsz.discordsrv.util.PlayerUtil;
 import github.scarsz.discordsrv.util.PluginUtil;
 import github.scarsz.discordsrv.util.TimeUtil;
 import org.apache.commons.lang3.StringUtils;
@@ -42,6 +43,9 @@ public class PlayerDeathListener implements Listener {
         if (event.getEntityType() != EntityType.PLAYER) return;
         if (StringUtils.isBlank(event.getDeathMessage())) return;
         if (StringUtils.isBlank(LangUtil.Message.PLAYER_DEATH.toString())) return;
+
+        // respect invisibility plugins
+        if (PlayerUtil.isVanished(event.getEntity())) return;
 
         String discordMessage = LangUtil.Message.PLAYER_DEATH.toString()
                 .replaceAll("%time%|%date%", TimeUtil.timeStamp())


### PR DESCRIPTION
Hi!

I often watch people playing on my server and don't want to interrupt them. To accomplish this, I use SuperVanish/PremiumVanish.
After installing DiscordSRV I discovered that the plugin doesn't respect invisibility plugins even though they are supported (but only being queried in a few situations).