### PR TITLE
Allow use of Discord Avatar and Name/Nickname in Minecraft to Discord Webhook Messages

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/util/WebhookUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/WebhookUtil.java
@@ -72,7 +72,9 @@ public class WebhookUtil {
                     String userId = DiscordSRV.getPlugin().getAccountLinkManager().getDiscordId(player.getUniqueId());
                     if (userId != null) {
                         Member member = DiscordUtil.getMemberById(userId);
-                        username = member.getNickname();
+                        if (member != null) {
+                            username = member.getNickname();
+                        }
                     }
                 }
                 String avatarUrl = DiscordSRV.config().getString("Experiment_WebhookChatMessageAvatarUrl");
@@ -80,7 +82,9 @@ public class WebhookUtil {
                     String userId = DiscordSRV.getPlugin().getAccountLinkManager().getDiscordId(player.getUniqueId());
                     if (userId != null) {
                         User user = DiscordUtil.getUserById(userId);
-                        avatarUrl = user.getAvatarUrl();
+                        if (user != null) {
+                            avatarUrl = user.getAvatarUrl();
+                        }
                     }
                 }
                 if (StringUtils.isBlank(avatarUrl)) avatarUrl = "https://crafatar.com/avatars/{uuid}?overlay";

--- a/src/main/java/github/scarsz/discordsrv/util/WebhookUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/WebhookUtil.java
@@ -68,7 +68,7 @@ public class WebhookUtil {
         Bukkit.getScheduler().runTaskAsynchronously(DiscordSRV.getPlugin(), () -> {
             try {
                 String username = DiscordUtil.strip(player.getDisplayName());
-                if (DiscordSRV.config().getBoolean("Experiment_WebhookChatMessageUsernameUseDiscord")) {
+                if (DiscordSRV.config().getBoolean("Experiment_WebhookChatMessageUsernameFromDiscord")) {
                     String userId = DiscordSRV.getPlugin().getAccountLinkManager().getDiscordId(player.getUniqueId());
                     if (userId != null) {
                         Member member = DiscordUtil.getMemberById(userId);
@@ -78,7 +78,7 @@ public class WebhookUtil {
                     }
                 }
                 String avatarUrl = DiscordSRV.config().getString("Experiment_WebhookChatMessageAvatarUrl");
-                if (DiscordSRV.config().getBoolean("Experiment_WebhookChatMessageAvatarUseDiscord")) {
+                if (DiscordSRV.config().getBoolean("Experiment_WebhookChatMessageAvatarFromDiscord")) {
                     String userId = DiscordSRV.getPlugin().getAccountLinkManager().getDiscordId(player.getUniqueId());
                     if (userId != null) {
                         User user = DiscordUtil.getUserById(userId);

--- a/src/main/java/github/scarsz/discordsrv/util/WebhookUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/WebhookUtil.java
@@ -73,7 +73,7 @@ public class WebhookUtil {
                     if (userId != null) {
                         Member member = DiscordUtil.getMemberById(userId);
                         if (member != null) {
-                            username = member.getNickname();
+                            username = member.getEffectiveName();
                         }
                     }
                 }

--- a/src/main/java/github/scarsz/discordsrv/util/WebhookUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/WebhookUtil.java
@@ -67,26 +67,20 @@ public class WebhookUtil {
 
         Bukkit.getScheduler().runTaskAsynchronously(DiscordSRV.getPlugin(), () -> {
             try {
-                String username = DiscordUtil.strip(player.getDisplayName());
-                if (DiscordSRV.config().getBoolean("Experiment_WebhookChatMessageUsernameFromDiscord")) {
-                    String userId = DiscordSRV.getPlugin().getAccountLinkManager().getDiscordId(player.getUniqueId());
-                    if (userId != null) {
-                        Member member = DiscordUtil.getMemberById(userId);
-                        if (member != null) {
-                            username = member.getEffectiveName();
-                        }
-                    }
-                }
                 String avatarUrl = DiscordSRV.config().getString("Experiment_WebhookChatMessageAvatarUrl");
-                if (DiscordSRV.config().getBoolean("Experiment_WebhookChatMessageAvatarFromDiscord")) {
-                    String userId = DiscordSRV.getPlugin().getAccountLinkManager().getDiscordId(player.getUniqueId());
-                    if (userId != null) {
-                        User user = DiscordUtil.getUserById(userId);
-                        if (user != null) {
-                            avatarUrl = user.getAvatarUrl();
-                        }
+                String username = DiscordUtil.strip(player.getDisplayName());
+
+                String userId = DiscordSRV.getPlugin().getAccountLinkManager().getDiscordId(player.getUniqueId());
+                if (userId != null) {
+                    Member member = DiscordUtil.getMemberById(userId);
+                    if (member != null) {
+                        if (DiscordSRV.config().getBoolean("Experiment_WebhookChatMessageAvatarFromDiscord"))
+                            avatarUrl = member.getUser().getAvatarUrl();
+                        if (DiscordSRV.config().getBoolean("Experiment_WebhookChatMessageUsernameFromDiscord"))
+                            username = member.getEffectiveName();
                     }
                 }
+
                 if (StringUtils.isBlank(avatarUrl)) avatarUrl = "https://crafatar.com/avatars/{uuid}?overlay";
                 avatarUrl = avatarUrl
                         .replace("{username}", player.getName())

--- a/src/main/java/github/scarsz/discordsrv/util/WebhookUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/WebhookUtil.java
@@ -32,7 +32,10 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class WebhookUtil {
 

--- a/src/main/resources/config/de.yml
+++ b/src/main/resources/config/de.yml
@@ -31,8 +31,10 @@ Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"
 Experiment_JdbcPassword: "password"
 Experiment_WebhookChatMessageDelivery: false
+Experiment_WebhookChatMessageUsernameFromDiscord: false
 Experiment_WebhookChatMessageAvatarUrl: https://crafatar.com/avatars/{uuid}?overlay
 #Experiment_WebhookChatMessageAvatarUrl: https://minotar.net/helm/{username}
+Experiment_WebhookChatMessageAvatarFromDiscord: false
 Experiment_MCDiscordReserializer_ToDiscord: false
 Experiment_MCDiscordReserializer_ToMinecraft: false
 Experiment_MCDiscordReserializer_InBroadcast: false

--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -31,8 +31,10 @@ Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"
 Experiment_JdbcPassword: "password"
 Experiment_WebhookChatMessageDelivery: false
+Experiment_WebhookChatMessageUsernameFromDiscord: false
 Experiment_WebhookChatMessageAvatarUrl: https://crafatar.com/avatars/{uuid}?overlay
 #Experiment_WebhookChatMessageAvatarUrl: https://minotar.net/helm/{username}
+Experiment_WebhookChatMessageAvatarFromDiscord: false
 Experiment_MCDiscordReserializer_ToDiscord: false
 Experiment_MCDiscordReserializer_ToMinecraft: false
 Experiment_MCDiscordReserializer_InBroadcast: false

--- a/src/main/resources/config/es.yml
+++ b/src/main/resources/config/es.yml
@@ -31,8 +31,10 @@ Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"
 Experiment_JdbcPassword: "password"
 Experiment_WebhookChatMessageDelivery: false
+Experiment_WebhookChatMessageUsernameFromDiscord: false
 Experiment_WebhookChatMessageAvatarUrl: https://crafatar.com/avatars/{uuid}?overlay
 #Experiment_WebhookChatMessageAvatarUrl: https://minotar.net/helm/{username}
+Experiment_WebhookChatMessageAvatarFromDiscord: false
 Experiment_MCDiscordReserializer_ToDiscord: false
 Experiment_MCDiscordReserializer_ToMinecraft: false
 Experiment_MCDiscordReserializer_InBroadcast: false

--- a/src/main/resources/config/et.yml
+++ b/src/main/resources/config/et.yml
@@ -31,8 +31,10 @@ Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"
 Experiment_JdbcPassword: "password"
 Experiment_WebhookChatMessageDelivery: false
+Experiment_WebhookChatMessageUsernameFromDiscord: false
 Experiment_WebhookChatMessageAvatarUrl: https://crafatar.com/avatars/{uuid}?overlay
 #Experiment_WebhookChatMessageAvatarUrl: https://minotar.net/helm/{username}
+Experiment_WebhookChatMessageAvatarFromDiscord: false
 Experiment_MCDiscordReserializer_ToDiscord: false
 Experiment_MCDiscordReserializer_ToMinecraft: false
 Experiment_MCDiscordReserializer_InBroadcast: false

--- a/src/main/resources/config/fr.yml
+++ b/src/main/resources/config/fr.yml
@@ -31,8 +31,10 @@ Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"
 Experiment_JdbcPassword: "password"
 Experiment_WebhookChatMessageDelivery: false
+Experiment_WebhookChatMessageUsernameFromDiscord: false
 Experiment_WebhookChatMessageAvatarUrl: https://crafatar.com/avatars/{uuid}?overlay
 #Experiment_WebhookChatMessageAvatarUrl: https://minotar.net/helm/{username}
+Experiment_WebhookChatMessageAvatarFromDiscord: false
 Experiment_MCDiscordReserializer_ToDiscord: false
 Experiment_MCDiscordReserializer_ToMinecraft: false
 Experiment_MCDiscordReserializer_InBroadcast: false

--- a/src/main/resources/config/ja.yml
+++ b/src/main/resources/config/ja.yml
@@ -31,8 +31,10 @@ Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"
 Experiment_JdbcPassword: "password"
 Experiment_WebhookChatMessageDelivery: false
+Experiment_WebhookChatMessageUsernameFromDiscord: false
 Experiment_WebhookChatMessageAvatarUrl: https://crafatar.com/avatars/{uuid}?overlay
 #Experiment_WebhookChatMessageAvatarUrl: https://minotar.net/helm/{username}
+Experiment_WebhookChatMessageAvatarFromDiscord: false
 Experiment_MCDiscordReserializer_ToDiscord: false
 Experiment_MCDiscordReserializer_ToMinecraft: false
 Experiment_MCDiscordReserializer_InBroadcast: false

--- a/src/main/resources/config/ko.yml
+++ b/src/main/resources/config/ko.yml
@@ -31,8 +31,10 @@ Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"
 Experiment_JdbcPassword: "password"
 Experiment_WebhookChatMessageDelivery: false
+Experiment_WebhookChatMessageUsernameFromDiscord: false
 Experiment_WebhookChatMessageAvatarUrl: https://crafatar.com/avatars/{uuid}?overlay
 #Experiment_WebhookChatMessageAvatarUrl: https://minotar.net/helm/{username}
+Experiment_WebhookChatMessageAvatarFromDiscord: false
 Experiment_MCDiscordReserializer_ToDiscord: false
 Experiment_MCDiscordReserializer_ToMinecraft: false
 Experiment_MCDiscordReserializer_InBroadcast: false

--- a/src/main/resources/config/nl.yml
+++ b/src/main/resources/config/nl.yml
@@ -31,8 +31,10 @@ Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"
 Experiment_JdbcPassword: "password"
 Experiment_WebhookChatMessageDelivery: false
+Experiment_WebhookChatMessageUsernameFromDiscord: false
 Experiment_WebhookChatMessageAvatarUrl: https://crafatar.com/avatars/{uuid}?overlay
 #Experiment_WebhookChatMessageAvatarUrl: https://minotar.net/helm/{username}
+Experiment_WebhookChatMessageAvatarFromDiscord: false
 Experiment_MCDiscordReserializer_ToDiscord: false
 Experiment_MCDiscordReserializer_ToMinecraft: false
 Experiment_MCDiscordReserializer_InBroadcast: false

--- a/src/main/resources/config/ru.yml
+++ b/src/main/resources/config/ru.yml
@@ -31,8 +31,10 @@ Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"
 Experiment_JdbcPassword: "password"
 Experiment_WebhookChatMessageDelivery: false
+Experiment_WebhookChatMessageUsernameFromDiscord: false
 Experiment_WebhookChatMessageAvatarUrl: https://crafatar.com/avatars/{uuid}?overlay
 #Experiment_WebhookChatMessageAvatarUrl: https://minotar.net/helm/{username}
+Experiment_WebhookChatMessageAvatarFromDiscord: false
 Experiment_MCDiscordReserializer_ToDiscord: false
 Experiment_MCDiscordReserializer_ToMinecraft: false
 Experiment_MCDiscordReserializer_InBroadcast: false

--- a/src/main/resources/config/zh.yml
+++ b/src/main/resources/config/zh.yml
@@ -30,8 +30,10 @@ Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"
 Experiment_JdbcPassword: "password"
 Experiment_WebhookChatMessageDelivery: false
+Experiment_WebhookChatMessageUsernameFromDiscord: false
 Experiment_WebhookChatMessageAvatarUrl: https://crafatar.com/avatars/{uuid}?overlay
 #Experiment_WebhookChatMessageAvatarUrl: https://minotar.net/helm/{username}
+Experiment_WebhookChatMessageAvatarFromDiscord: false
 Experiment_MCDiscordReserializer_ToDiscord: false
 Experiment_MCDiscordReserializer_ToMinecraft: false
 Experiment_MCDiscordReserializer_InBroadcast: false


### PR DESCRIPTION
Creates two options allowing for the use of the existing Discord avatar and name/nickname to be used in Minecraft to Discord messages.
For consideration, some minor optimisations can be made by:
- not getting and stripping the player name when Experiment_WebhookChatMessageUsernameFromDiscord is enabled
- caching the userId when both new boolean options are enabled
- bypassing the avatarUrl replace when using a Discord avatar
In addition, warnings can be added for enabling either of these options when linking hasn't been enforced.