### PR TITLE
Add support for target selectors in the broadcast command

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/commands/CommandBroadcast.java
+++ b/src/main/java/github/scarsz/discordsrv/commands/CommandBroadcast.java
@@ -23,6 +23,7 @@ import github.scarsz.discordsrv.DiscordSRV;
 import github.scarsz.discordsrv.util.DiscordUtil;
 import github.scarsz.discordsrv.util.LangUtil;
 import github.scarsz.discordsrv.util.PlaceholderUtil;
+import github.scarsz.discordsrv.util.PlayerUtil;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.kyori.text.serializer.legacy.LegacyComponentSerializer;
 import org.apache.commons.lang3.ArrayUtils;
@@ -71,6 +72,7 @@ public class CommandBroadcast {
             rawMessage = PlaceholderUtil.replacePlaceholdersToDiscord(rawMessage);
             if (DiscordSRV.config().getBoolean("DiscordChatChannelTranslateMentions"))
                 rawMessage = DiscordUtil.convertMentionsFromNames(rawMessage, DiscordSRV.getPlugin().getMainGuild());
+            rawMessage = PlayerUtil.convertTargetSelectors(rawMessage, sender);
 
             if (DiscordSRV.config().getBoolean("Experiment_MCDiscordReserializer_InBroadcast")) {
                 DiscordUtil.sendMessage(target, DiscordSerializer.INSTANCE.serialize(

--- a/src/main/java/github/scarsz/discordsrv/util/PlayerUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/PlayerUtil.java
@@ -26,6 +26,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
 import org.bukkit.Sound;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
 import java.lang.reflect.Method;
@@ -142,6 +144,74 @@ public class PlayerUtil {
             e.printStackTrace();
             return -1;
         }
+    }
+
+    private static final List<Character> VANILLA_TARGET_SELECTORS = Arrays.asList('p', 'r', 'a', 'e', 's');
+
+    public static String convertTargetSelectors(String message, CommandSender sender) {
+        for (int i = 0; i < message.length(); i++) {
+            if (message.charAt(i) == '@') {
+                int end = getSelectorEnd(message, i);
+                if (end < 0 || end + 1 < message.length() && !canSeparateSelectors(message.charAt(end + 1))) {
+                    continue;
+                }
+                String selector = message.substring(i, end + 1);
+
+                try {
+                    String target = sender == null ? "{TARGET}" : sender.getServer().selectEntities(sender, selector).stream()
+                            .map(Entity::getName)
+                            .collect(Collectors.joining(" "));
+                    message = message.substring(0, i) + target + message.substring(end + 1);
+                    i += target.length() - 1;
+                } catch (Exception ignored) {
+                    // 1.12 and below or invalid selector
+                }
+            }
+        }
+        return message;
+    }
+
+    /**
+     * Seeks the position of the end character of the selector.
+     *
+     * @param message the full raw message
+     * @param start the position of selector start
+     * @return the index of the last character or -1 if invalid
+     */
+    private static int getSelectorEnd(String message, int start) {
+        int end = start + 1;
+        if (end >= message.length() || !VANILLA_TARGET_SELECTORS.contains(message.charAt(end))) {
+            return -1; // Not a valid selector type
+        }
+
+        int argsPos = start + 2;
+        if (argsPos < message.length() && message.charAt(argsPos) == '[') {
+            for (int i = argsPos + 1; i < message.length(); i++) {
+                char current = message.charAt(i);
+                if (current == '[' || Character.isWhitespace(current)) {
+                    return -1; // Selectors args cannot be recursive or contain spaces
+                }
+                if (current == ']') {
+                    return i;
+                }
+            }
+            return -1; // No end to the arguments
+        }
+
+        return end;
+    }
+
+    /**
+     * Determines whether a character can separate two selectors.
+     *
+     * <p>Unlike the vanilla behavior, it is safer to not execute
+     * target selectors like {@code @everyone} to avoid confusion.</p>
+     *
+     * @param character the character
+     * @return if it could separate a selector from the rest
+     */
+    private static boolean canSeparateSelectors(char character) {
+        return Character.isWhitespace(character) || character == '@';
     }
 
 }

--- a/src/test/java/github/scarsz/discordsrv/util/PlayerUtilTest.java
+++ b/src/test/java/github/scarsz/discordsrv/util/PlayerUtilTest.java
@@ -1,0 +1,22 @@
+package github.scarsz.discordsrv.util;
+
+import org.junit.Test;
+
+import static github.scarsz.discordsrv.util.PlayerUtil.convertTargetSelectors;
+import static org.junit.Assert.assertEquals;
+
+public class PlayerUtilTest {
+
+    @Test
+    public void parseValidTargetSelectors() {
+        assertEquals("Is it {TARGET} selector ?", convertTargetSelectors("Is it @a selector ?", null));
+        assertEquals("Nested {TARGET}{TARGET}", convertTargetSelectors("Nested @e@r[limit=2]", null));
+        assertEquals("End {TARGET}", convertTargetSelectors("End @r", null));
+    }
+
+    @Test
+    public void parseInvalidTargetSelectors() {
+        assertEquals("@e[team= @u @", convertTargetSelectors("@e[team= @u @", null));
+        assertEquals("@everyone @ax", convertTargetSelectors("@everyone @ax", null));
+    }
+}


### PR DESCRIPTION
Hello,

This PR implements #585 (target selectors in `/discord bcast`).
This is not based on a regex to be able to more easily isolate the characters around the selector, and thus not capture selectors as `@everyone`. I also added some unit tests to this method.