### PR TITLE
Add linking options for (not) banned players

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/modules/requirelink/RequireLinkModule.java
+++ b/src/main/java/github/scarsz/discordsrv/modules/requirelink/RequireLinkModule.java
@@ -85,7 +85,7 @@ public class RequireLinkModule implements Listener {
                     banned = true;
                 }
                 if (onlyCheckBannedPlayers && !banned) {
-                    DiscordSRV.debug("Player " + playerName + " is bypassing link requirement, player is not banned");
+                    DiscordSRV.debug("Player " + playerName + " is bypassing link requirement beacuse Only check banned players is enabled");
                     return;
                 }
             }
@@ -212,7 +212,7 @@ public class RequireLinkModule implements Listener {
         }
         String ip = player.getAddress().getAddress().getHostAddress();
         if (onlyCheckBannedPlayers() && !Bukkit.getServer().getBannedPlayers().stream().anyMatch(p -> p.getUniqueId().equals(player.getUniqueId())) && !Bukkit.getServer().getIPBans().stream().anyMatch(ip::equals)) {
-            DiscordSRV.debug("Player " + player.getName() + " is bypassing link requirement, player is not banned");
+            DiscordSRV.debug("Player " + player.getName() + " is bypassing link requirement beacuse Only check banned players is enabled");
             return;
         }
 

--- a/src/main/java/github/scarsz/discordsrv/modules/requirelink/RequireLinkModule.java
+++ b/src/main/java/github/scarsz/discordsrv/modules/requirelink/RequireLinkModule.java
@@ -67,13 +67,27 @@ public class RequireLinkModule implements Listener {
                     return;
                 }
             }
-            if (Bukkit.getServer().getBannedPlayers().stream().anyMatch(p -> p.getUniqueId().equals(playerUuid))) {
-                DiscordSRV.debug("Player " + playerName + " is banned, skipping linked check");
-                return;
-            }
-            if (Bukkit.getServer().getIPBans().stream().anyMatch(ip::equals)) {
-                DiscordSRV.debug("Player " + playerName + " connecting with banned IP " + ip + ", skipping linked check");
-                return;
+            boolean onlyCheckBannedPlayers = onlyCheckBannedPlayers();
+            if (!checkBannedPlayers() || onlyCheckBannedPlayers) {
+                boolean banned = false;
+                if (Bukkit.getServer().getBannedPlayers().stream().anyMatch(p -> p.getUniqueId().equals(playerUuid))) {
+                    if (!onlyCheckBannedPlayers) {
+                        DiscordSRV.debug("Player " + playerName + " is banned, skipping linked check");
+                        return;
+                    }
+                    banned = true;
+                }
+                if (!banned && Bukkit.getServer().getIPBans().stream().anyMatch(ip::equals)) {
+                    if (!onlyCheckBannedPlayers) {
+                        DiscordSRV.debug("Player " + playerName + " connecting with banned IP " + ip + ", skipping linked check");
+                        return;
+                    }
+                    banned = true;
+                }
+                if (onlyCheckBannedPlayers && !banned) {
+                    DiscordSRV.debug("Player " + playerName + " is bypassing link requirement, player is not banned");
+                    return;
+                }
             }
 
             if (!DiscordSRV.isReady) {
@@ -196,6 +210,11 @@ public class RequireLinkModule implements Listener {
                 return;
             }
         }
+        String ip = player.getAddress().getAddress().getHostAddress();
+        if (onlyCheckBannedPlayers() && !Bukkit.getServer().getBannedPlayers().stream().anyMatch(p -> p.getUniqueId().equals(player.getUniqueId())) && !Bukkit.getServer().getIPBans().stream().anyMatch(ip::equals)) {
+            DiscordSRV.debug("Player " + player.getName() + " is bypassing link requirement, player is not banned");
+            return;
+        }
 
         DiscordSRV.info("Kicking player " + player.getName() + " for unlinking their accounts");
         Bukkit.getScheduler().runTask(DiscordSRV.getPlugin(), () -> player.kickPlayer(ChatColor.translateAlternateColorCodes('&', getUnlinkedKickMessage())));
@@ -203,6 +222,12 @@ public class RequireLinkModule implements Listener {
 
     private boolean checkWhitelist() {
         return DiscordSRV.config().getBoolean("Require linked account to play.Whitelisted players bypass check");
+    }
+    private boolean checkBannedPlayers() {
+        return DiscordSRV.config().getBoolean("Require linked account to play.Check banned players");
+    }
+    private boolean onlyCheckBannedPlayers() {
+        return DiscordSRV.config().getBoolean("Require linked account to play.Only check banned players");
     }
     private boolean getAllSubRolesRequired() {
         return DiscordSRV.config().getBoolean("Require linked account to play.Subscriber role.Require all of the listed roles");

--- a/src/main/resources/linking/de.yml
+++ b/src/main/resources/linking/de.yml
@@ -15,8 +15,12 @@ Require linked account to play:
 
   # Minecraft-IGNs, um immer zuzulassen, ob verknüpft oder Abonnent oder nicht
   Bypass names: [Scarsz, Notch]
-  # Ob Spieler auf der VANILLA-Whitelist die Notwendigkeit umgehen, ihre Konten zu verknüpfen oder eine Unterrolle zu haben
+  # Ob Spieler auf der VANILLA-Whitelist die Notwendigkeit umgehen, ihre Konten zu verknüpfen oder eine Unterrolle haben
   Whitelisted players bypass check: true
+  # ob Spieler in der VANILLA-Banlist ihre Konten verknüpfen können
+  Check banned players: false
+  # Ob Spieler, die nicht in der VANILLA-Banlist sind, die Notwendigkeit umgehen, ihre Konten zu verknüpfen oder eine Unterrolle haben
+  Only check banned players: false
 
   # Nachricht an die Spieler, die aufgefordert werden, ihre Konten zu verknüpfen
   # Verwenden Sie {BOT} als Platzhalter für den Namen des Bots

--- a/src/main/resources/linking/de.yml
+++ b/src/main/resources/linking/de.yml
@@ -17,7 +17,7 @@ Require linked account to play:
   Bypass names: [Scarsz, Notch]
   # Ob Spieler auf der VANILLA-Whitelist die Notwendigkeit umgehen, ihre Konten zu verknüpfen oder eine Unterrolle haben
   Whitelisted players bypass check: true
-  # ob Spieler in der VANILLA-Banlist ihre Konten verknüpfen können
+  # Ob Spieler in der VANILLA-Banlist ihre Konten verknüpfen können
   Check banned players: false
   # Ob Spieler, die nicht in der VANILLA-Banlist sind, die Notwendigkeit umgehen, ihre Konten zu verknüpfen oder eine Unterrolle haben
   Only check banned players: false

--- a/src/main/resources/linking/en.yml
+++ b/src/main/resources/linking/en.yml
@@ -17,6 +17,10 @@ Require linked account to play:
   Bypass names: [Scarsz, Notch]
   # Whether or not players on the VANILLA whitelist will bypass the need to link their accounts/have a sub role
   Whitelisted players bypass check: true
+  # Whether or not to let players in the VANILLA banlist be able to link their accounts
+  Check banned players: false
+  # Whether or not players not in the VANILLA banlist will bypass the need to link their accounts/have a sub role
+  Only check banned players: false
 
   # Message to kick players with telling them to link their accounts
   # Use {BOT} as a placeholder for the bot's name

--- a/src/main/resources/linking/es.yml
+++ b/src/main/resources/linking/es.yml
@@ -17,9 +17,9 @@ Require linked account to play:
   Bypass names: [Scarsz, Notch]
   # Si los jugadores en la lista blanca de VANILLA eludirán o no la necesidad de vincular sus cuentas / tener un rol secundario
   Whitelisted players bypass check: true
-  # Whether or not to let players in the VANILLA banlist be able to link their accounts
+  # Si permitir o no que los jugadores de la lista de prohibición de VANILLA puedan vincular sus cuentas
   Check banned players: false
-  # Whether or not players not in the VANILLA banlist will bypass the need to link their accounts/have a sub role
+  # Si los jugadores que no están en la lista de prohibición de VANILLA evitarán la necesidad de vincular sus cuentas / tener un rol secundario
   Only check banned players: false
 
   # Mensaje para patear a los jugadores diciéndoles que vinculen sus cuentas

--- a/src/main/resources/linking/es.yml
+++ b/src/main/resources/linking/es.yml
@@ -17,6 +17,10 @@ Require linked account to play:
   Bypass names: [Scarsz, Notch]
   # Si los jugadores en la lista blanca de VANILLA eludirán o no la necesidad de vincular sus cuentas / tener un rol secundario
   Whitelisted players bypass check: true
+  # Whether or not to let players in the VANILLA banlist be able to link their accounts
+  Check banned players: false
+  # Whether or not players not in the VANILLA banlist will bypass the need to link their accounts/have a sub role
+  Only check banned players: false
 
   # Mensaje para patear a los jugadores diciéndoles que vinculen sus cuentas
   # Utilice {BOT} como marcador de posición para el nombre del bot

--- a/src/main/resources/linking/et.yml
+++ b/src/main/resources/linking/et.yml
@@ -17,6 +17,10 @@ Require linked account to play:
   Bypass names: [Scarsz, Notch]
   # Whether or not players on the VANILLA whitelist will bypass the need to link their accounts/have a sub role
   Whitelisted players bypass check: true
+  # Whether or not to let players in the VANILLA banlist be able to link their accounts
+  Check banned players: false
+  # Whether or not players not in the VANILLA banlist will bypass the need to link their accounts/have a sub role
+  Only check banned players: false
 
   # Message to kick players with telling them to link their accounts
   # Use {BOT} as a placeholder for the bot's name

--- a/src/main/resources/linking/fr.yml
+++ b/src/main/resources/linking/fr.yml
@@ -17,9 +17,9 @@ Require linked account to play:
   Bypass names: [Scarsz, Notch]
   # Si les joueurs sur la liste blanche VANILLA contournent la nécessité de lier leurs comptes / ont un sous-rôle
   Whitelisted players bypass check: true
-  # Whether or not to let players in the VANILLA banlist be able to link their accounts
+  # Permettre ou non aux joueurs de la liste d'interdiction VANILLA de lier leurs comptes
   Check banned players: false
-  # Whether or not players not in the VANILLA banlist will bypass the need to link their accounts/have a sub role
+  # Le fait que les joueurs qui ne figurent pas dans la liste d'interdiction de VANILLA contournent ou non la nécessité de lier leurs comptes / d'avoir un sous-rôle
   Only check banned players: false
 
   # Message pour donner un coup de pied aux joueurs en leur disant de lier leurs comptes

--- a/src/main/resources/linking/fr.yml
+++ b/src/main/resources/linking/fr.yml
@@ -17,6 +17,10 @@ Require linked account to play:
   Bypass names: [Scarsz, Notch]
   # Si les joueurs sur la liste blanche VANILLA contournent la nécessité de lier leurs comptes / ont un sous-rôle
   Whitelisted players bypass check: true
+  # Whether or not to let players in the VANILLA banlist be able to link their accounts
+  Check banned players: false
+  # Whether or not players not in the VANILLA banlist will bypass the need to link their accounts/have a sub role
+  Only check banned players: false
 
   # Message pour donner un coup de pied aux joueurs en leur disant de lier leurs comptes
   # Utilisez {BOT} comme espace réservé pour le nom du bot

--- a/src/main/resources/linking/ja.yml
+++ b/src/main/resources/linking/ja.yml
@@ -17,6 +17,10 @@ Require linked account to play:
   Bypass names: [Scarsz, Notch]
   # VANILLAホワイトリストのプレイヤーがアカウントをリンクする必要がないか、サブロールを持つかどうか
   Whitelisted players bypass check: true
+  # Whether or not to let players in the VANILLA banlist be able to link their accounts
+  Check banned players: false
+  # Whether or not players not in the VANILLA banlist will bypass the need to link their accounts/have a sub role
+  Only check banned players: false
 
   # アカウントをリンクするようプレイヤーにキックするメッセージ
   # ボットの名前のプレースホルダーとして{BOT}を使用します

--- a/src/main/resources/linking/ja.yml
+++ b/src/main/resources/linking/ja.yml
@@ -17,9 +17,9 @@ Require linked account to play:
   Bypass names: [Scarsz, Notch]
   # VANILLAホワイトリストのプレイヤーがアカウントをリンクする必要がないか、サブロールを持つかどうか
   Whitelisted players bypass check: true
-  # Whether or not to let players in the VANILLA banlist be able to link their accounts
+  # VANILLAバンリストのプレイヤーが自分のアカウントをリンクできるようにするかどうか
   Check banned players: false
-  # Whether or not players not in the VANILLA banlist will bypass the need to link their accounts/have a sub role
+  # VANILLAバンリストに含まれていないプレイヤーが、アカウントをリンクする必要性を回避するか、サブロールを持つかどうか
   Only check banned players: false
 
   # アカウントをリンクするようプレイヤーにキックするメッセージ

--- a/src/main/resources/linking/ko.yml
+++ b/src/main/resources/linking/ko.yml
@@ -17,9 +17,9 @@ Require linked account to play:
   Bypass names: [Scarsz, Notch]
   # VANILLA 허용 목록에있는 플레이어가 자신의 계정을 연결하거나 하위 역할을 수행 할 필요성을 우회할지 여부
   Whitelisted players bypass check: true
-  # Whether or not to let players in the VANILLA banlist be able to link their accounts
+  # VANILLA 밴리스트의 플레이어가 자신의 계정을 연결할 수 있도록 허용할지 여부
   Check banned players: false
-  # Whether or not players not in the VANILLA banlist will bypass the need to link their accounts/have a sub role
+  # VANILLA 밴리스트에 속하지 않은 플레이어가 계정을 연결하거나 하위 역할을 할 필요가 없는지 여부
   Only check banned players: false
 
   # 플레이어에게 계정을 연결하도록 지시하는 메시지

--- a/src/main/resources/linking/ko.yml
+++ b/src/main/resources/linking/ko.yml
@@ -17,6 +17,10 @@ Require linked account to play:
   Bypass names: [Scarsz, Notch]
   # VANILLA 허용 목록에있는 플레이어가 자신의 계정을 연결하거나 하위 역할을 수행 할 필요성을 우회할지 여부
   Whitelisted players bypass check: true
+  # Whether or not to let players in the VANILLA banlist be able to link their accounts
+  Check banned players: false
+  # Whether or not players not in the VANILLA banlist will bypass the need to link their accounts/have a sub role
+  Only check banned players: false
 
   # 플레이어에게 계정을 연결하도록 지시하는 메시지
   # 봇 이름의 자리 표시 자로 {BOT}를 사용하십시오.

--- a/src/main/resources/linking/nl.yml
+++ b/src/main/resources/linking/nl.yml
@@ -17,9 +17,9 @@ Require linked account to play:
   Bypass names: [Scarsz, Notch]
   # Of spelers op de VANILLA-whitelist de noodzaak om hun accounts te koppelen zullen omzeilen / een subrol hebben
   Whitelisted players bypass check: true
-  # Whether or not to let players in the VANILLA banlist be able to link their accounts
+  # Of spelers in de VANILLA banlist al dan niet hun accounts moeten kunnen koppelen
   Check banned players: false
-  # Whether or not players not in the VANILLA banlist will bypass the need to link their accounts/have a sub role
+  # Of spelers die niet op de VANILLA banlist staan of niet, de noodzaak om hun accounts te linken / een subrol zullen hebben omzeilen
   Only check banned players: false
 
   # Bericht om spelers te schoppen door hen te vertellen hun accounts te linken

--- a/src/main/resources/linking/nl.yml
+++ b/src/main/resources/linking/nl.yml
@@ -17,6 +17,10 @@ Require linked account to play:
   Bypass names: [Scarsz, Notch]
   # Of spelers op de VANILLA-whitelist de noodzaak om hun accounts te koppelen zullen omzeilen / een subrol hebben
   Whitelisted players bypass check: true
+  # Whether or not to let players in the VANILLA banlist be able to link their accounts
+  Check banned players: false
+  # Whether or not players not in the VANILLA banlist will bypass the need to link their accounts/have a sub role
+  Only check banned players: false
 
   # Bericht om spelers te schoppen door hen te vertellen hun accounts te linken
   # Gebruik {BOT} als tijdelijke aanduiding voor de naam van de bot

--- a/src/main/resources/linking/ru.yml
+++ b/src/main/resources/linking/ru.yml
@@ -17,6 +17,10 @@ Require linked account to play:
   Bypass names: [Scarsz, Notch]
   # Имеют ли люди из ванильного вайтлиста право входить на сервер без подписки/привязки?
   Whitelisted players bypass check: true
+  # Whether or not to let players in the VANILLA banlist be able to link their accounts
+  Check banned players: false
+  # Whether or not players not in the VANILLA banlist will bypass the need to link their accounts/have a sub role
+  Only check banned players: false
 
   # Сообщение при кике игроков с просьбой связать их учетные записи
   # Используйте {BOT} в качестве заполнителя для имени бота

--- a/src/main/resources/linking/ru.yml
+++ b/src/main/resources/linking/ru.yml
@@ -17,9 +17,9 @@ Require linked account to play:
   Bypass names: [Scarsz, Notch]
   # Имеют ли люди из ванильного вайтлиста право входить на сервер без подписки/привязки?
   Whitelisted players bypass check: true
-  # Whether or not to let players in the VANILLA banlist be able to link their accounts
+  # Разрешить или запретить игрокам из бан-листа VANILLA связывать свои аккаунты
   Check banned players: false
-  # Whether or not players not in the VANILLA banlist will bypass the need to link their accounts/have a sub role
+  # Независимо от того, будут ли игроки, не включенные в банлист VANILLA, обходить необходимость связывать свои учетные записи / иметь дополнительную роль
   Only check banned players: false
 
   # Сообщение при кике игроков с просьбой связать их учетные записи

--- a/src/main/resources/linking/zh.yml
+++ b/src/main/resources/linking/zh.yml
@@ -17,6 +17,10 @@ Require linked account to play:
   Bypass names: [Scarsz, Notch]
   # 如果VANILLA白名单上的玩家不需要关联其帐户或具有子角色
   Whitelisted players bypass check: true
+  # Whether or not to let players in the VANILLA banlist be able to link their accounts
+  Check banned players: false
+  # Whether or not players not in the VANILLA banlist will bypass the need to link their accounts/have a sub role
+  Only check banned players: false
 
   # 提示玩家链接其帐户的消息
   # 使用{BOT}作为机器人名称的占位符

--- a/src/main/resources/linking/zh.yml
+++ b/src/main/resources/linking/zh.yml
@@ -17,9 +17,9 @@ Require linked account to play:
   Bypass names: [Scarsz, Notch]
   # 如果VANILLA白名单上的玩家不需要关联其帐户或具有子角色
   Whitelisted players bypass check: true
-  # Whether or not to let players in the VANILLA banlist be able to link their accounts
+  # 是否让VANILLA禁止名单中的玩家能够关联其帐户
   Check banned players: false
-  # Whether or not players not in the VANILLA banlist will bypass the need to link their accounts/have a sub role
+  # 不在VANILLA黑名单中的玩家是否会绕过链接其帐户/具有子角色的需要
   Only check banned players: false
 
   # 提示玩家链接其帐户的消息


### PR DESCRIPTION
This PR adds two boolean config options to the linking.yml config file.
```yml
  # Whether or not to let players in the VANILLA banlist be able to link their accounts
  Check banned players: false
```
This can be used to even allow banned players to link their accounts.
```yml
  # Whether or not players not in the VANILLA banlist will bypass the need to link their accounts/have a sub role
  Only check banned players: false
```
This is basically the opposite of the existing option `Whitelisted players bypass check`. So instead of a whitelist you now have a blacklist (the banned players).

Example usecase: Banned users are added to a `Banned` group, which is synchronized to a `Banned` role on Discord. Only users with the `Banned` role can see the channel `#ban-appeal` but no other channels. A normal (not banned player) doesn't need to link the account. Then one can use the following setup.
```yml
Require linked account to play:
  Enabled: true
  Whitelisted players bypass check: false
  Check banned players: false
  Only check banned players: true
  Not linked message: "&cYou are banned from this server!\n\n&7To appeal your ban, you must link your &9Discord &7account.\n\n&7Send a DM to &b{BOT}&7 in the Discord server containing just &b{CODE}&7 to link your account.\n\n&7Then you can contact us in the &9#ban-appeal &7channel.\n\n&7Discord Invite ยป &b{INVITE}"
```