### PR TITLE
 Support webhook and embed on achievements/advancements

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePostProcessEvent.java
@@ -57,4 +57,15 @@ public class AchievementMessagePostProcessEvent extends GameEvent implements Can
         this.achievementName = achievementName;
         setCancelled(cancelled);
     }
+
+    @Deprecated
+    public String getProcessedMessage() {
+        return discordMessage.getContentRaw();
+    }
+
+    @Deprecated
+    public void setProcessedMessage(String processedMessage) {
+        this.discordMessage = new MessageBuilder(processedMessage).build();
+    }
+
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePostProcessEvent.java
@@ -18,8 +18,11 @@
 
 package github.scarsz.discordsrv.api.events;
 
+import github.scarsz.discordsrv.objects.MessageFormat;
 import lombok.Getter;
 import lombok.Setter;
+import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.entities.Message;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 
@@ -29,14 +32,32 @@ public class AchievementMessagePostProcessEvent extends GameEvent implements Can
 
     @Getter private String achievementName;
     @Getter @Setter private String channel;
-    @Getter @Setter private String processedMessage;
 
+    @Getter @Setter private Message discordMessage;
+    @Getter @Setter private boolean usingWebhooks;
+    @Getter @Setter private String webhookName;
+    @Getter @Setter private String webhookAvatarUrl;
+
+    public AchievementMessagePostProcessEvent(String channel, Message discordMessage, Player player, String achievementName, boolean usingWebhooks, String webhookName, String webhookAvatarUrl, boolean cancelled) {
+        super(player);
+        this.channel = channel;
+        this.discordMessage = discordMessage;
+        this.achievementName = achievementName;
+        this.usingWebhooks = usingWebhooks;
+        this.webhookName = webhookName;
+        this.webhookAvatarUrl = webhookAvatarUrl;
+        setCancelled(cancelled);
+    }
+
+    /*
+    @Deprecated
     public AchievementMessagePostProcessEvent(String channel, String processedMessage, Player player, String achievementName, boolean cancelled) {
         super(player);
         this.channel = channel;
-        this.processedMessage = processedMessage;
+        this.discordMessage = new MessageBuilder().setContent(processedMessage).build();
         this.achievementName = achievementName;
         setCancelled(cancelled);
     }
+     */
 
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePostProcessEvent.java
@@ -49,7 +49,6 @@ public class AchievementMessagePostProcessEvent extends GameEvent implements Can
         setCancelled(cancelled);
     }
 
-    /*
     @Deprecated
     public AchievementMessagePostProcessEvent(String channel, String processedMessage, Player player, String achievementName, boolean cancelled) {
         super(player);
@@ -58,6 +57,4 @@ public class AchievementMessagePostProcessEvent extends GameEvent implements Can
         this.achievementName = achievementName;
         setCancelled(cancelled);
     }
-     */
-
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePreProcessEvent.java
@@ -49,4 +49,16 @@ public class AchievementMessagePreProcessEvent extends GameEvent implements Canc
         this.achievementName = achievementName;
     }
 
+    @Deprecated
+    public String getMessage() {
+        return messageFormat.getContent();
+    }
+
+    @Deprecated
+    public void setMessage(String message) {
+        MessageFormat messageFormat = new MessageFormat();
+        messageFormat.setContent(message);
+        this.messageFormat = messageFormat;
+    }
+
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePreProcessEvent.java
@@ -18,6 +18,7 @@
 
 package github.scarsz.discordsrv.api.events;
 
+import github.scarsz.discordsrv.objects.MessageFormat;
 import lombok.Getter;
 import lombok.Setter;
 import org.bukkit.entity.Player;
@@ -29,12 +30,22 @@ public class AchievementMessagePreProcessEvent extends GameEvent implements Canc
 
     @Getter @Setter private String achievementName;
     @Getter @Setter private String channel;
-    @Getter @Setter private String message;
+    @Getter @Setter private MessageFormat messageFormat;
 
+    public AchievementMessagePreProcessEvent(String channel, MessageFormat messageFormat, Player player, String achievementName) {
+        super(player);
+        this.channel = channel;
+        this.messageFormat = messageFormat;
+        this.achievementName = achievementName;
+    }
+
+    @Deprecated
     public AchievementMessagePreProcessEvent(String channel, String message, Player player, String achievementName) {
         super(player);
         this.channel = channel;
-        this.message = message;
+        MessageFormat messageFormat = new MessageFormat();
+        messageFormat.setContent(message);
+        this.messageFormat = messageFormat;
         this.achievementName = achievementName;
     }
 

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerAchievementsListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerAchievementsListener.java
@@ -22,7 +22,9 @@ import github.scarsz.discordsrv.DiscordSRV;
 import github.scarsz.discordsrv.api.events.AchievementMessagePostProcessEvent;
 import github.scarsz.discordsrv.api.events.AchievementMessagePreProcessEvent;
 import github.scarsz.discordsrv.hooks.world.MultiverseCoreHook;
+import github.scarsz.discordsrv.objects.MessageFormat;
 import github.scarsz.discordsrv.util.*;
+import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
@@ -31,6 +33,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerAchievementAwardedEvent;
+
+import java.util.function.BiFunction;
 
 @SuppressWarnings("deprecation")
 public class PlayerAchievementsListener implements Listener {
@@ -43,9 +47,6 @@ public class PlayerAchievementsListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerAchievementAwarded(PlayerAchievementAwardedEvent event) {
-        // return if achievement messages are disabled
-        if (StringUtils.isBlank(LangUtil.Message.PLAYER_ACHIEVEMENT.toString())) return;
-
         // return if achievement or player objects are knackered because this can apparently happen for some reason
         if (event == null || event.getAchievement() == null || event.getPlayer() == null) return;
 
@@ -55,10 +56,13 @@ public class PlayerAchievementsListener implements Listener {
         // turn "ACHIEVEMENT_NAME" into "Achievement Name"
         String channelName = DiscordSRV.getPlugin().getMainChatChannel();
         String achievementName = PrettyUtil.beautify(event.getAchievement());
-        String message = LangUtil.Message.PLAYER_ACHIEVEMENT.toString();
+
         Player player = event.getPlayer();
 
-        AchievementMessagePreProcessEvent preEvent = DiscordSRV.api.callEvent(new AchievementMessagePreProcessEvent(channelName, message, player, achievementName));
+        MessageFormat messageFormat = DiscordSRV.getPlugin().getMessageFromConfiguration("MinecraftPlayerAchievementMessage");
+        if (messageFormat == null) return;
+
+        AchievementMessagePreProcessEvent preEvent = DiscordSRV.api.callEvent(new AchievementMessagePreProcessEvent(channelName, messageFormat, player, achievementName));
         if (preEvent.isCancelled()) {
             DiscordSRV.debug("AchievementMessagePreProcessEvent was cancelled, message send aborted");
             return;
@@ -66,29 +70,63 @@ public class PlayerAchievementsListener implements Listener {
         // Update from event in case any listeners modified parameters
         achievementName = preEvent.getAchievementName();
         channelName = preEvent.getChannel();
-        message = preEvent.getMessage();
+        messageFormat = preEvent.getMessageFormat();
 
-        String discordMessage = message
-                .replaceAll("%time%|%date%", TimeUtil.timeStamp())
-                .replace("%username%", player.getName())
-                .replace("%displayname%", DiscordUtil.strip(DiscordUtil.escapeMarkdown(player.getDisplayName())))
-                .replace("%world%", player.getWorld().getName())
-                .replace("%worldalias%", DiscordUtil.strip(MultiverseCoreHook.getWorldAlias(player.getWorld().getName())))
-                .replace("%achievement%", achievementName);
-        discordMessage = PlaceholderUtil.replacePlaceholdersToDiscord(discordMessage, player);
+        if (messageFormat == null) return;
 
-        AchievementMessagePostProcessEvent postEvent = DiscordSRV.api.callEvent(new AchievementMessagePostProcessEvent(channelName, discordMessage, player, achievementName, preEvent.isCancelled()));
+        String finalAchievementName = StringUtils.isNotBlank(achievementName) ? achievementName : "";
+        String avatarUrl = DiscordSRV.getPlugin().getEmbedAvatarUrl(player);
+        String botAvatarUrl = DiscordUtil.getJda().getSelfUser().getEffectiveAvatarUrl();
+        String botName = DiscordSRV.getPlugin().getMainGuild() != null ? DiscordSRV.getPlugin().getMainGuild().getSelfMember().getEffectiveName() : DiscordUtil.getJda().getSelfUser().getName();
+        String webhookName = messageFormat.getWebhookName();
+        String webhookAvatarUrl = messageFormat.getWebhookAvatarUrl();
+        String displayName = StringUtils.isNotBlank(player.getDisplayName()) ? player.getDisplayName() : "";
+
+        String finalChannelName = channelName;
+        BiFunction<String, Boolean, String> translator = (content, needsEscape) -> {
+            if (content == null) return null;
+            content = content
+                    .replaceAll("%time%|%date%", TimeUtil.timeStamp())
+                    .replace("%username%", player.getName())
+                    .replace("%displayname%", DiscordUtil.strip(needsEscape ? DiscordUtil.escapeMarkdown(displayName) : displayName))
+                    .replace("%world%", player.getWorld().getName())
+                    .replace("%achievement%", DiscordUtil.strip(needsEscape ? DiscordUtil.escapeMarkdown(finalAchievementName) : finalAchievementName))
+                    .replace("%embedavatarurl%", avatarUrl)
+                    .replace("%botavatarurl%", botAvatarUrl)
+                    .replace("%botname%", botName);
+            TextChannel textChannel = DiscordSRV.getPlugin().getDestinationTextChannelForGameChannelName(finalChannelName);
+            if (textChannel != null) content = DiscordUtil.translateEmotes(content, textChannel.getGuild());
+            content = PlaceholderUtil.replacePlaceholdersToDiscord(content, player);
+            return content;
+        };
+        Message discordMessage = DiscordSRV.getPlugin().translateMessage(messageFormat, translator);
+        if (discordMessage == null) return;
+
+        webhookName = translator.apply(webhookName, true);
+        webhookAvatarUrl = translator.apply(webhookAvatarUrl, true);
+
+        if (achievementName.length() < 3) {
+            DiscordSRV.debug("Not sending achievement message, because it's less than three characters long. Message: " + messageFormat);
+            return;
+        }
+
+        AchievementMessagePostProcessEvent postEvent = DiscordSRV.api.callEvent(new AchievementMessagePostProcessEvent(channelName, discordMessage, player, achievementName, messageFormat.isUseWebhooks(), webhookName, webhookAvatarUrl, preEvent.isCancelled()));
         if (postEvent.isCancelled()) {
             DiscordSRV.debug("AchievementMessagePostProcessEvent was cancelled, message send aborted");
             return;
         }
+
         // Update from event in case any listeners modified parameters
         channelName = postEvent.getChannel();
-        discordMessage = postEvent.getProcessedMessage();
+        discordMessage = postEvent.getDiscordMessage();
 
-        TextChannel channel = DiscordSRV.getPlugin().getDestinationTextChannelForGameChannelName(channelName);
-
-        DiscordUtil.sendMessage(channel, discordMessage);
+        TextChannel textChannel = DiscordSRV.getPlugin().getDestinationTextChannelForGameChannelName(channelName);
+        if (messageFormat.isUseWebhooks()) {
+            WebhookUtil.deliverMessage(textChannel, postEvent.getWebhookName(), postEvent.getWebhookAvatarUrl(),
+                    discordMessage.getContentRaw(), discordMessage.getEmbeds().stream().findFirst().orElse(null));
+        } else {
+            DiscordUtil.queueMessage(textChannel, discordMessage);
+        }
     }
 
 }

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerAchievementsListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerAchievementsListener.java
@@ -105,11 +105,6 @@ public class PlayerAchievementsListener implements Listener {
         webhookName = translator.apply(webhookName, true);
         webhookAvatarUrl = translator.apply(webhookAvatarUrl, true);
 
-        if (achievementName.length() < 3) {
-            DiscordSRV.debug("Not sending achievement message, because the achievement name is less than three characters long. Message: " + messageFormat);
-            return;
-        }
-
         AchievementMessagePostProcessEvent postEvent = DiscordSRV.api.callEvent(new AchievementMessagePostProcessEvent(channelName, discordMessage, player, achievementName, messageFormat.isUseWebhooks(), webhookName, webhookAvatarUrl, preEvent.isCancelled()));
         if (postEvent.isCancelled()) {
             DiscordSRV.debug("AchievementMessagePostProcessEvent was cancelled, message send aborted");

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerAchievementsListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerAchievementsListener.java
@@ -106,7 +106,7 @@ public class PlayerAchievementsListener implements Listener {
         webhookAvatarUrl = translator.apply(webhookAvatarUrl, true);
 
         if (achievementName.length() < 3) {
-            DiscordSRV.debug("Not sending achievement message, because it's less than three characters long. Message: " + messageFormat);
+            DiscordSRV.debug("Not sending achievement message, because the achievement name is less than three characters long. Message: " + messageFormat);
             return;
         }
 

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerAdvancementDoneListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerAdvancementDoneListener.java
@@ -21,7 +21,10 @@ package github.scarsz.discordsrv.listeners;
 import github.scarsz.discordsrv.DiscordSRV;
 import github.scarsz.discordsrv.api.events.AchievementMessagePostProcessEvent;
 import github.scarsz.discordsrv.api.events.AchievementMessagePreProcessEvent;
+import github.scarsz.discordsrv.hooks.world.MultiverseCoreHook;
+import github.scarsz.discordsrv.objects.MessageFormat;
 import github.scarsz.discordsrv.util.*;
+import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
@@ -33,6 +36,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerAdvancementDoneEvent;
 
 import java.util.Arrays;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 public class PlayerAdvancementDoneListener implements Listener {
@@ -43,9 +47,6 @@ public class PlayerAdvancementDoneListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerAdvancementDone(PlayerAdvancementDoneEvent event) {
-        // return if advancement messages are disabled
-        if (StringUtils.isBlank(LangUtil.Message.PLAYER_ACHIEVEMENT.toString())) return;
-
         // return if advancement or player objects are knackered because this can apparently happen for some reason
         if (event.getAdvancement() == null || event.getAdvancement().getKey().getKey().contains("recipe/") || event.getPlayer() == null) return;
 
@@ -65,9 +66,11 @@ public class PlayerAdvancementDoneListener implements Listener {
         }
 
         String channelName = DiscordSRV.getPlugin().getMainChatChannel();
-        String message = LangUtil.Message.PLAYER_ACHIEVEMENT.toString();
         Player player = event.getPlayer();
         Advancement advancement = event.getAdvancement();
+
+        MessageFormat messageFormat = DiscordSRV.getPlugin().getMessageFromConfiguration("MinecraftPlayerAchievementMessage");
+        if (messageFormat == null) return;
 
         // turn "story/advancement_name" into "Advancement Name"
         String rawAdvancementName = advancement.getKey().getKey();
@@ -75,7 +78,7 @@ public class PlayerAdvancementDoneListener implements Listener {
                 .map(s -> s.substring(0, 1).toUpperCase() + s.substring(1))
                 .collect(Collectors.joining(" "));
 
-        AchievementMessagePreProcessEvent preEvent = DiscordSRV.api.callEvent(new AchievementMessagePreProcessEvent(channelName, message, player, advancementName));
+        AchievementMessagePreProcessEvent preEvent = DiscordSRV.api.callEvent(new AchievementMessagePreProcessEvent(channelName, messageFormat, player, advancementName));
         if (preEvent.isCancelled()) {
             DiscordSRV.debug("AchievementMessagePreProcessEvent was cancelled, message send aborted");
             return;
@@ -83,28 +86,62 @@ public class PlayerAdvancementDoneListener implements Listener {
         // Update from event in case any listeners modified parameters
         advancementName = preEvent.getAchievementName();
         channelName = preEvent.getChannel();
-        message = preEvent.getMessage();
+        messageFormat = preEvent.getMessageFormat();
 
-        String discordMessage = message
-                .replaceAll("%time%|%date%", TimeUtil.timeStamp())
-                .replace("%username%", player.getName())
-                .replace("%displayname%", DiscordUtil.strip(DiscordUtil.escapeMarkdown(player.getDisplayName())))
-                .replace("%world%", player.getWorld().getName())
-                .replace("%achievement%", advancementName);
-        discordMessage = PlaceholderUtil.replacePlaceholdersToDiscord(discordMessage, event.getPlayer());
+        if (messageFormat == null) return;
 
-        AchievementMessagePostProcessEvent postEvent = DiscordSRV.api.callEvent(new AchievementMessagePostProcessEvent(channelName, discordMessage, player, advancementName, preEvent.isCancelled()));
+        String finalAchievementName = StringUtils.isNotBlank(advancementName) ? advancementName : "";
+        String avatarUrl = DiscordSRV.getPlugin().getEmbedAvatarUrl(player);
+        String botAvatarUrl = DiscordUtil.getJda().getSelfUser().getEffectiveAvatarUrl();
+        String botName = DiscordSRV.getPlugin().getMainGuild() != null ? DiscordSRV.getPlugin().getMainGuild().getSelfMember().getEffectiveName() : DiscordUtil.getJda().getSelfUser().getName();
+        String webhookName = messageFormat.getWebhookName();
+        String webhookAvatarUrl = messageFormat.getWebhookAvatarUrl();
+        String displayName = StringUtils.isNotBlank(player.getDisplayName()) ? player.getDisplayName() : "";
+
+        String finalChannelName = channelName;
+        BiFunction<String, Boolean, String> translator = (content, needsEscape) -> {
+            if (content == null) return null;
+            content = content
+                    .replaceAll("%time%|%date%", TimeUtil.timeStamp())
+                    .replace("%username%", player.getName())
+                    .replace("%displayname%", DiscordUtil.strip(needsEscape ? DiscordUtil.escapeMarkdown(displayName) : displayName))
+                    .replace("%world%", player.getWorld().getName())
+                    .replace("%achievement%", DiscordUtil.strip(needsEscape ? DiscordUtil.escapeMarkdown(finalAchievementName) : finalAchievementName))
+                    .replace("%embedavatarurl%", avatarUrl)
+                    .replace("%botavatarurl%", botAvatarUrl)
+                    .replace("%botname%", botName);
+            TextChannel textChannel = DiscordSRV.getPlugin().getDestinationTextChannelForGameChannelName(finalChannelName);
+            if (textChannel != null) content = DiscordUtil.translateEmotes(content, textChannel.getGuild());
+            content = PlaceholderUtil.replacePlaceholdersToDiscord(content, player);
+            return content;
+        };
+        Message discordMessage = DiscordSRV.getPlugin().translateMessage(messageFormat, translator);
+        if (discordMessage == null) return;
+
+        webhookName = translator.apply(webhookName, true);
+        webhookAvatarUrl = translator.apply(webhookAvatarUrl, true);
+
+        if (advancementName.length() < 3) {
+            DiscordSRV.debug("Not sending achievement message, because it's less than three characters long. Message: " + messageFormat);
+            return;
+        }
+
+        AchievementMessagePostProcessEvent postEvent = DiscordSRV.api.callEvent(new AchievementMessagePostProcessEvent(channelName, discordMessage, player, advancementName, messageFormat.isUseWebhooks(), webhookName, webhookAvatarUrl, preEvent.isCancelled()));
         if (postEvent.isCancelled()) {
             DiscordSRV.debug("AchievementMessagePostProcessEvent was cancelled, message send aborted");
             return;
         }
         // Update from event in case any listeners modified parameters
         channelName = postEvent.getChannel();
-        discordMessage = postEvent.getProcessedMessage();
+        discordMessage = postEvent.getDiscordMessage();
 
-        TextChannel channel = DiscordSRV.getPlugin().getDestinationTextChannelForGameChannelName(channelName);
-
-        DiscordUtil.sendMessage(channel, discordMessage);
+        TextChannel textChannel = DiscordSRV.getPlugin().getDestinationTextChannelForGameChannelName(channelName);
+        if (messageFormat.isUseWebhooks()) {
+            WebhookUtil.deliverMessage(textChannel, postEvent.getWebhookName(), postEvent.getWebhookAvatarUrl(),
+                    discordMessage.getContentRaw(), discordMessage.getEmbeds().stream().findFirst().orElse(null));
+        } else {
+            DiscordUtil.queueMessage(textChannel, discordMessage);
+        }
     }
 
 }

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerAdvancementDoneListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerAdvancementDoneListener.java
@@ -121,11 +121,6 @@ public class PlayerAdvancementDoneListener implements Listener {
         webhookName = translator.apply(webhookName, true);
         webhookAvatarUrl = translator.apply(webhookAvatarUrl, true);
 
-        if (advancementName.length() < 3) {
-            DiscordSRV.debug("Not sending achievement message, because it's less than three characters long. Message: " + messageFormat);
-            return;
-        }
-
         AchievementMessagePostProcessEvent postEvent = DiscordSRV.api.callEvent(new AchievementMessagePostProcessEvent(channelName, discordMessage, player, advancementName, messageFormat.isUseWebhooks(), webhookName, webhookAvatarUrl, preEvent.isCancelled()));
         if (postEvent.isCancelled()) {
             DiscordSRV.debug("AchievementMessagePostProcessEvent was cancelled, message send aborted");

--- a/src/main/java/github/scarsz/discordsrv/util/LangUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/LangUtil.java
@@ -753,7 +753,6 @@ public class LangUtil {
         DYNMAP_DISCORD_FORMAT("DynmapDiscordFormat", false),
         DYNMAP_NAME_FORMAT("DynmapNameFormat", true),
         MINECRAFT_ACCOUNT_LINKED("MinecraftAccountLinked", true),
-        PLAYER_ACHIEVEMENT("MinecraftPlayerAchievementMessagesFormat", false),
         PLAYER_LIST_COMMAND("DiscordChatChannelListCommandFormatOnlinePlayers", false),
         PLAYER_LIST_COMMAND_NO_PLAYERS("DiscordChatChannelListCommandFormatNoOnlinePlayers", false),
         PLAYER_LIST_COMMAND_PLAYER("DiscordChatChannelListCommandPlayerFormat", true),

--- a/src/main/resources/messages/de.yml
+++ b/src/main/resources/messages/de.yml
@@ -149,7 +149,7 @@ DiscordChatChannelListCommandAllPlayersSeparator: ", "
 # Fields:     Format ist "titel;wert;inline" (z.B. "Wer ist beigetreten?;%displayname%;true") oder "leer", um ein leeres Feld hinzuzufügen
 # Timestamp:  Setzen Sie diesen Wert auf true, um die Zeit zu verwenden, zu der die Nachricht gesendet wurde, oder verwenden Sie einen Epochenzeitstempel für eine bestimmte Zeit (https://www.epochconverter.com/)
 #
-# Verfügbare Platzhalter für PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeath:
+# Verfügbare Platzhalter für PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeath/PlayerAchievement:
 # %displayname%:         Nickname des Nutzers
 # %username%:            Ursprünglicher Name des Nutzers (ohne Nickname)
 # %date%:                aktuelles Datum mit Uhrzeit
@@ -274,20 +274,36 @@ MinecraftPlayerDeathMessage:
       Text: ""
       IconUrl: ""
     Timestamp: false
-
-# Minecraft -> Discord Errungenschaftsnachrichten
 #
 # Verfügbare Platzhalter:
 # %achievement%: Name der Errungenschaft
-# %displayname%: modififzierter Name des Spielers in Minecraft, z.B. durch Essentials /nickname Befehl
-# %username%:    unveränderter Name des Spielers
 # %world%:       Welt in der der Spieler ist (z.B. Nether)
-# %worldalias%:   Alias des Namens der Welt in der sich der Spieler befindet (benötigt Multiverse-Core)
-# %date%:        aktuelles Datum mit Uhrzeit
-# PlaceholderAPI Platzhalter werden auch unterstützt
 #
-MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% hat den Fortschritt %achievement% erreicht!**"
-
+MinecraftPlayerAchievementMessage:
+  Enabled: true
+  Webhook:
+    Enable: false
+    AvatarUrl: "%botavatarurl%"
+    Name: "%botname%"
+  Content: ""
+  Embed:
+    Enabled: true
+    Color: "#ffd700"
+    Author:
+      ImageUrl: "%embedavatarurl%"
+      Name: "%displayname% hat den Fortschritt %achievement% erreicht!"
+      Url: ""
+    ThumbnailUrl: ""
+    Title:
+      Text: ""
+      Url: ""
+    Description: ""
+    Fields: []
+    ImageUrl: ""
+    Footer:
+      Text: ""
+      IconUrl: ""
+    Timestamp: false
 # Discord-Channelbeschreibung
 # Dies sind die Optionen, um die Channelbeschreibung von Chat und Konsole automatisch auf Serverdaten zu aktualisieren.
 # Um eine der Nachrichten zu deaktivieren, einfach "" einsetzen.

--- a/src/main/resources/messages/de.yml
+++ b/src/main/resources/messages/de.yml
@@ -275,7 +275,7 @@ MinecraftPlayerDeathMessage:
       IconUrl: ""
     Timestamp: false
 #
-# Verfügbare Platzhalter:
+# Verfügbare Platzhalter für PlayerAchievement-Nachrichten:
 # %achievement%: Name der Errungenschaft
 # %world%:       Welt in der der Spieler ist (z.B. Nether)
 #
@@ -304,6 +304,7 @@ MinecraftPlayerAchievementMessage:
       Text: ""
       IconUrl: ""
     Timestamp: false
+
 # Discord-Channelbeschreibung
 # Dies sind die Optionen, um die Channelbeschreibung von Chat und Konsole automatisch auf Serverdaten zu aktualisieren.
 # Um eine der Nachrichten zu deaktivieren, einfach "" einsetzen.

--- a/src/main/resources/messages/en.yml
+++ b/src/main/resources/messages/en.yml
@@ -144,7 +144,7 @@ DiscordChatChannelListCommandAllPlayersSeparator: ", "
 # Fields:     format is "title;value;inline" (eg. "Who joined?;%displayname%;true") or "blank" to add a blank field
 # Timestamp:  set to true to use the time the message was sent or use a epoch timestamp for a specific time (https://www.epochconverter.com/)
 #
-# Available placeholders for PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeath:
+# Available placeholders for PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeath/PlayerAchievement:
 # %displayname%:         display name from things like nicknames
 # %username%:            raw player username
 # %date%:                current date & time
@@ -269,20 +269,36 @@ MinecraftPlayerDeathMessage:
       Text: ""
       IconUrl: ""
     Timestamp: false
-
-# Minecraft -> Discord achievement/advancement messages
 #
 # Available placeholders:
 # %achievement%: title of the achievement/advancement
-# %displayname%: display name from things like nicknames
-# %username%:    raw player username
 # %world%:       the name of the world the user is in
-# %worldalias%:  alias of world player is in via Multiverse-Core
-# %date%:        current date & time
-# PlaceholderAPI placeholders are also supported
 #
-MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% has made the advancement %achievement%!**"
-
+MinecraftPlayerAchievementMessage:
+  Enabled: true
+  Webhook:
+    Enable: false
+    AvatarUrl: "%botavatarurl%"
+    Name: "%botname%"
+  Content: ""
+  Embed:
+    Enabled: true
+    Color: "#ffd700"
+    Author:
+      ImageUrl: "%embedavatarurl%"
+      Name: "%username% has made the advancement %achievement%!"
+      Url: ""
+    ThumbnailUrl: ""
+    Title:
+      Text: ""
+      Url: ""
+    Description: ""
+    Fields: []
+    ImageUrl: ""
+    Footer:
+      Text: ""
+      IconUrl: ""
+    Timestamp: false
 # Channel topic updater messages
 # This is all the stuff related to automatically updating the chat or console channel's topics with server information
 #

--- a/src/main/resources/messages/en.yml
+++ b/src/main/resources/messages/en.yml
@@ -270,7 +270,7 @@ MinecraftPlayerDeathMessage:
       IconUrl: ""
     Timestamp: false
 #
-# Available placeholders:
+# Available placeholders for PlayerAchievement messages:
 # %achievement%: title of the achievement/advancement
 # %world%:       the name of the world the user is in
 #
@@ -299,6 +299,7 @@ MinecraftPlayerAchievementMessage:
       Text: ""
       IconUrl: ""
     Timestamp: false
+
 # Channel topic updater messages
 # This is all the stuff related to automatically updating the chat or console channel's topics with server information
 #

--- a/src/main/resources/messages/es.yml
+++ b/src/main/resources/messages/es.yml
@@ -268,10 +268,8 @@ MinecraftPlayerDeathMessage:
       Text: ""
       IconUrl: ""
     Timestamp: false
-
-# Minecraft -> Mensaje de Discord de logros
 #
-# Variables disponibles:
+# Variables disponibles para mensaje de PlayerAchievement:
 # %achievement%: contenido del mensaje
 # %world%:       nombre del mundo en que está el usuario
 #

--- a/src/main/resources/messages/es.yml
+++ b/src/main/resources/messages/es.yml
@@ -143,7 +143,7 @@ DiscordChatChannelListCommandAllPlayersSeparator: ", "
 # Fields:     el formato es "título;valor;inline" (p.ej. "Quien se unio?;%displayname%;true") o "blanco" para agregar un campo en blanco
 # Timestamp:  establecido en verdadero para usar la hora en que se envió el mensaje o usar una marca de tiempo de época para una hora específica (https://www.epochconverter.com/)
 #
-# Marcadores de posición disponibles para PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeath:
+# Marcadores de posición disponibles para PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeath/PlayerAchievement:
 # %displayname%:         muestra el nombre modificado
 # %username%:            nombre original del jugador
 # %date%:                fecha & tiempo actual
@@ -273,13 +273,33 @@ MinecraftPlayerDeathMessage:
 #
 # Variables disponibles:
 # %achievement%: contenido del mensaje
-# %displayname%: muestra el nombre modificado
-# %username%:    nombre original del jugador
 # %world%:       nombre del mundo en que está el usuario
-# %date%:        fecha & tiempo actual
-# Los PlaceholderAPI placeholders tambien son compatibles
 #
-MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% ha conseguido el progreso %achievement%!**"
+MinecraftPlayerAchievementMessage:
+  Enabled: true
+  Webhook:
+    Enable: false
+    AvatarUrl: "%botavatarurl%"
+    Name: "%botname%"
+  Content: ""
+  Embed:
+    Enabled: true
+    Color: "#ffd700"
+    Author:
+      ImageUrl: "%embedavatarurl%"
+      Name: "%displayname% ha conseguido el progreso %achievement%!"
+      Url: ""
+    ThumbnailUrl: ""
+    Title:
+      Text: ""
+      Url: ""
+    Description: ""
+    Fields: []
+    ImageUrl: ""
+    Footer:
+      Text: ""
+      IconUrl: ""
+    Timestamp: false
 
 # Mensajes de actualización del tema del canal
 # Esto es todo lo relacionado con la actualización automática de los temas del chat o del canal de la consola con información del servidor

--- a/src/main/resources/messages/et.yml
+++ b/src/main/resources/messages/et.yml
@@ -144,7 +144,7 @@ DiscordChatChannelListCommandAllPlayersSeparator: ", "
 # Fields:     format is "title;value;inline" (eg. "Who joined?;%displayname%;true") or "blank" to add a blank field
 # Timestamp:  set to true to use the time the message was sent or use a epoch timestamp for a specific time (https://www.epochconverter.com/)
 #
-# Available placeholders for PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeath:
+# Available placeholders for PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeath/PlayerAchievement:
 # %displayname%:         display name from things like nicknames
 # %username%:            raw player username
 # %date%:                current date & time
@@ -269,20 +269,36 @@ MinecraftPlayerDeathMessage:
       Text: ""
       IconUrl: ""
     Timestamp: false
-
-# Minecraft -> Discord achievement/advancement messages
 #
 # Available placeholders:
 # %achievement%: title of the achievement/advancement
-# %displayname%: display name from things like nicknames
-# %username%:    raw player username
 # %world%:       the name of the world the user is in
-# %worldalias%:  alias of world player is in via Multiverse-Core
-# %date%:        current date & time
-# PlaceholderAPI placeholders are also supported
 #
-MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% jõudis edasi ülesandelt %achievement%!**"
-
+MinecraftPlayerAchievementMessage:
+  Enabled: true
+  Webhook:
+    Enable: false
+    AvatarUrl: "%botavatarurl%"
+    Name: "%botname%"
+  Content: ""
+  Embed:
+    Enabled: true
+    Color: "#ffd700"
+    Author:
+      ImageUrl: "%embedavatarurl%"
+      Name: "%displayname% jõudis edasi ülesandelt %achievement%!"
+      Url: ""
+    ThumbnailUrl: ""
+    Title:
+      Text: ""
+      Url: ""
+    Description: ""
+    Fields: []
+    ImageUrl: ""
+    Footer:
+      Text: ""
+      IconUrl: ""
+    Timestamp: false
 # Channel topic updater messages
 # This is all the stuff related to automatically updating the chat or console channel's topics with server information
 #

--- a/src/main/resources/messages/et.yml
+++ b/src/main/resources/messages/et.yml
@@ -270,7 +270,7 @@ MinecraftPlayerDeathMessage:
       IconUrl: ""
     Timestamp: false
 #
-# Available placeholders:
+# Available placeholders for PlayerAchievement messages:
 # %achievement%: title of the achievement/advancement
 # %world%:       the name of the world the user is in
 #
@@ -299,6 +299,7 @@ MinecraftPlayerAchievementMessage:
       Text: ""
       IconUrl: ""
     Timestamp: false
+
 # Channel topic updater messages
 # This is all the stuff related to automatically updating the chat or console channel's topics with server information
 #

--- a/src/main/resources/messages/fr.yml
+++ b/src/main/resources/messages/fr.yml
@@ -267,17 +267,10 @@ MinecraftPlayerDeathMessage:
       Text: ""
       IconUrl: ""
     Timestamp: false
-
-# Minecraft -> Discord Messages de succès
 #
-# Placeholders disponibles :
+# Espaces réservés disponibles pour PlayerAchievement:
 # %achievement%: contenu du message
-# %displayname%: nom du joueur (ou surnom)
-# %username%:    nom du joueur
 # %world%:       nom du monde dans lequel le joueur se trouve
-# %worldalias%:   alias du monde dans lequel se trouve le joueur
-# %date%:        date et heure actuelle
-# PlaceholderAPI les placeholders sont compatibles
 #
 MinecraftPlayerAchievementMessage:
   Enabled: true
@@ -304,6 +297,7 @@ MinecraftPlayerAchievementMessage:
       Text: ""
       IconUrl: ""
     Timestamp: false
+
 # Messages de mise à jour des informations du canal
 # Il s'agit de toutes les choses liées à la mise à jour automatique des sujets du canal de discussion ou de la console avec les informations du serveur
 #

--- a/src/main/resources/messages/fr.yml
+++ b/src/main/resources/messages/fr.yml
@@ -142,7 +142,7 @@ DiscordChatChannelListCommandAllPlayersSeparator: ", "
 # Fields:     le format est "titre;valeur;inline" (par ex. "Qui a rejoint??;%displayname%;true") ou "vide" pour ajouter un champ vide
 # Timestamp:  défini sur true pour utiliser l'heure d'envoi du message ou utiliser un horodatage d'époque pour une heure spécifique (https://www.epochconverter.com/)
 #
-# Espaces réservés disponibles pour PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeath:
+# Espaces réservés disponibles pour PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeath/PlayerAchievement:
 # %displayname%:         nom du joueur (ou surnom)
 # %username%:            nom du joueur
 # %date%:                current date & time
@@ -279,8 +279,31 @@ MinecraftPlayerDeathMessage:
 # %date%:        date et heure actuelle
 # PlaceholderAPI les placeholders sont compatibles
 #
-MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% a réalisé le progrès %achievement%!**"
-
+MinecraftPlayerAchievementMessage:
+  Enabled: true
+  Webhook:
+    Enable: false
+    AvatarUrl: "%botavatarurl%"
+    Name: "%botname%"
+  Content: ""
+  Embed:
+    Enabled: true
+    Color: "#ffd700"
+    Author:
+      ImageUrl: "%embedavatarurl%"
+      Name: "%displayname% a réalisé le progrès %achievement%!"
+      Url: ""
+    ThumbnailUrl: ""
+    Title:
+      Text: ""
+      Url: ""
+    Description: ""
+    Fields: []
+    ImageUrl: ""
+    Footer:
+      Text: ""
+      IconUrl: ""
+    Timestamp: false
 # Messages de mise à jour des informations du canal
 # Il s'agit de toutes les choses liées à la mise à jour automatique des sujets du canal de discussion ou de la console avec les informations du serveur
 #

--- a/src/main/resources/messages/ja.yml
+++ b/src/main/resources/messages/ja.yml
@@ -144,7 +144,7 @@ DiscordChatChannelListCommandAllPlayersSeparator: ", "
 # Fields:     フォーマットは "題名;値;inline" (例 "誰が参加しましたか？;%displayname%;true") または"Blank"で空白のフィールドを追加します
 # Timestamp:  メッセージが送信された時間を使用するか、特定の時間のエポックタイムスタンプを使用するには、trueに設定します (https://www.epochconverter.com/)
 #
-# PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeathで使用可能なプレースホルダー:
+# PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeath/PlayerAchievementで使用可能なプレースホルダー:
 # %displayname%:         プレイヤーの表示名
 # %username%:            プレイヤー名
 # %date%:                現在の日付と時間
@@ -269,20 +269,36 @@ MinecraftPlayerDeathMessage:
       Text: ""
       IconUrl: ""
     Timestamp: false
-
-# Minecraft -> Discord 実績メッセージ
 #
 # 使用できるキーワード:
 # %achievement%: メッセージ内容
-# %displayname%: プレイヤーの表示名
-# %username%:    プレイヤー名
 # %world%:       実績を得たときにいたワールドの名前
-# %worldalias%:   プレイヤーが発言した時に居たワールドの、Multiverse-Coreに設定されているエイリアス名
-# %date%:        現在の日付と時間
-# PlaceholderAPIプレースホルダもサポートされています
 #
-MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% は進捗 %achievement% を達成した！**"
-
+MinecraftPlayerAchievementMessage:
+  Enabled: true
+  Webhook:
+    Enable: false
+    AvatarUrl: "%botavatarurl%"
+    Name: "%botname%"
+  Content: ""
+  Embed:
+    Enabled: true
+    Color: "#ffd700"
+    Author:
+      ImageUrl: "%embedavatarurl%"
+      Name: "%displayname% は進捗 %achievement% を達成した！"
+      Url: ""
+    ThumbnailUrl: ""
+    Title:
+      Text: ""
+      Url: ""
+    Description: ""
+    Fields: []
+    ImageUrl: ""
+    Footer:
+      Text: ""
+      IconUrl: ""
+    Timestamp: false
 # チャンネルトピックメッセージ
 # チャットチャンネルやコンソールチャンネルのトピックをサーバー情報で自動的に更新することに関連する設定です
 #

--- a/src/main/resources/messages/ja.yml
+++ b/src/main/resources/messages/ja.yml
@@ -270,7 +270,7 @@ MinecraftPlayerDeathMessage:
       IconUrl: ""
     Timestamp: false
 #
-# 使用できるキーワード:
+# PlayerAchievementメッセージで使用可能なプレースホルダー：
 # %achievement%: メッセージ内容
 # %world%:       実績を得たときにいたワールドの名前
 #
@@ -299,6 +299,7 @@ MinecraftPlayerAchievementMessage:
       Text: ""
       IconUrl: ""
     Timestamp: false
+
 # チャンネルトピックメッセージ
 # チャットチャンネルやコンソールチャンネルのトピックをサーバー情報で自動的に更新することに関連する設定です
 #

--- a/src/main/resources/messages/ko.yml
+++ b/src/main/resources/messages/ko.yml
@@ -144,7 +144,7 @@ DiscordChatChannelListCommandAllPlayersSeparator: ", "
 # Fields:     형식은 "표제;값;inline" (예 "누가 합류 했습니까?;%displayname%;true") 빈 필드를 추가하려면"blank"또는
 # Timestamp:  메시지가 전송 된 시간을 사용하거나 특정 시간 동안 에포크 시간 소인을 사용하려면 true로 설정하십시오. (https://www.epochconverter.com/)
 #
-# PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeath에 사용 가능한 자리 표시 자:
+# PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeath/PlayerAchievement에 사용 가능한 자리 표시 자:
 # %displayname%:         플레이어의 보여지는 이름 (에센셜 닉네임 등)
 # %username%:            플레이어 실제 닉네임
 # %date%:                현재 날짜 및 시간
@@ -269,20 +269,36 @@ MinecraftPlayerDeathMessage:
       Text: ""
       IconUrl: ""
     Timestamp: false
-
-# Minecraft -> Discord 도전과제 메세지
 #
 # 사용가능한 변수들:
 # %achievement%: 서버상의 도전과제 메세지 내용
-# %displayname%:  플레이어의 보여지는 이름
-# %username%:     플레이어 실제 닉네임
 # %world%:       플레이어의 현재 월드
-# %worldalias%:   Multiverse-Core에서 사용하는 월드 이름의 약어(alias)
-# %date%:        현재 시각 및 날짜
-# PlaceholderAPI 변수(placeholders) 또한 지원됩니다.
 #
-MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname%이(가) %achievement% 발전 과제를 달성했습니다!**"
-
+MinecraftPlayerAchievementMessage:
+  Enabled: true
+  Webhook:
+    Enable: false
+    AvatarUrl: "%botavatarurl%"
+    Name: "%botname%"
+  Content: ""
+  Embed:
+    Enabled: true
+    Color: "#ffd700"
+    Author:
+      ImageUrl: "%embedavatarurl%"
+      Name: "%displayname%이(가) %achievement% 발전 과제를 달성했습니다!"
+      Url: ""
+    ThumbnailUrl: ""
+    Title:
+      Text: ""
+      Url: ""
+    Description: ""
+    Fields: []
+    ImageUrl: ""
+    Footer:
+      Text: ""
+      IconUrl: ""
+    Timestamp: false
 # 채널 토픽 업데이트 메세지
 # 여기에서는 채널 토픽 업데이트에 관련된 내용을 설정 하실 수 있습니다.
 #

--- a/src/main/resources/messages/ko.yml
+++ b/src/main/resources/messages/ko.yml
@@ -270,7 +270,7 @@ MinecraftPlayerDeathMessage:
       IconUrl: ""
     Timestamp: false
 #
-# 사용가능한 변수들:
+# PlayerAchievement 메시지에 사용 가능한 자리 표시 자 :
 # %achievement%: 서버상의 도전과제 메세지 내용
 # %world%:       플레이어의 현재 월드
 #
@@ -299,6 +299,7 @@ MinecraftPlayerAchievementMessage:
       Text: ""
       IconUrl: ""
     Timestamp: false
+
 # 채널 토픽 업데이트 메세지
 # 여기에서는 채널 토픽 업데이트에 관련된 내용을 설정 하실 수 있습니다.
 #

--- a/src/main/resources/messages/nl.yml
+++ b/src/main/resources/messages/nl.yml
@@ -144,7 +144,7 @@ DiscordChatChannelListCommandAllPlayersSeparator: ", "
 # Fields:     format is "title;value;inline" (b.v. "Who joined?;%displayname%;true") of "leeg" om een leeg veld toe te voegen
 # Timestamp:  ingesteld op true om de tijd te gebruiken waarop het bericht is verzonden of gebruik een tijdstempel voor een bepaalde tijd (https://www.epochconverter.com/)
 #
-# Beschikbare tijdelijke aanduidingen voor PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeath:
+# Beschikbare tijdelijke aanduidingen voor PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeath/PlayerAchievement:
 # %displayname%:         De spelers Nickname als die ingesteld is.
 # %username%:            Alleen de spelers username.
 # %date%:                Huidige datum en tijd.
@@ -269,20 +269,36 @@ MinecraftPlayerDeathMessage:
       Text: ""
       IconUrl: ""
     Timestamp: false
-
-# Minecraft -> Discord achievement berichten
 #
 # Beschikbare 'placeholders':
 # %achievement%: avhievment bericht.
-# %displayname%: De spelers Nickname als die ingesteld is.
-# %username%:    Alleen de spelers username.
 # %world%:       De naam van de wereld waar de speler in zit.
-# %worldalias%:   alias van de wereldwaar de speler in zir via Multiverse-Core.
-# %date%:        Huidige datum en tijd.
-# PlaceholderAPI placeholders zijn ook ondersteund
 #
-MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% heeft vooruitgang %achievement% behaald!**"
-
+MinecraftPlayerAchievementMessage:
+  Enabled: true
+  Webhook:
+    Enable: false
+    AvatarUrl: "%botavatarurl%"
+    Name: "%botname%"
+  Content: ""
+  Embed:
+    Enabled: true
+    Color: "#ffd700"
+    Author:
+      ImageUrl: "%embedavatarurl%"
+      Name: "%displayname% heeft vooruitgang %achievement% behaald!"
+      Url: ""
+    ThumbnailUrl: ""
+    Title:
+      Text: ""
+      Url: ""
+    Description: ""
+    Fields: []
+    ImageUrl: ""
+    Footer:
+      Text: ""
+      IconUrl: ""
+    Timestamp: false
 # Channel 'topic' updater berichten
 # Dit is alles dat te maken heeft met het automatisch updaten van de 'topic's van de console en chat kanalen.
 #

--- a/src/main/resources/messages/nl.yml
+++ b/src/main/resources/messages/nl.yml
@@ -270,7 +270,7 @@ MinecraftPlayerDeathMessage:
       IconUrl: ""
     Timestamp: false
 #
-# Beschikbare 'placeholders':
+# Beschikbare tijdelijke aanduidingen voor PlayerAchievement-berichten:
 # %achievement%: avhievment bericht.
 # %world%:       De naam van de wereld waar de speler in zit.
 #
@@ -299,6 +299,7 @@ MinecraftPlayerAchievementMessage:
       Text: ""
       IconUrl: ""
     Timestamp: false
+
 # Channel 'topic' updater berichten
 # Dit is alles dat te maken heeft met het automatisch updaten van de 'topic's van de console en chat kanalen.
 #

--- a/src/main/resources/messages/ru.yml
+++ b/src/main/resources/messages/ru.yml
@@ -270,7 +270,7 @@ MinecraftPlayerDeathMessage:
       IconUrl: ""
     Timestamp: false
 #
-# Доступные шаблоны:
+# Доступные заполнители для сообщений PlayerAchievement:
 # %achievement%: сообщение
 # %world%:       название мира, где сейчас находится игрок
 # Также поддерживаются PlaceholderAPI шаблоны
@@ -300,6 +300,7 @@ MinecraftPlayerAchievementMessage:
       Text: ""
       IconUrl: ""
     Timestamp: false
+
 # Сообщения тем каналов
 # Все эти опции помогут вам задать тему канала чата или консоли со всевозможной серверной информацией
 #

--- a/src/main/resources/messages/ru.yml
+++ b/src/main/resources/messages/ru.yml
@@ -144,7 +144,7 @@ DiscordChatChannelListCommandAllPlayersSeparator: ", "
 # Fields:     формат "заглавие;стоимость;inline" (e.c. "Кто присоединился?;%displayname%;true") или "пусто", чтобы добавить пустое поле
 # Timestamp:  установите значение true, чтобы использовать время, когда было отправлено, или использовать отметку времени эпохи (https://www.epochconverter.com/)
 #
-# Доступные заполнители для PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeath:
+# Доступные заполнители для PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeath/PlayerAchievement:
 # %displayname%:         отображаемое имя игрока, по типу ника
 # %username%:            исходное имя игрока
 # %date%:                текущие время и дата
@@ -269,20 +269,37 @@ MinecraftPlayerDeathMessage:
       Text: ""
       IconUrl: ""
     Timestamp: false
-
-# Minecraft -> Discord сообщения о достижениях игрока
 #
 # Доступные шаблоны:
 # %achievement%: сообщение
-# %displayname%: отображаемое имя игрока, по типу ника
-# %username%:    исходное имя игрока
 # %world%:       название мира, где сейчас находится игрок
-# %worldalias%:  псевдоним к названию мира игрока, используемый в Multiverse-Core
-# %date%:        текущие время и дата
 # Также поддерживаются PlaceholderAPI шаблоны
 #
-MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% получил достижение %achievement%!**"
-
+MinecraftPlayerAchievementMessage:
+  Enabled: true
+  Webhook:
+    Enable: false
+    AvatarUrl: "%botavatarurl%"
+    Name: "%botname%"
+  Content: ""
+  Embed:
+    Enabled: true
+    Color: "#ffd700"
+    Author:
+      ImageUrl: "%embedavatarurl%"
+      Name: "%displayname% получил достижение %achievement%!"
+      Url: ""
+    ThumbnailUrl: ""
+    Title:
+      Text: ""
+      Url: ""
+    Description: ""
+    Fields: []
+    ImageUrl: ""
+    Footer:
+      Text: ""
+      IconUrl: ""
+    Timestamp: false
 # Сообщения тем каналов
 # Все эти опции помогут вам задать тему канала чата или консоли со всевозможной серверной информацией
 #

--- a/src/main/resources/messages/zh.yml
+++ b/src/main/resources/messages/zh.yml
@@ -145,7 +145,7 @@ DiscordChatChannelListCommandAllPlayersSeparator: ", "
 # Fields:     格式为 "标题;值;inline" (eg. "谁加入了？;%displayname%;true") 或"blank"以添加空白字段
 # Timestamp:  设置为true以使用发送消息的时间或在特定时间使用纪元时间戳 (https://www.epochconverter.com/)
 #
-# PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeath的可用占位符:
+# PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeath/PlayerAchievement的可用占位符:
 # %displayname%:         玩家的顯示名稱，如暱稱等
 # %username%:            原始玩家名稱
 # %date%:                當前日期與時間
@@ -270,20 +270,36 @@ MinecraftPlayerDeathMessage:
       Text: ""
       IconUrl: ""
     Timestamp: false
-
-# Minecraft -> Discord 成就與進度訊息
 #
 # 可用的變數:
 # %achievement%: 成就或進度的標題
-# %displayname%: 玩家的顯示名稱，如暱稱等
-# %username%:    原始玩家名稱
 # %world%:       玩家所在的世界名稱
-# %worldalias%:  玩家所在的Multiverse-Core世界名稱
-# %date%:        當前日期與時間
-# 同樣支援PlaceholderAPI所提供的變數
 #
-MinecraftPlayerAchievementMessagesFormat: ":medal: **%displayname% 達成進度 %achievement%!**"
-
+MinecraftPlayerAchievementMessage:
+  Enabled: true
+  Webhook:
+    Enable: false
+    AvatarUrl: "%botavatarurl%"
+    Name: "%botname%"
+  Content: ""
+  Embed:
+    Enabled: true
+    Color: "#ffd700"
+    Author:
+      ImageUrl: "%embedavatarurl%"
+      Name: "%displayname% 達成進度 %achievement%!"
+      Url: ""
+    ThumbnailUrl: ""
+    Title:
+      Text: ""
+      Url: ""
+    Description: ""
+    Fields: []
+    ImageUrl: ""
+    Footer:
+      Text: ""
+      IconUrl: ""
+    Timestamp: false
 # Channel 頻道主題訊息
 # 在頻道主題中顯示的伺服器資訊
 #

--- a/src/main/resources/messages/zh.yml
+++ b/src/main/resources/messages/zh.yml
@@ -271,7 +271,7 @@ MinecraftPlayerDeathMessage:
       IconUrl: ""
     Timestamp: false
 #
-# 可用的變數:
+# PlayerAchievement消息的可用占位符：
 # %achievement%: 成就或進度的標題
 # %world%:       玩家所在的世界名稱
 #
@@ -300,6 +300,7 @@ MinecraftPlayerAchievementMessage:
       Text: ""
       IconUrl: ""
     Timestamp: false
+
 # Channel 頻道主題訊息
 # 在頻道主題中顯示的伺服器資訊
 #


### PR DESCRIPTION
I worked on this feature for my own server, but I figure others would want this too. Updated the messages.yml for all 10 languages as well. Tested on a local server, appears to work fine.

Example of how it shows up (can update the color to your preference, I borrowed it from the first join message)
![image](https://user-images.githubusercontent.com/49998039/83931283-e0043c00-a769-11ea-84fd-554d338ad972.png)