### PR TITLE
MySQL 8 BIGINT changes

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/objects/managers/JdbcAccountLinkManager.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/managers/JdbcAccountLinkManager.java
@@ -122,17 +122,9 @@ public class JdbcAccountLinkManager extends AccountLinkManager {
 
             final Map<String, String> legacyExpected = new HashMap<>(expected);
             legacyExpected.put("expiration", "bigint(20)");
-            if (SQLUtil.checkIfTableMatchesStructure(connection, codesTable, legacyExpected)) {
-                try (final PreparedStatement statement = connection.prepareStatement(
-                "alter table " + codesTable + "\n" +
-                "modify expiration bigint not null\n" +
-                ";")) {
-                    statement.executeUpdate();
-                }
-            }
-
             expected.put("expiration", "bigint");
-            if (!SQLUtil.checkIfTableMatchesStructure(connection, codesTable, expected)) {
+            if (!(SQLUtil.checkIfTableMatchesStructure(connection, codesTable, expected, false)
+            || SQLUtil.checkIfTableMatchesStructure(connection, codesTable, legacyExpected))) {
                 throw new SQLException("JDBC table " + codesTable + " does not match expected structure");
             }
         } else {
@@ -141,7 +133,7 @@ public class JdbcAccountLinkManager extends AccountLinkManager {
                             "(\n" +
                             "    code       char(4)     not null primary key,\n" +
                             "    uuid       varchar(36) not null,\n" +
-                            "    expiration bigint      not null,\n" +
+                            "    expiration bigint(20)  not null,\n" +
                             "    constraint codes_uuid_uindex unique (uuid)\n" +
                             ");")) {
                 statement.executeUpdate();

--- a/src/main/java/github/scarsz/discordsrv/util/SQLUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/SQLUtil.java
@@ -43,13 +43,19 @@ public class SQLUtil {
     }
 
     public static boolean checkIfTableMatchesStructure(Connection connection, String table, Map<String, String> expectedColumns) throws SQLException {
+        return checkIfTableMatchesStructure(connection, table, expectedColumns, true);
+    }
+
+    public static boolean checkIfTableMatchesStructure(Connection connection, String table, Map<String, String> expectedColumns, boolean showErrors) throws SQLException {
         final List<String> found = new LinkedList<>();
         for (Map.Entry<String, String> entry : SQLUtil.getTableColumns(connection, table).entrySet()) {
             if (!expectedColumns.containsKey(entry.getKey())) continue; // only check columns that we're expecting
             final String expectedType = expectedColumns.get(entry.getKey());
             final String actualType = entry.getValue();
             if (!expectedType.equals(actualType)) {
-                DiscordSRV.error("Expected type " + expectedType + " for column " + entry.getKey() + ", got " + actualType);
+                if (showErrors) {
+                    DiscordSRV.error("Expected type " + expectedType + " for column " + entry.getKey() + ", got " + actualType);
+                }
                 return false;
             }
             found.add(entry.getKey());


### PR DESCRIPTION
MySQL 8 removed the size of zero padding for BIGINT columns causing the column checks to fail. Here we allow both the old and the new column definition and silently check for the new type so as not to show errors if using legacy column type.