### PR TITLE
VentureChat 2.18.* Updated Plugin Hook

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -519,7 +519,7 @@
         <dependency>
             <groupId>mineverse.aust1n46</groupId>
             <artifactId>venturechat</artifactId>
-            <version>2.18.2</version>
+            <version>2.18.3</version>
             <scope>provided</scope>
         </dependency>
         <!-- ProtocolLib (needed for venturechat) -->

--- a/pom.xml
+++ b/pom.xml
@@ -522,6 +522,13 @@
             <version>2.18.2</version>
             <scope>provided</scope>
         </dependency>
+        <!-- ProtocolLib (needed for venturechat) -->
+        <dependency>
+            <groupId>com.comphenix.protocol</groupId>
+            <artifactId>ProtocolLib</artifactId>
+            <version>4.5.0</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- fancychat -->
         <dependency>
             <groupId>br.com.finalcraft</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -519,7 +519,7 @@
         <dependency>
             <groupId>mineverse.aust1n46</groupId>
             <artifactId>venturechat</artifactId>
-            <version>2.14.0</version>
+            <version>2.18.2</version>
             <scope>provided</scope>
         </dependency>
         <!-- fancychat -->

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/VentureChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/VentureChatHook.java
@@ -51,7 +51,7 @@ public class VentureChatHook implements ChatHook {
     public void onVentureChatEvent(VentureChatEvent event) {
         // event will fire again when received. Don't want to listen twice on the sending server
         if (event.isBungee()) return;
-	
+
         // get channel
         ChatChannel chatChannel = event.getChannel();
         String channel = chatChannel.getName();
@@ -61,7 +61,7 @@ public class VentureChatHook implements ChatHook {
 
         // get plain text message (no JSON)
         String message = event.getChat();
-		
+
         String userPrimaryGroup = event.getPlayerPrimaryGroup();
         if (userPrimaryGroup.equals("default")) userPrimaryGroup = " ";
 
@@ -77,21 +77,21 @@ public class VentureChatHook implements ChatHook {
         username = DiscordUtil.strip(username);
         if (!reserializer) username = DiscordUtil.escapeMarkdown(username);
 
-	String discordMessage = (hasGoodGroup
+        String discordMessage = (hasGoodGroup
                 ? LangUtil.Message.CHAT_TO_DISCORD.toString()
                 : LangUtil.Message.CHAT_TO_DISCORD_NO_PRIMARY_GROUP.toString())
             .replaceAll("%time%|%date%", TimeUtil.timeStamp())
             .replace("%channelname%", channel != null ? channel.substring(0, 1).toUpperCase() + channel.substring(1) : "")
             .replace("%primarygroup%", userPrimaryGroup)
             .replace("%username%", username);
-		
+
         String displayName = DiscordUtil.strip(nickname);
         if (!reserializer) displayName = DiscordUtil.escapeMarkdown(displayName);
 
         discordMessage = discordMessage
                 .replace("%displayname%", displayName)
                 .replace("%message%", message);
-        
+
         if (!reserializer) discordMessage = DiscordUtil.strip(discordMessage);
 
         if (DiscordSRV.config().getBoolean("DiscordChatChannelTranslateMentions")) {
@@ -100,11 +100,11 @@ public class VentureChatHook implements ChatHook {
             discordMessage = discordMessage.replace("@", "@\u200B"); // zero-width space
             message = message.replace("@", "@\u200B"); // zero-width space
         }
-		
+
         if (reserializer) {
             discordMessage = DiscordSerializer.INSTANCE.serialize(LegacyComponentSerializer.legacy().deserialize(discordMessage));
         }
-		
+
         if (!DiscordSRV.config().getBoolean("Experiment_WebhookChatMessageDelivery")) {
             if (channel == null) {
                 DiscordUtil.sendMessage(DiscordSRV.getPlugin().getMainTextChannel(), discordMessage);
@@ -124,7 +124,7 @@ public class VentureChatHook implements ChatHook {
             DiscordSRV.debug("Attempted to broadcast message to channel \"" + channel + "\" but got null channel info; aborting message");
             return;
         }
-		
+
         // filter chat if bad words filter is on for channel and player
         String msg = message;
         if (chatChannel.isFiltered()) msg = Format.FilterChat(msg);
@@ -134,7 +134,7 @@ public class VentureChatHook implements ChatHook {
                 .replace("%channelname%", chatChannel.getName())
                 .replace("%channelnickname%", chatChannel.getAlias())
                 .replace("%message%", msg);
-        
+
         if (chatChannel.getBungee()) {
             if (DiscordSRV.config().getBoolean("Experiment_MCDiscordReserializer_ToMinecraft")) {
                 plainMessage = DiscordSerializer.INSTANCE.serialize(MinecraftSerializer.INSTANCE.serialize(plainMessage));

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/VentureChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/VentureChatHook.java
@@ -61,8 +61,6 @@ public class VentureChatHook implements ChatHook {
 
         // get plain text message (no JSON)
         String message = event.getChat();
-
-        DiscordSRV discordsrv = DiscordSRV.getPlugin();
 		
         String userPrimaryGroup = event.getPlayerPrimaryGroup();
         if (userPrimaryGroup.equals("default")) userPrimaryGroup = " ";

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/VentureChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/VentureChatHook.java
@@ -95,7 +95,7 @@ public class VentureChatHook implements ChatHook {
         if (!reserializer) discordMessage = DiscordUtil.strip(discordMessage);
 
         if (DiscordSRV.config().getBoolean("DiscordChatChannelTranslateMentions")) {
-            discordMessage = DiscordUtil.convertMentionsFromNames(discordMessage, discordsrv.getMainGuild());
+            discordMessage = DiscordUtil.convertMentionsFromNames(discordMessage, DiscordSRV.getPlugin().getMainGuild());
         } else {
             discordMessage = discordMessage.replace("@", "@\u200B"); // zero-width space
             message = message.replace("@", "@\u200B"); // zero-width space
@@ -107,9 +107,9 @@ public class VentureChatHook implements ChatHook {
 		
         if (!DiscordSRV.config().getBoolean("Experiment_WebhookChatMessageDelivery")) {
             if (channel == null) {
-                DiscordUtil.sendMessage(discordsrv.getMainTextChannel(), discordMessage);
+                DiscordUtil.sendMessage(DiscordSRV.getPlugin().getMainTextChannel(), discordMessage);
             } else {
-                DiscordUtil.sendMessage(discordsrv.getDestinationTextChannelForGameChannelName(channel), discordMessage);
+                DiscordUtil.sendMessage(DiscordSRV.getPlugin().getDestinationTextChannelForGameChannelName(channel), discordMessage);
             }
         } else {
             // requires player object we don't have


### PR DESCRIPTION
Key features:

Utilizes new VentureChatEvent instead of having to manually check for mutes, permissions, etc in the AsyncPlayerChatEvent.

BungeeCord chat channels from across the network can transmit to the same Discord channel with just a single bot and a single installation of DiscordSRV on one Spigot server.

A single bot can transmit chat from Discord to all servers with a single installation of DiscordSRV on one Spigot server.

Multiple DiscordSRV bots and installations can still be used for standard chat channels.

Messages sent from Discord -> Minecraft support VentureChat's message remover via the Moderation GUI.

Caveats: 

The server with DiscordSRV installed on it needs to have at least one player logged on in order to receive and send plugin messages via VentureChat.

Dependency Changes:

Requires VentureChat 2.18.3 (soon to be released)
ProtocolLib