### PR TITLE
Add discord command permission

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -33,8 +33,12 @@ commands:
            /discord setpicture - Set the avatar of the bot
            /discord debug - Send debug information to Gist
            /discord reload - Reload the plugin
+    permission: discordsrv.discord
 
 permissions:
+  discordsrv.discord:
+    description: allows access to the discord command
+    default: true
   discordsrv.player:
     description: parent permission of player-related functions of DiscordSRV
     default: true


### PR DESCRIPTION
This simply adds a permission to /discord, which allows server admins to 1) prevent users from using the command if they so choose, and 2) prevents Bukkit from suggesting tab completions for the command if users do not have access.