### PR TITLE
Add a WatchdogMessageEvent for 3rd party plugins to alter or cancel the watchdog message

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/api/events/WatchdogMessageEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/WatchdogMessageEvent.java
@@ -1,0 +1,41 @@
+/*
+ * DiscordSRV - A Minecraft to Discord and back link plugin
+ * Copyright (C) 2016-2019 Austin "Scarsz" Shapiro
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package github.scarsz.discordsrv.api.events;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.bukkit.event.Cancellable;
+
+public class WatchdogMessageEvent extends Event implements Cancellable {
+
+    @Getter @Setter private boolean cancelled;
+
+    @Getter @Setter private String channel;
+    @Getter @Setter private String processedMessage;
+
+    @Getter @Setter private Integer count;
+
+    public WatchdogMessageEvent(String channel, String processedMessage, Integer count, boolean cancelled) {
+        this.channel = channel;
+        this.count = count;
+        this.processedMessage = processedMessage;
+        setCancelled(cancelled);
+    }
+
+}

--- a/src/main/java/github/scarsz/discordsrv/api/events/WatchdogMessageEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/WatchdogMessageEvent.java
@@ -27,14 +27,14 @@ public class WatchdogMessageEvent extends Event implements Cancellable {
     @Getter @Setter private boolean cancelled;
 
     @Getter @Setter private String channel;
-    @Getter @Setter private String processedMessage;
+    @Getter @Setter private String message;
 
     @Getter @Setter private Integer count;
 
-    public WatchdogMessageEvent(String channel, String processedMessage, Integer count, boolean cancelled) {
+    public WatchdogMessageEvent(String channel, String message, Integer count, boolean cancelled) {
         this.channel = channel;
         this.count = count;
-        this.processedMessage = processedMessage;
+        this.message = message;
         setCancelled(cancelled);
     }
 

--- a/src/main/java/github/scarsz/discordsrv/api/events/WatchdogMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/WatchdogMessagePostProcessEvent.java
@@ -29,7 +29,7 @@ public class WatchdogMessagePostProcessEvent extends Event implements Cancellabl
     @Getter @Setter private String channel;
     @Getter @Setter private String message;
 
-    @Getter @Setter private Integer count;
+    @Getter @Setter private int count;
 
     public WatchdogMessagePostProcessEvent(String channel, String message, int count, boolean cancelled) {
         this.channel = channel;

--- a/src/main/java/github/scarsz/discordsrv/api/events/WatchdogMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/WatchdogMessagePostProcessEvent.java
@@ -22,7 +22,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.bukkit.event.Cancellable;
 
-public class WatchdogMessageEvent extends Event implements Cancellable {
+public class WatchdogMessagePostProcessEvent extends Event implements Cancellable {
 
     @Getter @Setter private boolean cancelled;
 
@@ -31,7 +31,7 @@ public class WatchdogMessageEvent extends Event implements Cancellable {
 
     @Getter @Setter private Integer count;
 
-    public WatchdogMessageEvent(String channel, String message, Integer count, boolean cancelled) {
+    public WatchdogMessagePostProcessEvent(String channel, String message, int count, boolean cancelled) {
         this.channel = channel;
         this.count = count;
         this.message = message;

--- a/src/main/java/github/scarsz/discordsrv/api/events/WatchdogMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/WatchdogMessagePreProcessEvent.java
@@ -1,0 +1,41 @@
+/*
+ * DiscordSRV - A Minecraft to Discord and back link plugin
+ * Copyright (C) 2016-2019 Austin "Scarsz" Shapiro
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package github.scarsz.discordsrv.api.events;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.bukkit.event.Cancellable;
+
+public class WatchdogMessagePreProcessEvent extends Event implements Cancellable {
+
+    @Getter @Setter private boolean cancelled;
+
+    @Getter @Setter private String channel;
+    @Getter @Setter private String message;
+
+    @Getter @Setter private Integer count;
+
+    public WatchdogMessagePreProcessEvent(String channel, String message, int count, boolean cancelled) {
+        this.channel = channel;
+        this.count = count;
+        this.message = message;
+        setCancelled(cancelled);
+    }
+
+}

--- a/src/main/java/github/scarsz/discordsrv/api/events/WatchdogMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/WatchdogMessagePreProcessEvent.java
@@ -29,7 +29,7 @@ public class WatchdogMessagePreProcessEvent extends Event implements Cancellable
     @Getter @Setter private String channel;
     @Getter @Setter private String message;
 
-    @Getter @Setter private Integer count;
+    @Getter @Setter private int count;
 
     public WatchdogMessagePreProcessEvent(String channel, String message, int count, boolean cancelled) {
         this.channel = channel;

--- a/src/main/java/github/scarsz/discordsrv/objects/threads/ServerWatchdog.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/threads/ServerWatchdog.java
@@ -70,7 +70,7 @@ public class ServerWatchdog extends Thread {
 
                     WatchdogMessagePreProcessEvent preEvent = DiscordSRV.api.callEvent(new WatchdogMessagePreProcessEvent(channelName, message, count, false));
                     if (preEvent.isCancelled()) {
-                        DiscordSRV.debug("WatchdogMessageEvent was cancelled, message send aborted");
+                        DiscordSRV.debug("WatchdogMessagePreProcessEvent was cancelled, message send aborted");
                         return;
                     }
                     // Update from event in case any listeners modified parameters
@@ -84,7 +84,7 @@ public class ServerWatchdog extends Thread {
 
                     WatchdogMessagePostProcessEvent postEvent = DiscordSRV.api.callEvent(new WatchdogMessagePostProcessEvent(channelName, message, count, false));
                     if (postEvent.isCancelled()) {
-                        DiscordSRV.debug("WatchdogMessageEvent was cancelled, message send aborted");
+                        DiscordSRV.debug("WatchdogMessagePostProcessEvent was cancelled, message send aborted");
                         return;
                     }
                     // Update from event in case any listeners modified parameters


### PR DESCRIPTION
Add a WatchdogMessageEvent for 3rd party plugins to alter or cancel the watchdog message.
Fixes Issue #647