### PR TITLE
Added JDBC caching for single server environments

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/objects/managers/JdbcAccountLinkManager.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/managers/JdbcAccountLinkManager.java
@@ -13,8 +13,16 @@ import org.bukkit.OfflinePlayer;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
-import java.sql.*;
-import java.util.*;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;

--- a/src/main/resources/config/de.yml
+++ b/src/main/resources/config/de.yml
@@ -33,6 +33,7 @@ Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnec
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"
 Experiment_JdbcPassword: "password"
+Experiment_JdbcSingleServerCache: false
 Experiment_WebhookChatMessageDelivery: false
 Experiment_WebhookChatMessageUsernameFromDiscord: false
 Experiment_EmbedAvatarUrl: https://crafatar.com/avatars/{uuid}?overlay

--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -33,6 +33,7 @@ Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnec
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"
 Experiment_JdbcPassword: "password"
+Experiment_JdbcSingleServerCache: false
 Experiment_WebhookChatMessageDelivery: false
 Experiment_WebhookChatMessageUsernameFromDiscord: false
 Experiment_EmbedAvatarUrl: https://crafatar.com/avatars/{uuid}?overlay&size={size}

--- a/src/main/resources/config/es.yml
+++ b/src/main/resources/config/es.yml
@@ -33,6 +33,7 @@ Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnec
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"
 Experiment_JdbcPassword: "password"
+Experiment_JdbcSingleServerCache: false
 Experiment_WebhookChatMessageDelivery: false
 Experiment_WebhookChatMessageUsernameFromDiscord: false
 Experiment_EmbedAvatarUrl: https://crafatar.com/avatars/{uuid}?overlay

--- a/src/main/resources/config/et.yml
+++ b/src/main/resources/config/et.yml
@@ -33,6 +33,7 @@ Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnec
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"
 Experiment_JdbcPassword: "password"
+Experiment_JdbcSingleServerCache: false
 Experiment_WebhookChatMessageDelivery: false
 Experiment_WebhookChatMessageUsernameFromDiscord: false
 Experiment_EmbedAvatarUrl: https://crafatar.com/avatars/{uuid}?overlay

--- a/src/main/resources/config/fr.yml
+++ b/src/main/resources/config/fr.yml
@@ -33,6 +33,7 @@ Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnec
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"
 Experiment_JdbcPassword: "password"
+Experiment_JdbcSingleServerCache: false
 Experiment_WebhookChatMessageDelivery: false
 Experiment_WebhookChatMessageUsernameFromDiscord: false
 Experiment_EmbedAvatarUrl: https://crafatar.com/avatars/{uuid}?overlay

--- a/src/main/resources/config/ja.yml
+++ b/src/main/resources/config/ja.yml
@@ -33,6 +33,7 @@ Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnec
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"
 Experiment_JdbcPassword: "password"
+Experiment_JdbcSingleServerCache: false
 Experiment_WebhookChatMessageDelivery: false
 Experiment_WebhookChatMessageUsernameFromDiscord: false
 Experiment_EmbedAvatarUrl: https://crafatar.com/avatars/{uuid}?overlay

--- a/src/main/resources/config/ko.yml
+++ b/src/main/resources/config/ko.yml
@@ -33,6 +33,7 @@ Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnec
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"
 Experiment_JdbcPassword: "password"
+Experiment_JdbcSingleServerCache: false
 Experiment_WebhookChatMessageDelivery: false
 Experiment_WebhookChatMessageUsernameFromDiscord: false
 Experiment_EmbedAvatarUrl: https://crafatar.com/avatars/{uuid}?overlay

--- a/src/main/resources/config/nl.yml
+++ b/src/main/resources/config/nl.yml
@@ -33,6 +33,7 @@ Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnec
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"
 Experiment_JdbcPassword: "password"
+Experiment_JdbcSingleServerCache: false
 Experiment_WebhookChatMessageDelivery: false
 Experiment_WebhookChatMessageUsernameFromDiscord: false
 Experiment_EmbedAvatarUrl: https://crafatar.com/avatars/{uuid}?overlay

--- a/src/main/resources/config/ru.yml
+++ b/src/main/resources/config/ru.yml
@@ -33,6 +33,7 @@ Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnec
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"
 Experiment_JdbcPassword: "password"
+Experiment_JdbcSingleServerCache: false
 Experiment_WebhookChatMessageDelivery: false
 Experiment_WebhookChatMessageUsernameFromDiscord: false
 Experiment_EmbedAvatarUrl: https://crafatar.com/avatars/{uuid}?overlay

--- a/src/main/resources/config/zh.yml
+++ b/src/main/resources/config/zh.yml
@@ -32,6 +32,7 @@ Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnec
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"
 Experiment_JdbcPassword: "password"
+Experiment_JdbcSingleServerCache: false
 Experiment_WebhookChatMessageDelivery: false
 Experiment_WebhookChatMessageUsernameFromDiscord: false
 Experiment_EmbedAvatarUrl: https://crafatar.com/avatars/{uuid}?overlay


### PR DESCRIPTION
Every use of the account linking lookup resulted in a MySQL query. For a single server environment, caching the results locally seemed more appropriate.