### PR TITLE
Fix discord command NPE on startup

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -841,9 +841,8 @@ public class DiscordSRV extends JavaPlugin implements Listener {
 
         voiceModule = new VoiceModule();
 
-        if (Bukkit.getServer().getPluginCommand("discord").getPlugin() != this) {
+        if (getCommand("discord").getPlugin() != this) {
             DiscordSRV.warning("/discord command is being handled by plugin other than DiscordSRV. You must use /discordsrv instead.");
-            Bukkit.getServer().getPluginCommand("discordsrv:discord").setAliases(Collections.singletonList("discordsrv"));
         }
 
         // set ready status

--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -81,6 +81,7 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.PluginCommand;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
@@ -841,7 +842,8 @@ public class DiscordSRV extends JavaPlugin implements Listener {
 
         voiceModule = new VoiceModule();
 
-        if (getCommand("discord").getPlugin() != this) {
+        PluginCommand discordCommand = getCommand("discord");
+        if (discordCommand != null && discordCommand.getPlugin() != this) {
             DiscordSRV.warning("/discord command is being handled by plugin other than DiscordSRV. You must use /discordsrv instead.");
         }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -22,6 +22,7 @@ softdepend: [
 
 commands:
   discord:
+    aliases: [discordsrv]
     description: DiscordSRV commands
     usage: |
            /discord - Show the invite link of the Discord server


### PR DESCRIPTION
When DiscordSRV initializes it attempts to get the discord command from the server. As documented [here](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Server.html#getPluginCommand-java.lang.String-), this will return null if the command is not found. This can easily happen if the command overridden or disabled (through commands.yml, another plugin, or some other means). This PR simply adds a check for this, so that DiscordSRV can start up properly. It also reverts a previous commit which attempted to fix this, however still fails to check for null and thus still exhibits the exact same issue.