### PR TITLE
Provide some LuckPerms contexts

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/hooks/permissions/LuckPermsHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/permissions/LuckPermsHook.java
@@ -22,7 +22,14 @@ import github.scarsz.discordsrv.DiscordSRV;
 import github.scarsz.discordsrv.hooks.PluginHook;
 import github.scarsz.discordsrv.objects.managers.GroupSynchronizationManager;
 import github.scarsz.discordsrv.util.PluginUtil;
-import net.luckperms.api.LuckPermsProvider;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.context.ContextCalculator;
+import net.luckperms.api.context.ContextConsumer;
+import net.luckperms.api.context.ContextSet;
+import net.luckperms.api.context.ImmutableContextSet;
 import net.luckperms.api.event.EventSubscription;
 import net.luckperms.api.event.node.NodeAddEvent;
 import net.luckperms.api.event.node.NodeMutateEvent;
@@ -33,21 +40,35 @@ import net.luckperms.api.node.Node;
 import net.luckperms.api.node.NodeType;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.plugin.Plugin;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.*;
 
-public class LuckPermsHook implements PluginHook {
+public class LuckPermsHook implements PluginHook, ContextCalculator<Player> {
+    private static final String CONTEXT_LINKED = "discordsrv:linked";
+    private static final String CONTEXT_BOOSTING = "discordsrv:boosting";
+    private static final String CONTEXT_ROLE = "discordsrv:role";
 
+    private final LuckPerms luckPerms;
     private final Set<EventSubscription<?>> subscriptions = new HashSet<>();
 
     public LuckPermsHook() {
-        subscriptions.add(LuckPermsProvider.get().getEventBus().subscribe(UserTrackEvent.class, event -> handle(event.getUser().getUniqueId())));
-        subscriptions.add(LuckPermsProvider.get().getEventBus().subscribe(NodeAddEvent.class, event -> handle(event, event.getNode(), true)));
-        subscriptions.add(LuckPermsProvider.get().getEventBus().subscribe(NodeRemoveEvent.class, event -> handle(event, event.getNode(), false)));
+        luckPerms = Bukkit.getServicesManager().load(LuckPerms.class);
+
+        // update events
+        subscriptions.add(luckPerms.getEventBus().subscribe(UserTrackEvent.class, event -> handle(event.getUser().getUniqueId())));
+        subscriptions.add(luckPerms.getEventBus().subscribe(NodeAddEvent.class, event -> handle(event, event.getNode(), true)));
+        subscriptions.add(luckPerms.getEventBus().subscribe(NodeRemoveEvent.class, event -> handle(event, event.getNode(), false)));
+
+        // contexts
+        if (!DiscordSRV.config().getStringList("DisabledPluginHooks").contains("LuckPerms-Contexts")) {
+            luckPerms.getContextManager().registerCalculator(this);
+        }
     }
 
     private void handle(NodeMutateEvent event, Node node, boolean add) {
@@ -72,9 +93,58 @@ public class LuckPermsHook implements PluginHook {
         );
     }
 
+    @Override
+    public void calculate(@NonNull Player target, @NonNull ContextConsumer consumer) {
+        String userId = DiscordSRV.getPlugin().getAccountLinkManager().getDiscordId(target.getUniqueId());
+        consumer.accept(CONTEXT_LINKED, Boolean.toString(userId != null));
+
+        if (userId == null) {
+            return;
+        }
+
+        Guild mainGuild = DiscordSRV.getPlugin().getMainGuild();
+        if (mainGuild == null) {
+            return;
+        }
+
+        Member member = mainGuild.getMemberById(userId);
+        if (member == null) {
+            return;
+        }
+
+        consumer.accept(CONTEXT_BOOSTING, Boolean.toString(member.getTimeBoosted() != null));
+
+        for (Role role : member.getRoles()) {
+            consumer.accept(CONTEXT_ROLE, role.getName());
+        }
+    }
+
+    @Override
+    public ContextSet estimatePotentialContexts() {
+        ImmutableContextSet.Builder builder = ImmutableContextSet.builder();
+
+        builder.add(CONTEXT_LINKED, "true");
+        builder.add(CONTEXT_LINKED, "false");
+
+        builder.add(CONTEXT_BOOSTING, "true");
+        builder.add(CONTEXT_BOOSTING, "false");
+
+        Guild mainGuild = DiscordSRV.getPlugin().getMainGuild();
+        if (mainGuild != null) {
+            for (Role role : mainGuild.getRoles()) {
+                builder.add(CONTEXT_ROLE, role.getName());
+            }
+        }
+
+        return builder.build();
+    }
+
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPluginDisable(PluginDisableEvent event) {
-        if (event.getPlugin() instanceof DiscordSRV) subscriptions.forEach(EventSubscription::close);
+        if (event.getPlugin() instanceof DiscordSRV) {
+            subscriptions.forEach(EventSubscription::close);
+            luckPerms.getContextManager().unregisterCalculator(this);
+        }
     }
 
     @Override

--- a/src/main/java/github/scarsz/discordsrv/hooks/permissions/LuckPermsHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/permissions/LuckPermsHook.java
@@ -61,9 +61,11 @@ public class LuckPermsHook implements PluginHook, ContextCalculator<Player> {
         luckPerms = Bukkit.getServicesManager().load(LuckPerms.class);
 
         // update events
-        subscriptions.add(luckPerms.getEventBus().subscribe(UserTrackEvent.class, event -> handle(event.getUser().getUniqueId())));
-        subscriptions.add(luckPerms.getEventBus().subscribe(NodeAddEvent.class, event -> handle(event, event.getNode(), true)));
-        subscriptions.add(luckPerms.getEventBus().subscribe(NodeRemoveEvent.class, event -> handle(event, event.getNode(), false)));
+        if (!DiscordSRV.config().getStringList("DisabledPluginHooks").contains("LuckPerms-GroupUpdates")) {
+            subscriptions.add(luckPerms.getEventBus().subscribe(UserTrackEvent.class, event -> handle(event.getUser().getUniqueId())));
+            subscriptions.add(luckPerms.getEventBus().subscribe(NodeAddEvent.class, event -> handle(event, event.getNode(), true)));
+            subscriptions.add(luckPerms.getEventBus().subscribe(NodeRemoveEvent.class, event -> handle(event, event.getNode(), false)));
+        }
 
         // contexts
         if (!DiscordSRV.config().getStringList("DisabledPluginHooks").contains("LuckPerms-Contexts")) {


### PR DESCRIPTION
Allows permissions/groups/prefixes/etc to be assigned easily based on certain DiscordSRV states.

More information about contexts can be found here: https://github.com/lucko/LuckPerms/wiki/Context

This PR adds the following contexts:

* `discordsrv:linked` - whether the player has linked a Discord account (true/false)
* `discordsrv:boosting` - whether the player is boosting the Discord guild (true/false)
* `discordsrv:role` - the roles the user has in Discord

e.g. 

##### `/lp group default permission set essentials.fly true discordsrv:linked=true`
will give all users access to `/fly` if they have their account linked to Discord.

##### `/lp group default meta addsuffix 100 &d[Boost] discordsrv:boosting=true`
will give a pink `[Boost]` suffix to all users boosting the Discord guild.

##### `/lp group default permission set chat.use false discordsrv:role=muted`
will negate the `chat.use` permission for anyone with the `muted` role in Discord.

I've used the existing LuckPerms hook class to implement these, but also allowed for them to be disabled using a `LuckPerms-Contexts` entry in the `DisabledPluginHooks` config section.