### PR TITLE
Simplifying placeholders

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -47,7 +47,6 @@ import github.scarsz.discordsrv.objects.threads.ConsoleMessageQueueWorker;
 import github.scarsz.discordsrv.objects.threads.PresenceUpdater;
 import github.scarsz.discordsrv.objects.threads.ServerWatchdog;
 import github.scarsz.discordsrv.util.*;
-import javafx.print.PageLayout;
 import lombok.Getter;
 import me.vankka.reserializer.discord.DiscordSerializer;
 import me.vankka.reserializer.minecraft.MinecraftSerializer;

--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -47,6 +47,7 @@ import github.scarsz.discordsrv.objects.threads.ConsoleMessageQueueWorker;
 import github.scarsz.discordsrv.objects.threads.PresenceUpdater;
 import github.scarsz.discordsrv.objects.threads.ServerWatchdog;
 import github.scarsz.discordsrv.util.*;
+import javafx.print.PageLayout;
 import lombok.Getter;
 import me.vankka.reserializer.discord.DiscordSerializer;
 import me.vankka.reserializer.minecraft.MinecraftSerializer;
@@ -902,6 +903,8 @@ public class DiscordSRV extends JavaPlugin implements Listener {
                 .replace("%worldalias%", DiscordUtil.strip(MultiverseCoreHook.getWorldAlias(player.getWorld().getName())))
         ;
         discordMessage = PlaceholderUtil.applyAll(player, null, discordMessage, true);
+        discordMessage = PlaceholderUtil.applyLegacy("%primarygroup", userPrimaryGroup, discordMessage, "%minecraft_group");
+        discordMessage = PlaceholderUtil.applyLegacy("%username%", username, discordMessage, "%minecraft_playername%");
 
         String displayName = DiscordUtil.strip(player.getDisplayName());
         if (!reserializer) displayName = DiscordUtil.escapeMarkdown(displayName);

--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -898,12 +898,10 @@ public class DiscordSRV extends JavaPlugin implements Listener {
                 : LangUtil.Message.CHAT_TO_DISCORD_NO_PRIMARY_GROUP.toString())
                 .replaceAll("%time%|%date%", TimeUtil.timeStamp())
                 .replace("%channelname%", channel != null ? channel.substring(0, 1).toUpperCase() + channel.substring(1) : "")
-                .replace("%primarygroup%", userPrimaryGroup)
-                .replace("%username%", username)
                 .replace("%world%", player.getWorld().getName())
                 .replace("%worldalias%", DiscordUtil.strip(MultiverseCoreHook.getWorldAlias(player.getWorld().getName())))
         ;
-        if (PluginUtil.pluginHookIsEnabled("placeholderapi")) discordMessage = me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(player, discordMessage);
+        discordMessage = PlaceholderUtil.applyAll(player, null, discordMessage, true);
 
         String displayName = DiscordUtil.strip(player.getDisplayName());
         if (!reserializer) displayName = DiscordUtil.escapeMarkdown(displayName);

--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordChatListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordChatListener.java
@@ -56,8 +56,7 @@ public class DiscordChatListener extends ListenerAdapter {
         for (Map.Entry<String, String> entry : DiscordSRV.getPlugin().getResponses().entrySet()) {
             if (event.getMessage().getContentRaw().toLowerCase().startsWith(entry.getKey().toLowerCase())) {
                 String discordMessage = entry.getValue();
-                if (PluginUtil.pluginHookIsEnabled("placeholderapi"))
-                    discordMessage = me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(null, discordMessage);
+                discordMessage = PlaceholderUtil.applyAll(null, event.getAuthor(), discordMessage);
 
                 DiscordUtil.sendMessage(event.getChannel(), DiscordUtil.strip(discordMessage));
                 return; // found a canned response, return so the message doesn't get processed further
@@ -131,13 +130,10 @@ public class DiscordChatListener extends ListenerAdapter {
                         ? LangUtil.Message.CHAT_TO_MINECRAFT.toString()
                         : LangUtil.Message.CHAT_TO_MINECRAFT_NO_ROLE.toString();
 
+                placedMessage = PlaceholderUtil.applyAll(null, event.getAuthor(), placedMessage);
                 placedMessage = ChatColor.translateAlternateColorCodes('&', placedMessage
                         .replace("%message%", attachment.getUrl())
-                        .replace("%username%", DiscordUtil.strip(event.getMember().getEffectiveName()))
-                        .replace("%toprole%", DiscordUtil.getRoleName(!selectedRoles.isEmpty() ? selectedRoles.get(0) : null))
-                        .replace("%toproleinitial%", !selectedRoles.isEmpty() ? DiscordUtil.getRoleName(selectedRoles.get(0)).substring(0, 1) : "")
                         .replace("%toprolecolor%", DiscordUtil.convertRoleToMinecraftColor(!selectedRoles.isEmpty() ? selectedRoles.get(0) : null))
-                        .replace("%allroles%", DiscordUtil.getFormattedRoles(selectedRoles))
                         .replace("\\~", "~") // get rid of badly escaped characters
                         .replace("\\*", "") // get rid of badly escaped characters
                         .replace("\\_", "_") // get rid of badly escaped characters
@@ -184,14 +180,11 @@ public class DiscordChatListener extends ListenerAdapter {
         formatMessage = formatMessage
                 .replace("%channelname%", event.getChannel().getName())
                 .replace("%message%", message != null ? message : "<blank message>")
-                .replace("%username%", DiscordUtil.strip(event.getMember().getEffectiveName()))
-                .replace("%toprole%", DiscordUtil.getRoleName(!selectedRoles.isEmpty() ? selectedRoles.get(0) : null))
-                .replace("%toproleinitial%", !selectedRoles.isEmpty() ? DiscordUtil.getRoleName(selectedRoles.get(0)).substring(0, 1) : "")
                 .replace("%toprolecolor%", DiscordUtil.convertRoleToMinecraftColor(!selectedRoles.isEmpty() ? selectedRoles.get(0) : null))
-                .replace("%allroles%", DiscordUtil.getFormattedRoles(selectedRoles))
                 .replace("\\~", "~") // get rid of badly escaped characters
                 .replace("\\*", "") // get rid of badly escaped characters
                 .replace("\\_", "_"); // get rid of badly escaped characters
+        formatMessage = PlaceholderUtil.applyAll(null, event.getAuthor(), formatMessage);
 
         // translate color codes
         formatMessage = ChatColor.translateAlternateColorCodes('&', formatMessage);
@@ -239,7 +232,7 @@ public class DiscordChatListener extends ListenerAdapter {
                         .replace("%worldalias%", DiscordUtil.strip(MultiverseCoreHook.getWorldAlias(player.getWorld().getName())));
 
                 // use PlaceholderAPI if available
-                if (PluginUtil.pluginHookIsEnabled("placeholderapi")) playerFormat = me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(player, playerFormat);
+                playerFormat = PlaceholderUtil.applyPlaceholderApi(player, playerFormat);
 
                 players.add(playerFormat);
             }

--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordChatListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordChatListener.java
@@ -138,6 +138,10 @@ public class DiscordChatListener extends ListenerAdapter {
                         .replace("\\*", "") // get rid of badly escaped characters
                         .replace("\\_", "_") // get rid of badly escaped characters
                 );
+                placedMessage = PlaceholderUtil.applyLegacy("%username%", DiscordUtil.strip(event.getMember().getEffectiveName()), placedMessage, "%discord_name%");
+                placedMessage = PlaceholderUtil.applyLegacy("%toprole%", DiscordUtil.getRoleName(!selectedRoles.isEmpty() ? selectedRoles.get(0) : null), placedMessage, "%discord_toprole%");
+                placedMessage = PlaceholderUtil.applyLegacy("%toproleinitial%", !selectedRoles.isEmpty() ? DiscordUtil.getRoleName(selectedRoles.get(0)).substring(0, 1) : "", placedMessage, "%discord_toproleinital%");
+                placedMessage = PlaceholderUtil.applyLegacy("%allroles%", DiscordUtil.getFormattedRoles(selectedRoles), placedMessage, "%discord_allroles%");
                 DiscordGuildMessagePostProcessEvent postEvent = DiscordSRV.api.callEvent(new DiscordGuildMessagePostProcessEvent(event, preEvent.isCancelled(), placedMessage));
                 if (postEvent.isCancelled()) {
                     DiscordSRV.debug("DiscordGuildMessagePostProcessEvent was cancelled, attachment send aborted");
@@ -185,6 +189,10 @@ public class DiscordChatListener extends ListenerAdapter {
                 .replace("\\*", "") // get rid of badly escaped characters
                 .replace("\\_", "_"); // get rid of badly escaped characters
         formatMessage = PlaceholderUtil.applyAll(null, event.getAuthor(), formatMessage);
+        formatMessage = PlaceholderUtil.applyLegacy("%username%", DiscordUtil.strip(event.getMember().getEffectiveName()), formatMessage, "%discord_name%");
+        formatMessage = PlaceholderUtil.applyLegacy("%toprole%", DiscordUtil.getRoleName(!selectedRoles.isEmpty() ? selectedRoles.get(0) : null), formatMessage, "%discord_toprole%");
+        formatMessage = PlaceholderUtil.applyLegacy("%toproleinitial%", !selectedRoles.isEmpty() ? DiscordUtil.getRoleName(selectedRoles.get(0)).substring(0, 1) : "", formatMessage, "%discord_toproleinital%");
+        formatMessage = PlaceholderUtil.applyLegacy("%allroles%", DiscordUtil.getFormattedRoles(selectedRoles), formatMessage, "%discord_allroles%");
 
         // translate color codes
         formatMessage = ChatColor.translateAlternateColorCodes('&', formatMessage);

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerAchievementsListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerAchievementsListener.java
@@ -57,6 +57,8 @@ public class PlayerAchievementsListener implements Listener {
                 .replace("%worldalias%", DiscordUtil.strip(MultiverseCoreHook.getWorldAlias(event.getPlayer().getWorld().getName())))
                 .replace("%achievement%", achievementName);
         discordMessage = PlaceholderUtil.applyAll(event.getPlayer(), null, discordMessage, true);
+        discordMessage = PlaceholderUtil.applyLegacy("%username%", event.getPlayer().getName(), discordMessage, "%minecraft_playername%");
+        discordMessage = PlaceholderUtil.applyLegacy("%displayname%", DiscordUtil.escapeMarkdown(event.getPlayer().getDisplayName()), discordMessage, "%minecraft_displayname%");
 
         DiscordUtil.sendMessage(DiscordSRV.getPlugin().getMainTextChannel(), discordMessage);
     }

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerAchievementsListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerAchievementsListener.java
@@ -53,12 +53,10 @@ public class PlayerAchievementsListener implements Listener {
 
         String discordMessage = LangUtil.Message.PLAYER_ACHIEVEMENT.toString()
                 .replaceAll("%time%|%date%", TimeUtil.timeStamp())
-                .replace("%username%", event.getPlayer().getName())
-                .replace("%displayname%", DiscordUtil.strip(DiscordUtil.escapeMarkdown(event.getPlayer().getDisplayName())))
                 .replace("%world%", event.getPlayer().getWorld().getName())
                 .replace("%worldalias%", DiscordUtil.strip(MultiverseCoreHook.getWorldAlias(event.getPlayer().getWorld().getName())))
                 .replace("%achievement%", achievementName);
-        if (PluginUtil.pluginHookIsEnabled("placeholderapi")) discordMessage = me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(event.getPlayer(), discordMessage);
+        discordMessage = PlaceholderUtil.applyAll(event.getPlayer(), null, discordMessage, true);
 
         DiscordUtil.sendMessage(DiscordSRV.getPlugin().getMainTextChannel(), discordMessage);
     }

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerAdvancementDoneListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerAdvancementDoneListener.java
@@ -19,11 +19,7 @@
 package github.scarsz.discordsrv.listeners;
 
 import github.scarsz.discordsrv.DiscordSRV;
-import github.scarsz.discordsrv.util.DiscordUtil;
-import github.scarsz.discordsrv.util.LangUtil;
-import github.scarsz.discordsrv.util.PlayerUtil;
-import github.scarsz.discordsrv.util.PluginUtil;
-import github.scarsz.discordsrv.util.TimeUtil;
+import github.scarsz.discordsrv.util.*;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
@@ -71,11 +67,9 @@ public class PlayerAdvancementDoneListener implements Listener {
 
         String discordMessage = LangUtil.Message.PLAYER_ACHIEVEMENT.toString()
                 .replaceAll("%time%|%date%", TimeUtil.timeStamp())
-                .replace("%username%", event.getPlayer().getName())
-                .replace("%displayname%", DiscordUtil.strip(DiscordUtil.escapeMarkdown(event.getPlayer().getDisplayName())))
                 .replace("%world%", event.getPlayer().getWorld().getName())
                 .replace("%achievement%", advancementName);
-        if (PluginUtil.pluginHookIsEnabled("placeholderapi")) discordMessage = me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(event.getPlayer(), discordMessage);
+        discordMessage = PlaceholderUtil.applyAll(event.getPlayer(), null, discordMessage, true);
 
         DiscordUtil.sendMessage(DiscordSRV.getPlugin().getMainTextChannel(), discordMessage);
     }

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerAdvancementDoneListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerAdvancementDoneListener.java
@@ -70,6 +70,8 @@ public class PlayerAdvancementDoneListener implements Listener {
                 .replace("%world%", event.getPlayer().getWorld().getName())
                 .replace("%achievement%", advancementName);
         discordMessage = PlaceholderUtil.applyAll(event.getPlayer(), null, discordMessage, true);
+        discordMessage = PlaceholderUtil.applyLegacy("%username%", event.getPlayer().getName(), discordMessage, "%minecraft_playername%");
+        discordMessage = PlaceholderUtil.applyLegacy("%displayname%", DiscordUtil.escapeMarkdown(event.getPlayer().getDisplayName()), discordMessage, "%minecraft_displayname%");
 
         DiscordUtil.sendMessage(DiscordSRV.getPlugin().getMainTextChannel(), discordMessage);
     }

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerDeathListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerDeathListener.java
@@ -19,11 +19,7 @@
 package github.scarsz.discordsrv.listeners;
 
 import github.scarsz.discordsrv.DiscordSRV;
-import github.scarsz.discordsrv.util.DiscordUtil;
-import github.scarsz.discordsrv.util.LangUtil;
-import github.scarsz.discordsrv.util.PlayerUtil;
-import github.scarsz.discordsrv.util.PluginUtil;
-import github.scarsz.discordsrv.util.TimeUtil;
+import github.scarsz.discordsrv.util.*;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.EntityType;
@@ -49,11 +45,9 @@ public class PlayerDeathListener implements Listener {
 
         String discordMessage = LangUtil.Message.PLAYER_DEATH.toString()
                 .replaceAll("%time%|%date%", TimeUtil.timeStamp())
-                .replace("%username%", event.getEntity().getName())
-                .replace("%displayname%", DiscordUtil.strip(DiscordUtil.escapeMarkdown(event.getEntity().getDisplayName())))
                 .replace("%world%", event.getEntity().getWorld().getName())
                 .replace("%deathmessage%", DiscordUtil.strip(DiscordUtil.escapeMarkdown(event.getDeathMessage())));
-        if (PluginUtil.pluginHookIsEnabled("placeholderapi")) discordMessage = me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(event.getEntity(), discordMessage);
+        discordMessage = PlaceholderUtil.applyAll(event.getEntity(), null, discordMessage, true);
 
         discordMessage = DiscordUtil.strip(discordMessage);
         if (StringUtils.isBlank(discordMessage)) return;

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerDeathListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerDeathListener.java
@@ -48,6 +48,8 @@ public class PlayerDeathListener implements Listener {
                 .replace("%world%", event.getEntity().getWorld().getName())
                 .replace("%deathmessage%", DiscordUtil.strip(DiscordUtil.escapeMarkdown(event.getDeathMessage())));
         discordMessage = PlaceholderUtil.applyAll(event.getEntity(), null, discordMessage, true);
+        discordMessage = PlaceholderUtil.applyLegacy("%username%", event.getEntity().getName(), discordMessage, "%minecraft_playername%");
+        discordMessage = PlaceholderUtil.applyLegacy("%displayname%", DiscordUtil.escapeMarkdown(event.getEntity().getDisplayName()), discordMessage, "%minecraft_displayname%");
 
         discordMessage = DiscordUtil.strip(discordMessage);
         if (StringUtils.isBlank(discordMessage)) return;

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerJoinLeaveListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerJoinLeaveListener.java
@@ -69,10 +69,8 @@ public class PlayerJoinLeaveListener implements Listener {
         Bukkit.getScheduler().scheduleSyncDelayedTask(DiscordSRV.getPlugin(), () -> {
             String discordMessage = joinMessageFormat
                     .replaceAll("%time%|%date%", TimeUtil.timeStamp())
-                    .replace("%message%", DiscordUtil.strip(DiscordUtil.escapeMarkdown(event.getJoinMessage())))
-                    .replace("%username%", DiscordUtil.strip(DiscordUtil.escapeMarkdown(event.getPlayer().getName())))
-                    .replace("%displayname%", DiscordUtil.strip(DiscordUtil.escapeMarkdown(event.getPlayer().getDisplayName())));
-            if (PluginUtil.pluginHookIsEnabled("placeholderapi")) discordMessage = me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(event.getPlayer(), discordMessage);
+                    .replace("%message%", DiscordUtil.strip(DiscordUtil.escapeMarkdown(event.getJoinMessage())));
+            discordMessage = PlaceholderUtil.applyAll(event.getPlayer(), null, discordMessage, true);
 
             DiscordUtil.queueMessage(DiscordSRV.getPlugin().getMainTextChannel(), discordMessage);
         }, 20);
@@ -103,10 +101,8 @@ public class PlayerJoinLeaveListener implements Listener {
 
         String discordMessage = LangUtil.Message.PLAYER_LEAVE.toString()
                 .replaceAll("%time%|%date%", TimeUtil.timeStamp())
-                .replace("%message%", DiscordUtil.strip(DiscordUtil.escapeMarkdown(event.getQuitMessage())))
-                .replace("%username%", DiscordUtil.strip(DiscordUtil.escapeMarkdown(event.getPlayer().getName())))
-                .replace("%displayname%", DiscordUtil.strip(DiscordUtil.escapeMarkdown(DiscordUtil.strip(event.getPlayer().getDisplayName()))));
-        if (PluginUtil.pluginHookIsEnabled("placeholderapi")) discordMessage = me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(event.getPlayer(), discordMessage);
+                .replace("%message%", DiscordUtil.strip(DiscordUtil.escapeMarkdown(event.getQuitMessage())));
+        discordMessage = PlaceholderUtil.applyAll(event.getPlayer(), null, discordMessage, true);
 
         // player doesn't have silent quit, show quit message
         DiscordUtil.sendMessage(DiscordSRV.getPlugin().getMainTextChannel(), discordMessage);

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerJoinLeaveListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerJoinLeaveListener.java
@@ -71,6 +71,8 @@ public class PlayerJoinLeaveListener implements Listener {
                     .replaceAll("%time%|%date%", TimeUtil.timeStamp())
                     .replace("%message%", DiscordUtil.strip(DiscordUtil.escapeMarkdown(event.getJoinMessage())));
             discordMessage = PlaceholderUtil.applyAll(event.getPlayer(), null, discordMessage, true);
+            discordMessage = PlaceholderUtil.applyLegacy("%username%", event.getPlayer().getName(), discordMessage, "%minecraft_playername%");
+            discordMessage = PlaceholderUtil.applyLegacy("%displayname%", DiscordUtil.escapeMarkdown(event.getPlayer().getDisplayName()), discordMessage, "%minecraft_displayname%");
 
             DiscordUtil.queueMessage(DiscordSRV.getPlugin().getMainTextChannel(), discordMessage);
         }, 20);
@@ -103,6 +105,8 @@ public class PlayerJoinLeaveListener implements Listener {
                 .replaceAll("%time%|%date%", TimeUtil.timeStamp())
                 .replace("%message%", DiscordUtil.strip(DiscordUtil.escapeMarkdown(event.getQuitMessage())));
         discordMessage = PlaceholderUtil.applyAll(event.getPlayer(), null, discordMessage, true);
+        discordMessage = PlaceholderUtil.applyLegacy("%username%", event.getPlayer().getName(), discordMessage, "%minecraft_playername%");
+        discordMessage = PlaceholderUtil.applyLegacy("%displayname%", DiscordUtil.escapeMarkdown(event.getPlayer().getDisplayName()), discordMessage, "%minecraft_displayname%");
 
         // player doesn't have silent quit, show quit message
         DiscordUtil.sendMessage(DiscordSRV.getPlugin().getMainTextChannel(), discordMessage);

--- a/src/main/java/github/scarsz/discordsrv/objects/threads/ChannelTopicUpdater.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/threads/ChannelTopicUpdater.java
@@ -40,11 +40,11 @@ public class ChannelTopicUpdater extends Thread {
             if (rate < 5) rate = 5;
 
             if (DiscordUtil.getJda() != null) {
-                String chatTopic = applyPlaceholders(LangUtil.Message.CHAT_CHANNEL_TOPIC.toString());
+                String chatTopic = PlaceholderUtil.applyAll(null, null, LangUtil.Message.CHAT_CHANNEL_TOPIC.toString());
                 if (StringUtils.isNotBlank(chatTopic))
                     DiscordUtil.setTextChannelTopic(DiscordSRV.getPlugin().getMainTextChannel(), chatTopic);
 
-                String consoleTopic = applyPlaceholders(LangUtil.Message.CONSOLE_CHANNEL_TOPIC.toString());
+                String consoleTopic = PlaceholderUtil.applyAll(null, null, LangUtil.Message.CONSOLE_CHANNEL_TOPIC.toString());
                 if (StringUtils.isNotBlank(consoleTopic))
                     DiscordUtil.setTextChannelTopic(DiscordSRV.getPlugin().getConsoleChannel(), consoleTopic);
             } else {
@@ -59,40 +59,4 @@ public class ChannelTopicUpdater extends Thread {
             }
         }
     }
-
-    @SuppressWarnings({"SpellCheckingInspection"})
-    private static String applyPlaceholders(String input) {
-        if (StringUtils.isBlank(input)) return "";
-
-        // set PAPI placeholders
-        if (PluginUtil.pluginHookIsEnabled("placeholderapi")) input = me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(null, input);
-
-        final Map<String, String> mem = MemUtil.get();
-
-        input = input.replaceAll("%time%|%date%", notNull(TimeUtil.timeStamp()))
-                     .replace("%playercount%", notNull(Integer.toString(PlayerUtil.getOnlinePlayers(true).size())))
-                     .replace("%playermax%", notNull(Integer.toString(Bukkit.getMaxPlayers())))
-                     .replace("%totalplayers%", notNull(Integer.toString(DiscordSRV.getTotalPlayerCount())))
-                     .replace("%uptimemins%", notNull(Long.toString(TimeUnit.MILLISECONDS.toMinutes(System.currentTimeMillis() - DiscordSRV.getPlugin().getStartTime()))))
-                     .replace("%uptimehours%", notNull(Long.toString(TimeUnit.MILLISECONDS.toHours(System.currentTimeMillis() - DiscordSRV.getPlugin().getStartTime()))))
-                     .replace("%uptimedays%", notNull(Long.toString(TimeUnit.MILLISECONDS.toDays(System.currentTimeMillis() - DiscordSRV.getPlugin().getStartTime()))))
-                     .replace("%motd%", notNull(StringUtils.isNotBlank(Bukkit.getMotd()) ? DiscordUtil.strip(Bukkit.getMotd()) : ""))
-                     .replace("%serverversion%", notNull(Bukkit.getBukkitVersion()))
-                     .replace("%freememory%", notNull(mem.get("freeMB")))
-                     .replace("%usedmemory%", notNull(mem.get("usedMB")))
-                     .replace("%totalmemory%", notNull(mem.get("totalMB")))
-                     .replace("%maxmemory%", notNull(mem.get("maxMB")))
-                     .replace("%freememorygb%", notNull(mem.get("freeGB")))
-                     .replace("%usedmemorygb%", notNull(mem.get("usedGB")))
-                     .replace("%totalmemorygb%", notNull(mem.get("totalGB")))
-                     .replace("%maxmemorygb%", notNull(mem.get("maxGB")))
-                     .replace("%tps%", notNull(Lag.getTPSString()));
-
-        return input;
-    }
-
-    private static String notNull(Object object) {
-        return object != null ? object.toString() : "";
-    }
-
 }

--- a/src/main/java/github/scarsz/discordsrv/objects/threads/ChannelTopicUpdater.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/threads/ChannelTopicUpdater.java
@@ -40,7 +40,8 @@ public class ChannelTopicUpdater extends Thread {
             if (rate < 5) rate = 5;
 
             if (DiscordUtil.getJda() != null) {
-                String chatTopic = PlaceholderUtil.applyAll(null, null, LangUtil.Message.CHAT_CHANNEL_TOPIC.toString());
+                String chatTopic = applyLegacyPlaceholders(LangUtil.Message.CHAT_CHANNEL_TOPIC.toString()).replaceAll("%time%|%date%", notNull(TimeUtil.timeStamp()));
+                chatTopic = PlaceholderUtil.applyAll(null, null, chatTopic);
                 if (StringUtils.isNotBlank(chatTopic))
                     DiscordUtil.setTextChannelTopic(DiscordSRV.getPlugin().getMainTextChannel(), chatTopic);
 
@@ -58,5 +59,19 @@ public class ChannelTopicUpdater extends Thread {
                 return;
             }
         }
+    }
+
+    private String applyLegacyPlaceholders(String text) {
+        String[] legacyPlaceholders = {"playercount","playermax","totalplayers","uptimemins","uptimehours","uptimedays",
+                "motd","serverversion","freememory","usedmemory","totalmemory","maxmemory","freememorygb","usedmemorygb","totalmemorygb","maxmemorygb","tps"};
+        for (String legacyPlaceholder : legacyPlaceholders) {
+            if (text.contains(legacyPlaceholder))
+                DiscordSRV.info("Found legacy placeholder " + legacyPlaceholder + " in " + text + ". This should be replaced with %server_" + legacyPlaceholder + "%");
+            text = text.replace("%" + legacyPlaceholder + "%", "%server_" + legacyPlaceholder + "%");
+        }
+        return text;
+    }
+    private static String notNull(Object object) {
+        return object != null ? object.toString() : "";
     }
 }

--- a/src/main/java/github/scarsz/discordsrv/objects/threads/PresenceUpdater.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/threads/PresenceUpdater.java
@@ -21,6 +21,7 @@ package github.scarsz.discordsrv.objects.threads;
 import alexh.weak.Dynamic;
 import github.scarsz.discordsrv.DiscordSRV;
 import github.scarsz.discordsrv.util.DiscordUtil;
+import github.scarsz.discordsrv.util.PlaceholderUtil;
 import github.scarsz.discordsrv.util.PluginUtil;
 import net.dv8tion.jda.api.entities.Activity;
 import org.apache.commons.lang3.StringUtils;
@@ -69,6 +70,7 @@ public class PresenceUpdater extends Thread {
                 if (lastStatus >= statuses.size()) lastStatus = 0;
 
                 if (!StringUtils.isEmpty(status)) {
+                    status = PlaceholderUtil.applyAll(null, DiscordUtil.getJda().getSelfUser(), status);
                     if (StringUtils.startsWithIgnoreCase(status, "watching")) {
                         String removed = status.substring("watching".length(), status.length()).trim();
                         DiscordUtil.getJda().getPresence().setPresence(Activity.watching(removed), false);

--- a/src/main/java/github/scarsz/discordsrv/objects/threads/ServerWatchdog.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/threads/ServerWatchdog.java
@@ -21,6 +21,7 @@ package github.scarsz.discordsrv.objects.threads;
 import github.scarsz.discordsrv.DiscordSRV;
 import github.scarsz.discordsrv.util.DiscordUtil;
 import github.scarsz.discordsrv.util.LangUtil;
+import github.scarsz.discordsrv.util.PlaceholderUtil;
 import github.scarsz.discordsrv.util.TimeUtil;
 import org.bukkit.Bukkit;
 
@@ -61,9 +62,9 @@ public class ServerWatchdog extends Thread {
                     }
 
                     for (int i = 0; i < DiscordSRV.config().getInt("ServerWatchdogMessageCount"); i++) {
-                        DiscordUtil.sendMessage(DiscordSRV.getPlugin().getMainTextChannel(), LangUtil.Message.SERVER_WATCHDOG.toString()
+                        DiscordUtil.sendMessage(DiscordSRV.getPlugin().getMainTextChannel(), PlaceholderUtil.applyAll(null, null, LangUtil.Message.SERVER_WATCHDOG.toString()
                                 .replaceAll("%time%|%date%", TimeUtil.timeStamp())
-                                .replace("%guildowner%", DiscordSRV.getPlugin().getMainGuild().getOwner().getAsMention())
+                                .replace("%guildowner%", DiscordSRV.getPlugin().getMainGuild().getOwner().getAsMention()))
                         );
                     }
 

--- a/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
@@ -39,10 +39,12 @@ public class PlaceholderUtil {
 
     // General placeholders for a online player
     public static String applyPlayerPlaceholders(Player player, String text) {
-        return text
+        if (player != null)
+            return text
                 .replace("%dsrv_minecraft_playername", notNull(player.getName()))
                 .replace("%dsrv_minecraft_displayname", notNull(player.getDisplayName()))
                 .replace("%dsrv_minecraft_uuid%", notNull(player.getUniqueId().toString()));
+        else return text;
     }
 
     // General placeholders for the online server
@@ -69,11 +71,13 @@ public class PlaceholderUtil {
 
     // General placeholders for a Discord User
     public static String applyUserPlaceholders(User user, String text) {
-        return text
+        if (user != null)
+            return text
                 .replace("dsrv_discord_name", notNull(user.getName()))
                 .replace("dsrv_discord_tag", notNull(user.getAsTag()))
                 .replace("dsrv_discord_mention", notNull(user.getAsMention()))
                 .replace("%dsrv_discord_id", notNull(user.getId()));
+        else return text;
     }
 
     // General placeholders for the main guild

--- a/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
@@ -123,7 +123,7 @@ public class PlaceholderUtil {
 
     public static String applyLegacy(String legacyPlaceholder, String data, String text, String newPlaceholder) {
         if (text.contains(legacyPlaceholder)) {
-            DiscordSRV.info("Found legacy placeholder "+legacyPlaceholder+" in "+text+". This should be replaced with "+newPlaceholder);
+            DiscordSRV.info("Found legacy placeholder " + legacyPlaceholder + " in " + text + ". This should be replaced with " + newPlaceholder);
             text = text.replace(legacyPlaceholder, data);
         }
         return text;

--- a/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
@@ -121,7 +121,7 @@ public class PlaceholderUtil {
         return applyAll(player, user, text, false);
     }
 
-    public static String applyUnsupported(String legacyPlaceholder, String data, String text, String newPlaceholder) {
+    public static String applyLegacy(String legacyPlaceholder, String data, String text, String newPlaceholder) {
         if (text.contains(legacyPlaceholder)) {
             DiscordSRV.info("Found legacy placeholder "+legacyPlaceholder+" in "+text+". This should be replaced with "+newPlaceholder);
             text = text.replace(legacyPlaceholder, data);

--- a/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
@@ -121,6 +121,14 @@ public class PlaceholderUtil {
         return applyAll(player, user, text, false);
     }
 
+    public static String applyUnsupported(String legacyPlaceholder, String data, String text, String newPlaceholder) {
+        if (text.contains(legacyPlaceholder)) {
+            DiscordSRV.info("Found legacy placeholder "+legacyPlaceholder+" in "+text+". This should be replaced with "+newPlaceholder);
+            text = text.replace(legacyPlaceholder, data);
+        }
+        return text;
+    }
+
     private static String notNull(Object object) {
         return object != null ? object.toString() : "";
     }

--- a/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
@@ -1,0 +1,89 @@
+/*
+ * DiscordSRV - A Minecraft to Discord and back link plugin
+ * Copyright (C) 2016-2019 Austin "Scarsz" Shapiro
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package github.scarsz.discordsrv.util;
+
+import github.scarsz.discordsrv.DiscordSRV;
+import github.scarsz.discordsrv.objects.Lag;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.User;
+import org.apache.commons.lang3.StringUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+// A bunch of general placeholders. All discordSRV internal placeholders are prefixed with "dsrv_" to prevent placeholderapi conflicts
+public class PlaceholderUtil {
+    // Tries to apply placeholderAPI placeholders
+    public static String applyPlaceholderApi(Player player, String text) {
+        if (PluginUtil.pluginHookIsEnabled("placeholderapi")) return me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(player, text);
+        else return text;
+    }
+
+    // General placeholders for a online player
+    public static String applyPlayerPlaceholders(Player player, String text) {
+        return text
+                .replace("%dsrv_minecraft_playername", notNull(player.getName()))
+                .replace("%dsrv_minecraft_displayname", notNull(player.getDisplayName()))
+                .replace("%dsrv_minecraft_uuid%", notNull(player.getUniqueId().toString()));
+    }
+
+    // General placeholders for the online server
+    public static String applyOnlineServerPlaceholders(String text) {
+        final Map<String, String> mem = MemUtil.get();
+        return text
+                .replace("%dsrv_server_playermax%", notNull(Integer.toString(Bukkit.getMaxPlayers())))
+                .replace("%dsrv_server_totalplayers%", notNull(Integer.toString(DiscordSRV.getTotalPlayerCount())))
+                .replace("%dsrv_server_uptimemins%", notNull(Long.toString(TimeUnit.MILLISECONDS.toMinutes(System.currentTimeMillis() - DiscordSRV.getPlugin().getStartTime()))))
+                .replace("%dsrv_server_uptimehours%", notNull(Long.toString(TimeUnit.MILLISECONDS.toHours(System.currentTimeMillis() - DiscordSRV.getPlugin().getStartTime()))))
+                .replace("%dsrv_server_uptimedays%", notNull(Long.toString(TimeUnit.MILLISECONDS.toDays(System.currentTimeMillis() - DiscordSRV.getPlugin().getStartTime()))))
+                .replace("%dsrv_server_motd%", notNull(StringUtils.isNotBlank(Bukkit.getMotd()) ? DiscordUtil.strip(Bukkit.getMotd()) : ""))
+                .replace("%dsrv_server_serverversion%", notNull(Bukkit.getBukkitVersion()))
+                .replace("%dsrv_server_freememory%", notNull(mem.get("freeMB")))
+                .replace("%dsrv_server_usedmemory%", notNull(mem.get("usedMB")))
+                .replace("%dsrv_server_totalmemory%", notNull(mem.get("totalMB")))
+                .replace("%dsrv_server_maxmemory%", notNull(mem.get("maxMB")))
+                .replace("%dsrv_server_freememorygb%", notNull(mem.get("freeGB")))
+                .replace("%dsrv_server_usedmemorygb%", notNull(mem.get("usedGB")))
+                .replace("%dsrv_server_totalmemorygb%", notNull(mem.get("totalGB")))
+                .replace("%dsrv_server_maxmemorygb%", notNull(mem.get("maxGB")))
+                .replace("%dsrv_server_tps%", notNull(Lag.getTPSString()));
+    }
+
+    // General placeholders for a Discord User
+    public static String applyUserPlaceholders(User user, String text) {
+        return text
+                .replace("dsrv_discord_name", notNull(user.getName()))
+                .replace("dsrv_discord_tag", notNull(user.getAsTag()))
+                .replace("dsrv_discord_mention", notNull(user.getAsMention()));
+    }
+
+    // General placeholders for the main guild
+    public static String applyGuildPlaceholders(String text) {
+        Guild guild = DiscordSRV.getPlugin().getMainGuild();
+        return text
+                .replace("dsrv_guild_name", notNull(guild.getName()))
+                .replace("dsrv_guild_members", notNull(guild.getMembers().size()));
+    }
+
+    private static String notNull(Object object) {
+        return object != null ? object.toString() : "";
+    }
+}

--- a/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
@@ -58,6 +58,7 @@ public class PlaceholderUtil {
     public static String applyOnlineServerPlaceholders(String text) {
         final Map<String, String> mem = MemUtil.get();
         return text
+                .replace("%server_playercount%", notNull(Integer.toString(PlayerUtil.getOnlinePlayers(true).size())))
                 .replace("%server_playermax%", notNull(Integer.toString(Bukkit.getMaxPlayers())))
                 .replace("%server_totalplayers%", notNull(Integer.toString(DiscordSRV.getTotalPlayerCount())))
                 .replace("%server_uptimemins%", notNull(Long.toString(TimeUnit.MILLISECONDS.toMinutes(System.currentTimeMillis() - DiscordSRV.getPlugin().getStartTime()))))

--- a/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
@@ -108,6 +108,30 @@ public class PlaceholderUtil {
                 .replace("%guild_members%", notNull(guild.getMembers().size()));
     }
 
+    // Placeholders to apply mentions for roles, channels, and users for Discord
+    public static String applyMentions(String text) {
+        String[] split = text.split("%");
+        if (split.length == 1)
+            return text;
+
+        for (String string : split) {
+            if (string.startsWith("mention_role")) {
+                String id = string.substring("mention_role_".length());
+                text = text.replace("%mention_role_" + id + "%", "<@&" + id + ">");
+            }
+            if (string.startsWith("mention_user")) {
+                String id = string.substring("mention_user_".length());
+                text = text.replace("%mention_user_" + id + "%", "<@" + id + ">");
+            }
+            if (string.startsWith("mention_channel")) {
+                String id = string.substring("mention_channel_".length());
+                text = text.replace("%mention_channel_" + id + "%", "<#" + id + ">");
+            }
+        }
+        text = text.replace("%mention_guildowner%", DiscordSRV.getPlugin().getMainGuild().getOwner().getAsMention());
+        return text;
+    }
+
     public static String applyAll(Player player, User user, String text, boolean escapeMarkdown) {
         text = applyPlayerPlaceholders(player, text, escapeMarkdown);
         text = applyOnlineServerPlaceholders(text);

--- a/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
@@ -72,7 +72,8 @@ public class PlaceholderUtil {
         return text
                 .replace("dsrv_discord_name", notNull(user.getName()))
                 .replace("dsrv_discord_tag", notNull(user.getAsTag()))
-                .replace("dsrv_discord_mention", notNull(user.getAsMention()));
+                .replace("dsrv_discord_mention", notNull(user.getAsMention()))
+                .replace("%dsrv_discord_id", notNull(user.getId()));
     }
 
     // General placeholders for the main guild

--- a/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
@@ -41,13 +41,17 @@ public class PlaceholderUtil {
     }
 
     // General placeholders for a online player
-    public static String applyPlayerPlaceholders(Player player, String text) {
+    public static String applyPlayerPlaceholders(Player player, String text, boolean escapeMarkdown) {
         if (player != null)
             return text
-                .replace("%minecraft_playername", notNull(player.getName()))
-                .replace("%minecraft_displayname", notNull(player.getDisplayName()))
+                .replace("%minecraft_playername", notNull(escapeMarkdown ? DiscordUtil.escapeMarkdown(player.getName()) : player.getName()))
+                .replace("%minecraft_displayname", notNull(escapeMarkdown ? DiscordUtil.escapeMarkdown(player.getDisplayName()) : player.getDisplayName()))
                 .replace("%minecraft_uuid%", notNull(player.getUniqueId().toString()));
         else return text;
+    }
+
+    public static String applyPlayerPlaceholders(Player player, String text) {
+        return applyPlayerPlaceholders(player, text, false);
     }
 
     // General placeholders for the online server
@@ -101,14 +105,19 @@ public class PlaceholderUtil {
                 .replace("%guild_members%", notNull(guild.getMembers().size()));
     }
 
-    public static String applyAll(Player player, User user, String text) {
-        text = applyPlayerPlaceholders(player, text);
+    public static String applyAll(Player player, User user, String text, boolean escapeMarkdown) {
+        text = applyPlayerPlaceholders(player, text, escapeMarkdown);
         text = applyOnlineServerPlaceholders(text);
         text = applyUserPlaceholders(user, text);
         text = applyGuildPlaceholders(text);
         text = applyPlaceholderApi(player, text);
         return text;
     }
+
+    public static String applyAll(Player player, User user, String text) {
+        return applyAll(player, user, text, false);
+    }
+
     private static String notNull(Object object) {
         return object != null ? object.toString() : "";
     }

--- a/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
@@ -84,6 +84,14 @@ public class PlaceholderUtil {
                 .replace("dsrv_guild_members", notNull(guild.getMembers().size()));
     }
 
+    public static String applyAll(Player player, User user, String text) {
+        text = applyPlayerPlaceholders(player, text);
+        text = applyOnlineServerPlaceholders(text);
+        text = applyUserPlaceholders(user, text);
+        text = applyGuildPlaceholders(text);
+        text = applyPlaceholderApi(player, text);
+        return text;
+    }
     private static String notNull(Object object) {
         return object != null ? object.toString() : "";
     }

--- a/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
@@ -21,11 +21,14 @@ package github.scarsz.discordsrv.util;
 import github.scarsz.discordsrv.DiscordSRV;
 import github.scarsz.discordsrv.objects.Lag;
 import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.User;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -71,21 +74,31 @@ public class PlaceholderUtil {
 
     // General placeholders for a Discord User
     public static String applyUserPlaceholders(User user, String text) {
-        if (user != null)
-            return text
-                .replace("discord_name", notNull(user.getName()))
-                .replace("%discord_tag", notNull(user.getAsTag()))
-                .replace("%discord_mention", notNull(user.getAsMention()))
-                .replace("%discord_id", notNull(user.getId()));
-        else return text;
+        if (user != null) {
+            text = text
+                .replace("%discord_name%", notNull(user.getName()))
+                .replace("%discord_tag%", notNull(user.getAsTag()))
+                .replace("%discord_mention%", notNull(user.getAsMention()))
+                .replace("%discord_id%", notNull(user.getId()));
+            Member member = DiscordSRV.getPlugin().getMainGuild().getMember(user);
+            if (member != null) {
+                List<Role> roles = member.getRoles();
+                text = text
+                        .replace("%discord_nickname%", notNull(member.getEffectiveName()))
+                        .replace("%discord_toprole%", notNull(DiscordUtil.getRoleName(!roles.isEmpty() ? roles.get(0) : null)))
+                        .replace("%discord_toproleinitial%", notNull(!roles.isEmpty() ? DiscordUtil.getRoleName(roles.get(0)).substring(0, 1) : ""))
+                        .replace("%discord_allroles%", notNull(DiscordUtil.getFormattedRoles(roles)));
+            }
+        }
+        return text;
     }
 
     // General placeholders for the main guild
     public static String applyGuildPlaceholders(String text) {
         Guild guild = DiscordSRV.getPlugin().getMainGuild();
         return text
-                .replace("%guild_name", notNull(guild.getName()))
-                .replace("%guild_members", notNull(guild.getMembers().size()));
+                .replace("%guild_name%", notNull(guild.getName()))
+                .replace("%guild_members%", notNull(guild.getMembers().size()));
     }
 
     public static String applyAll(Player player, User user, String text) {

--- a/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
@@ -19,6 +19,7 @@
 package github.scarsz.discordsrv.util;
 
 import github.scarsz.discordsrv.DiscordSRV;
+import github.scarsz.discordsrv.hooks.VaultHook;
 import github.scarsz.discordsrv.objects.Lag;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
@@ -46,7 +47,8 @@ public class PlaceholderUtil {
             return text
                 .replace("%minecraft_playername", notNull(escapeMarkdown ? DiscordUtil.escapeMarkdown(player.getName()) : player.getName()))
                 .replace("%minecraft_displayname", notNull(escapeMarkdown ? DiscordUtil.escapeMarkdown(player.getDisplayName()) : player.getDisplayName()))
-                .replace("%minecraft_uuid%", notNull(player.getUniqueId().toString()));
+                .replace("%minecraft_uuid%", notNull(player.getUniqueId().toString()))
+                .replace("%minecraft_group", notNull(VaultHook.getPrimaryGroup(player)));
         else return text;
     }
 

--- a/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/PlaceholderUtil.java
@@ -29,7 +29,7 @@ import org.bukkit.entity.Player;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-// A bunch of general placeholders. All discordSRV internal placeholders are prefixed with "dsrv_" to prevent placeholderapi conflicts
+// A bunch of general placeholders.
 public class PlaceholderUtil {
     // Tries to apply placeholderAPI placeholders
     public static String applyPlaceholderApi(Player player, String text) {
@@ -41,9 +41,9 @@ public class PlaceholderUtil {
     public static String applyPlayerPlaceholders(Player player, String text) {
         if (player != null)
             return text
-                .replace("%dsrv_minecraft_playername", notNull(player.getName()))
-                .replace("%dsrv_minecraft_displayname", notNull(player.getDisplayName()))
-                .replace("%dsrv_minecraft_uuid%", notNull(player.getUniqueId().toString()));
+                .replace("%minecraft_playername", notNull(player.getName()))
+                .replace("%minecraft_displayname", notNull(player.getDisplayName()))
+                .replace("%minecraft_uuid%", notNull(player.getUniqueId().toString()));
         else return text;
     }
 
@@ -51,32 +51,32 @@ public class PlaceholderUtil {
     public static String applyOnlineServerPlaceholders(String text) {
         final Map<String, String> mem = MemUtil.get();
         return text
-                .replace("%dsrv_server_playermax%", notNull(Integer.toString(Bukkit.getMaxPlayers())))
-                .replace("%dsrv_server_totalplayers%", notNull(Integer.toString(DiscordSRV.getTotalPlayerCount())))
-                .replace("%dsrv_server_uptimemins%", notNull(Long.toString(TimeUnit.MILLISECONDS.toMinutes(System.currentTimeMillis() - DiscordSRV.getPlugin().getStartTime()))))
-                .replace("%dsrv_server_uptimehours%", notNull(Long.toString(TimeUnit.MILLISECONDS.toHours(System.currentTimeMillis() - DiscordSRV.getPlugin().getStartTime()))))
-                .replace("%dsrv_server_uptimedays%", notNull(Long.toString(TimeUnit.MILLISECONDS.toDays(System.currentTimeMillis() - DiscordSRV.getPlugin().getStartTime()))))
-                .replace("%dsrv_server_motd%", notNull(StringUtils.isNotBlank(Bukkit.getMotd()) ? DiscordUtil.strip(Bukkit.getMotd()) : ""))
-                .replace("%dsrv_server_serverversion%", notNull(Bukkit.getBukkitVersion()))
-                .replace("%dsrv_server_freememory%", notNull(mem.get("freeMB")))
-                .replace("%dsrv_server_usedmemory%", notNull(mem.get("usedMB")))
-                .replace("%dsrv_server_totalmemory%", notNull(mem.get("totalMB")))
-                .replace("%dsrv_server_maxmemory%", notNull(mem.get("maxMB")))
-                .replace("%dsrv_server_freememorygb%", notNull(mem.get("freeGB")))
-                .replace("%dsrv_server_usedmemorygb%", notNull(mem.get("usedGB")))
-                .replace("%dsrv_server_totalmemorygb%", notNull(mem.get("totalGB")))
-                .replace("%dsrv_server_maxmemorygb%", notNull(mem.get("maxGB")))
-                .replace("%dsrv_server_tps%", notNull(Lag.getTPSString()));
+                .replace("%server_playermax%", notNull(Integer.toString(Bukkit.getMaxPlayers())))
+                .replace("%server_totalplayers%", notNull(Integer.toString(DiscordSRV.getTotalPlayerCount())))
+                .replace("%server_uptimemins%", notNull(Long.toString(TimeUnit.MILLISECONDS.toMinutes(System.currentTimeMillis() - DiscordSRV.getPlugin().getStartTime()))))
+                .replace("%server_uptimehours%", notNull(Long.toString(TimeUnit.MILLISECONDS.toHours(System.currentTimeMillis() - DiscordSRV.getPlugin().getStartTime()))))
+                .replace("%server_uptimedays%", notNull(Long.toString(TimeUnit.MILLISECONDS.toDays(System.currentTimeMillis() - DiscordSRV.getPlugin().getStartTime()))))
+                .replace("%server_motd%", notNull(StringUtils.isNotBlank(Bukkit.getMotd()) ? DiscordUtil.strip(Bukkit.getMotd()) : ""))
+                .replace("%server_serverversion%", notNull(Bukkit.getBukkitVersion()))
+                .replace("%server_freememory%", notNull(mem.get("freeMB")))
+                .replace("%server_usedmemory%", notNull(mem.get("usedMB")))
+                .replace("%server_totalmemory%", notNull(mem.get("totalMB")))
+                .replace("%server_maxmemory%", notNull(mem.get("maxMB")))
+                .replace("%server_freememorygb%", notNull(mem.get("freeGB")))
+                .replace("%server_usedmemorygb%", notNull(mem.get("usedGB")))
+                .replace("%server_totalmemorygb%", notNull(mem.get("totalGB")))
+                .replace("%server_maxmemorygb%", notNull(mem.get("maxGB")))
+                .replace("%server_tps%", notNull(Lag.getTPSString()));
     }
 
     // General placeholders for a Discord User
     public static String applyUserPlaceholders(User user, String text) {
         if (user != null)
             return text
-                .replace("dsrv_discord_name", notNull(user.getName()))
-                .replace("dsrv_discord_tag", notNull(user.getAsTag()))
-                .replace("dsrv_discord_mention", notNull(user.getAsMention()))
-                .replace("%dsrv_discord_id", notNull(user.getId()));
+                .replace("discord_name", notNull(user.getName()))
+                .replace("%discord_tag", notNull(user.getAsTag()))
+                .replace("%discord_mention", notNull(user.getAsMention()))
+                .replace("%discord_id", notNull(user.getId()));
         else return text;
     }
 
@@ -84,8 +84,8 @@ public class PlaceholderUtil {
     public static String applyGuildPlaceholders(String text) {
         Guild guild = DiscordSRV.getPlugin().getMainGuild();
         return text
-                .replace("dsrv_guild_name", notNull(guild.getName()))
-                .replace("dsrv_guild_members", notNull(guild.getMembers().size()));
+                .replace("%guild_name", notNull(guild.getName()))
+                .replace("%guild_members", notNull(guild.getMembers().size()));
     }
 
     public static String applyAll(Player player, User user, String text) {


### PR DESCRIPTION
This consolidates all common placeholder replace methods into 1 file, to allow for easy addition of new placeholders, less repeated code, and more placeholders available for the end user.

All placeholders now follow a style of `%CATEGORY_FIELD%`. Each category is a different entity e.g. Player, Server, Guild, User, with different fields for each.

End goal is that each field that supports placeholders in config files can simply say which categories it supports, as well as any special placeholders specific to that field (e.g. %level% for console channel)

As of original Pull Request, comments in config files have not been edited yet