### PR TITLE
Add Invite command

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/commands/CommandInvite.java
+++ b/src/main/java/github/scarsz/discordsrv/commands/CommandInvite.java
@@ -11,7 +11,11 @@ public class CommandInvite {
             permission = "discordsrv.invite"
     )
     public static void execute(CommandSender sender, String[] args) {
-        String invite = DiscordUtil.getJda().getInviteUrl(Permission.ADMINISTRATOR);
-        sender.sendMessage(ChatColor.DARK_AQUA + "You may invite the bot with this link:\n" + ChatColor.AQUA + invite);
+        try {
+            String invite = DiscordUtil.getJda().getInviteUrl(Permission.ADMINISTRATOR);
+            sender.sendMessage(ChatColor.DARK_AQUA + "You may invite the bot with this link:\n" + ChatColor.AQUA + invite);
+        } catch (NullPointerException e) {
+            sender.sendMessage(ChatColor.RED + "Could not generate an invite. Is your token valid?");
+        }
     }
 }

--- a/src/main/java/github/scarsz/discordsrv/commands/CommandInvite.java
+++ b/src/main/java/github/scarsz/discordsrv/commands/CommandInvite.java
@@ -11,11 +11,11 @@ public class CommandInvite {
             permission = "discordsrv.invite"
     )
     public static void execute(CommandSender sender, String[] args) {
-        try {
+        if (DiscordUtil.getJda() != null) {
             String invite = DiscordUtil.getJda().getInviteUrl(Permission.ADMINISTRATOR);
             sender.sendMessage(ChatColor.DARK_AQUA + "You may invite the bot with this link:\n" + ChatColor.AQUA + invite);
-        } catch (NullPointerException e) {
-            sender.sendMessage(ChatColor.RED + "Could not generate an invite. Is your token valid?");
+        } else {
+            sender.sendMessage(ChatColor.RED + "Could not generate an invite.");
         }
     }
 }

--- a/src/main/java/github/scarsz/discordsrv/commands/CommandInvite.java
+++ b/src/main/java/github/scarsz/discordsrv/commands/CommandInvite.java
@@ -1,0 +1,17 @@
+package github.scarsz.discordsrv.commands;
+
+import github.scarsz.discordsrv.util.DiscordUtil;
+import net.dv8tion.jda.api.Permission;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+
+public class CommandInvite {
+    @Command(commandNames = { "invite" },
+            helpMessage = "Generates an invite code for the bot",
+            permission = "discordsrv.invite"
+    )
+    public static void execute(CommandSender sender, String[] args) {
+        String invite = DiscordUtil.getJda().getInviteUrl(Permission.ADMINISTRATOR);
+        sender.sendMessage(ChatColor.DARK_AQUA + "You may invite the bot with this link:\n" + ChatColor.AQUA + invite);
+    }
+}

--- a/src/main/java/github/scarsz/discordsrv/objects/managers/CommandManager.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/managers/CommandManager.java
@@ -47,7 +47,8 @@ public class CommandManager {
                 CommandLinked.class,
                 CommandReload.class,
                 CommandSetPicture.class,
-                CommandUnlink.class
+                CommandUnlink.class,
+                CommandInvite.class
         );
 
         for (Class clazz: commandClasses) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -99,3 +99,6 @@ permissions:
   discordsrv.linked.others:
     description: whether or not the player is able to check what Discord account other Minecraft accounts are linked to
     default: op
+  discordsrv.invite:
+    description: whether or not the player is able to generate a bot invite link
+    default: op

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -34,6 +34,7 @@ commands:
            /discord setpicture - Set the avatar of the bot
            /discord debug - Send debug information to Gist
            /discord reload - Reload the plugin
+           /discord invite - Invite the bot
 
 permissions:
   discordsrv.player:
@@ -57,6 +58,7 @@ permissions:
       discordsrv.linked.others: true
       discordsrv.unlink: true
       discordsrv.unlink.others: true
+      discordsrv.invite: true
   discordsrv.chat:
     description: whether or not the user is able to have their chat forwarded to Discord
     default: true


### PR DESCRIPTION
An easy command to generate a bot invite, eliminating the need for people to use https://scarsz.me/authorize.

Would change install workflow to: 

1. Paste jar into plugins folder
2. Start and stop server to generate files
3. Fill in config completely
4. Start server, `/discordsrv:discord invite`, `/discordsrv:discord reload`

This workflow has been tested and does work.