### PR TITLE
One-way group/role synchronization

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/objects/managers/GroupSynchronizationManager.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/managers/GroupSynchronizationManager.java
@@ -182,6 +182,7 @@ public class GroupSynchronizationManager extends ListenerAdapter implements List
         boolean oneWaySynchronisation = DiscordSRV.config().getBoolean("GroupRoleSynchronizationOneWay");
         boolean minecraftIsStrictlyAuthoritative = oneWaySynchronisation && DiscordSRV.config().getBoolean("GroupRoleSynchronizationMinecraftIsAuthoritative");
         boolean discordIsStrictlyAuthoritative = oneWaySynchronisation && !DiscordSRV.config().getBoolean("GroupRoleSynchronizationMinecraftIsAuthoritative");
+        synchronizationSummary.add("Synchronisation is one way (" + (minecraftIsStrictlyAuthoritative ? "MineCraft -> Discord" : "Discord -> MineCraft") + ")");
 
         for (Map.Entry<String, String> entry : DiscordSRV.getPlugin().getGroupSynchronizables().entrySet()) {
             String groupName = entry.getKey();
@@ -267,7 +268,6 @@ public class GroupSynchronizationManager extends ListenerAdapter implements List
                 || (!roleIsManaged
                     && !discordIsStrictlyAuthoritative
                     && (direction == SyncDirection.AUTHORITATIVE ? DiscordSRV.config().getBoolean("GroupRoleSynchronizationMinecraftIsAuthoritative") : direction == SyncDirection.TO_DISCORD));
-            DiscordSRV.debug((minecraftIsAuthoritative ? "MineCraft" : "Discord") + "is authoritative for synchronising {" + groupName + ":" + role + "} for {" + player.getName() + ":" + user + "}");
 
             if (hasGroup == hasRole) {
                 // both sides agree, no changes necessary

--- a/src/main/java/github/scarsz/discordsrv/objects/managers/GroupSynchronizationManager.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/managers/GroupSynchronizationManager.java
@@ -179,12 +179,9 @@ public class GroupSynchronizationManager extends ListenerAdapter implements List
         Map<Guild, Map<String, Set<Role>>> roleChanges = new HashMap<>();
 
         // Check if Minecraft or Discord is strictly authoritative.
-        boolean minecraftIsStrictlyAuthoritative = DiscordSRV.config().getBoolean("GroupRoleSynchronizationMinecraftIsStrictlyAuthoritative");
-        boolean discordIsStrictlyAuthoritative = DiscordSRV.config().getBoolean("GroupRoleSynchronizationDiscordIsStrictlyAuthoritative");
-        if (minecraftIsStrictlyAuthoritative && discordIsStrictlyAuthoritative) {
-            DiscordSRV.debug("Both Minecraft and Discord are set to be strictly authoritative, Minecraft will take precedence");
-            discordIsStrictlyAuthoritative = false;
-        }
+        boolean oneWaySynchronisation = DiscordSRV.config().getBoolean("GroupRoleSynchronizationOneWay");
+        boolean minecraftIsStrictlyAuthoritative = oneWaySynchronisation && DiscordSRV.config().getBoolean("GroupRoleSynchronizationMinecraftIsAuthoritative");
+        boolean discordIsStrictlyAuthoritative = oneWaySynchronisation && !DiscordSRV.config().getBoolean("GroupRoleSynchronizationMinecraftIsAuthoritative");
 
         for (Map.Entry<String, String> entry : DiscordSRV.getPlugin().getGroupSynchronizables().entrySet()) {
             String groupName = entry.getKey();

--- a/src/main/java/github/scarsz/discordsrv/objects/managers/GroupSynchronizationManager.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/managers/GroupSynchronizationManager.java
@@ -178,6 +178,14 @@ public class GroupSynchronizationManager extends ListenerAdapter implements List
 
         Map<Guild, Map<String, Set<Role>>> roleChanges = new HashMap<>();
 
+        // Check if Minecraft or Discord is strictly authoritative.
+        boolean minecraftIsStrictlyAuthoritative = DiscordSRV.config().getBoolean("GroupRoleSynchronizationMinecraftIsStrictlyAuthoritative");
+        boolean discordIsStrictlyAuthoritative = DiscordSRV.config().getBoolean("GroupRoleSynchronizationDiscordIsStrictlyAuthoritative");
+        if (minecraftIsStrictlyAuthoritative && discordIsStrictlyAuthoritative) {
+            DiscordSRV.debug("Both Minecraft and Discord are set to be strictly authoritative, Minecraft will take precedence");
+            discordIsStrictlyAuthoritative = false;
+        }
+
         for (Map.Entry<String, String> entry : DiscordSRV.getPlugin().getGroupSynchronizables().entrySet()) {
             String groupName = entry.getKey();
             String roleId = entry.getValue();
@@ -253,10 +261,15 @@ public class GroupSynchronizationManager extends ListenerAdapter implements List
             boolean hasRole = member != null && member.getRoles().contains(role);
             boolean roleIsManaged = role.isManaged();
             // Managed roles cannot be given or taken, so it will be Discord -> Minecraft only
-            boolean minecraftIsAuthoritative = !roleIsManaged && (DiscordSRV.config().getBoolean("GroupRoleSynchronizationMinecraftIsAuthoritative") || direction == SyncDirection.TO_DISCORD);
-//            boolean minecraftIsAuthoritative = !roleIsManaged && (direction == SyncDirection.AUTHORITATIVE
-//                    ? DiscordSRV.config().getBoolean("GroupRoleSynchronizationMinecraftIsAuthoritative")
-//                    : direction == SyncDirection.TO_DISCORD);
+            if (roleIsManaged && minecraftIsStrictlyAuthoritative) {
+                synchronizationSummary.add("Tried to sync {" + role + ":" + groupName + "} to Discord but the role is managed and Minecraft is strictly authoritative");
+                continue;
+            }
+            // Determine if Minecraft is authoritative in the synchronization.
+            boolean minecraftIsAuthoritative = minecraftIsStrictlyAuthoritative
+                || (!roleIsManaged
+                    && !discordIsStrictlyAuthoritative
+                    && (direction == SyncDirection.AUTHORITATIVE ? DiscordSRV.config().getBoolean("GroupRoleSynchronizationMinecraftIsAuthoritative") : direction == SyncDirection.TO_DISCORD));
             DiscordSRV.debug((minecraftIsAuthoritative ? "MineCraft" : "Discord") + "is authoritative for synchronising {" + groupName + ":" + role + "} for {" + player.getName() + ":" + user + "}");
 
             if (hasGroup == hasRole) {

--- a/src/main/java/github/scarsz/discordsrv/objects/managers/GroupSynchronizationManager.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/managers/GroupSynchronizationManager.java
@@ -182,7 +182,7 @@ public class GroupSynchronizationManager extends ListenerAdapter implements List
         boolean oneWaySynchronisation = DiscordSRV.config().getBoolean("GroupRoleSynchronizationOneWay");
         boolean minecraftIsStrictlyAuthoritative = oneWaySynchronisation && DiscordSRV.config().getBoolean("GroupRoleSynchronizationMinecraftIsAuthoritative");
         boolean discordIsStrictlyAuthoritative = oneWaySynchronisation && !DiscordSRV.config().getBoolean("GroupRoleSynchronizationMinecraftIsAuthoritative");
-        synchronizationSummary.add("Synchronisation is one way (" + (minecraftIsStrictlyAuthoritative ? "MineCraft -> Discord" : "Discord -> MineCraft") + ")");
+        if (oneWaySynchronisation) synchronizationSummary.add("Synchronisation is one way (" + (minecraftIsStrictlyAuthoritative ? "Minecraft -> Discord" : "Discord -> Minecraft") + ")");
 
         for (Map.Entry<String, String> entry : DiscordSRV.getPlugin().getGroupSynchronizables().entrySet()) {
             String groupName = entry.getKey();

--- a/src/main/java/github/scarsz/discordsrv/objects/managers/GroupSynchronizationManager.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/managers/GroupSynchronizationManager.java
@@ -253,9 +253,11 @@ public class GroupSynchronizationManager extends ListenerAdapter implements List
             boolean hasRole = member != null && member.getRoles().contains(role);
             boolean roleIsManaged = role.isManaged();
             // Managed roles cannot be given or taken, so it will be Discord -> Minecraft only
-            boolean minecraftIsAuthoritative = !roleIsManaged && (direction == SyncDirection.AUTHORITATIVE
-                    ? DiscordSRV.config().getBoolean("GroupRoleSynchronizationMinecraftIsAuthoritative")
-                    : direction == SyncDirection.TO_DISCORD);
+            boolean minecraftIsAuthoritative = !roleIsManaged && (DiscordSRV.config().getBoolean("GroupRoleSynchronizationMinecraftIsAuthoritative") || direction == SyncDirection.TO_DISCORD);
+//            boolean minecraftIsAuthoritative = !roleIsManaged && (direction == SyncDirection.AUTHORITATIVE
+//                    ? DiscordSRV.config().getBoolean("GroupRoleSynchronizationMinecraftIsAuthoritative")
+//                    : direction == SyncDirection.TO_DISCORD);
+            DiscordSRV.debug((minecraftIsAuthoritative ? "MineCraft" : "Discord") + "is authoritative for synchronising {" + groupName + ":" + role + "} for {" + player.getName() + ":" + user + "}");
 
             if (hasGroup == hasRole) {
                 // both sides agree, no changes necessary

--- a/src/main/resources/synchronization/de.yml
+++ b/src/main/resources/synchronization/de.yml
@@ -20,6 +20,8 @@ NicknameSynchronizationFormat: "%displayname%"
 #                                               {"MC_GROUP_NAME": "DISCORD_ROLE_ID"} ist das Format, das beim Hinzufügen weiterer Gruppen- / Rollenpaare verwendet werden muss
 #                                               Um die Rollen-IDs der Discord-Gilde zu erhalten, nutze "/discord debug" und schau dir den ersten Abschnitt an
 # GroupRoleSynchronizationMinecraftIsAuthoritative: ob Änderungen an der Minecraft-Gruppe Änderungen an der Discord-Rolle überschreiben oder nicht
+# GroupRoleSynchronizationOneWay: whether or not to synchronise only one way, the way it is synchronised depends on the value
+#                                 of GroupRoleSynchronizationMinecraftIsAuthoritative.
 # GroupRoleSynchronizationEnableDenyPermission: Gibt an, ob die Berechtigungen discordsrv.sync.deny.<gruppe> aktiviert sind
 # GroupRoleSynchronizationPrimaryGroupOnly: Wenn true, wird nur die primäre Gruppe des Spielers für die Synchronisierung gezählt,
 #                                           Andernfalls zählt die Gruppensynchronisierung alle Gruppen, in denen sich der

--- a/src/main/resources/synchronization/de.yml
+++ b/src/main/resources/synchronization/de.yml
@@ -29,6 +29,7 @@ NicknameSynchronizationFormat: "%displayname%"
 #
 GroupRoleSynchronizationGroupsAndRolesToSync: {"trusted": "000000000000000000", "vip": "000000000000000000"}
 GroupRoleSynchronizationMinecraftIsAuthoritative: true
+GroupRoleSynchronizationOneWay: false
 GroupRoleSynchronizationEnableDenyPermission: false
 GroupRoleSynchronizationPrimaryGroupOnly: false
 GroupRoleSynchronizationOnLink: true

--- a/src/main/resources/synchronization/en.yml
+++ b/src/main/resources/synchronization/en.yml
@@ -20,6 +20,8 @@ NicknameSynchronizationFormat: "%displayname%"
 #                                               {"MC_GROUP_NAME": "DISCORD_ROLE_ID"} is the format to go by when adding more group/role pairs
 #                                               to get your Discord guild's role IDs, run "/discord debug" and look at the first section
 # GroupRoleSynchronizationMinecraftIsAuthoritative: whether or not Minecraft group changes override Discord role changes
+# GroupRoleSynchronizationOneWay: whether or not to synchronise only one way, the way it is synchronised depends on the value
+#                                 of GroupRoleSynchronizationMinecraftIsAuthoritative.
 # GroupRoleSynchronizationEnableDenyPermission: whether or not discordsrv.sync.deny.<group> permissions are enabled
 # GroupRoleSynchronizationPrimaryGroupOnly: if true, only the player's primary group is counted for synchronization,
 #                                           otherwise, group sync counts all groups the player is in, including parent groups
@@ -28,6 +30,7 @@ NicknameSynchronizationFormat: "%displayname%"
 #
 GroupRoleSynchronizationGroupsAndRolesToSync: {"trusted": "000000000000000000", "vip": "000000000000000000"}
 GroupRoleSynchronizationMinecraftIsAuthoritative: true
+GroupRoleSynchronizationOneWay: false
 GroupRoleSynchronizationEnableDenyPermission: false
 GroupRoleSynchronizationPrimaryGroupOnly: false
 GroupRoleSynchronizationOnLink: true

--- a/src/main/resources/synchronization/es.yml
+++ b/src/main/resources/synchronization/es.yml
@@ -29,6 +29,7 @@ NicknameSynchronizationFormat: "%displayname%"
 #
 GroupRoleSynchronizationGroupsAndRolesToSync: {"trusted": "000000000000000000", "vip": "000000000000000000"}
 GroupRoleSynchronizationMinecraftIsAuthoritative: true
+GroupRoleSynchronizationOneWay: false
 GroupRoleSynchronizationEnableDenyPermission: false
 GroupRoleSynchronizationPrimaryGroupOnly: false
 GroupRoleSynchronizationOnLink: true

--- a/src/main/resources/synchronization/es.yml
+++ b/src/main/resources/synchronization/es.yml
@@ -20,6 +20,8 @@ NicknameSynchronizationFormat: "%displayname%"
 #                                               {"MC_GROUP_NAME": "DISCORD_ROLE_ID"} es el formato que debe seguir al agregar más pares de grupo / rol
 #                                               para obtener los ID de rol de tu Discord, ejecuta "/discord debug" y mira la primera sección
 # GroupRoleSynchronizationMinecraftIsAuthoritative: si los cambios de grupo de Minecraft anulan o no los cambios de rol de Discord
+# GroupRoleSynchronizationOneWay: whether or not to synchronise only one way, the way it is synchronised depends on the value
+#                                 of GroupRoleSynchronizationMinecraftIsAuthoritative.
 # GroupRoleSynchronizationEnableDenyPermission: si los permisos discordsrv.sync.deny.<grupo> están habilitados
 # GroupRoleSynchronizationPrimaryGroupOnly: si es verdadero, solo el grupo primario del jugador se cuenta para la sincronización,
 #                                           de lo contrario, la sincronización de grupos cuenta todos los grupos en los

--- a/src/main/resources/synchronization/et.yml
+++ b/src/main/resources/synchronization/et.yml
@@ -28,6 +28,7 @@ NicknameSynchronizationFormat: "%displayname%"
 #
 GroupRoleSynchronizationGroupsAndRolesToSync: {"trusted": "000000000000000000", "vip": "000000000000000000"}
 GroupRoleSynchronizationMinecraftIsAuthoritative: true
+GroupRoleSynchronizationOneWay: false
 GroupRoleSynchronizationEnableDenyPermission: false
 GroupRoleSynchronizationPrimaryGroupOnly: false
 GroupRoleSynchronizationOnLink: true

--- a/src/main/resources/synchronization/et.yml
+++ b/src/main/resources/synchronization/et.yml
@@ -20,6 +20,8 @@ NicknameSynchronizationFormat: "%displayname%"
 #                                               {"MC_GROUP_NAME": "DISCORD_ROLE_ID"} is the format to go by when adding more group/role pairs
 #                                               to get your Discord guild's role IDs, run "/discord debug" and look at the first section
 # GroupRoleSynchronizationMinecraftIsAuthoritative: whether or not minecraft group changes override discord role changes
+# GroupRoleSynchronizationOneWay: whether or not to synchronise only one way, the way it is synchronised depends on the value
+#                                 of GroupRoleSynchronizationMinecraftIsAuthoritative.
 # GroupRoleSynchronizationEnableDenyPermission: kas discordsrv.sync.deny.<group> õigused on lubatud või mitte
 # GroupRoleSynchronizationPrimaryGroupOnly: if true, only the parent group of the player will be considered for synchronization,
 #                                           vastasel korral loendab grupi sünkroonimine kõik rühmad, milles mängija asub, sealhulgas vanemrühmad

--- a/src/main/resources/synchronization/fr.yml
+++ b/src/main/resources/synchronization/fr.yml
@@ -20,6 +20,8 @@ NicknameSynchronizationFormat: "%displayname%"
 #                                               {"MC_GROUP_NAME": "DISCORD_ROLE_ID"} est le format à utiliser lors de l'ajout de paires de groupes / rôles supplémentaires
 #                                               pour obtenir les ID de rôle de votre Discord, exécutez "/discord debug" et regardez la première section
 # GroupRoleSynchronizationMinecraftIsAuthoritative: si les changements de groupe Minecraft remplacent ou non les changements de rôle de Discord
+# GroupRoleSynchronizationOneWay: whether or not to synchronise only one way, the way it is synchronised depends on the value
+#                                 of GroupRoleSynchronizationMinecraftIsAuthoritative.
 # GroupRoleSynchronizationEnableDenyPermission: si les autorisations discordsrv.sync.deny.<groupe> sont activées ou non
 # GroupRoleSynchronizationPrimaryGroupOnly: si vrai, seul le groupe principal du joueur est compté pour la synchronisation,
 #                                           sinon, la synchronisation de groupe compte tous les groupes dans lesquels se trouve le lecteur, y compris les groupes parents

--- a/src/main/resources/synchronization/fr.yml
+++ b/src/main/resources/synchronization/fr.yml
@@ -28,6 +28,7 @@ NicknameSynchronizationFormat: "%displayname%"
 #
 GroupRoleSynchronizationGroupsAndRolesToSync: {"trusted": "000000000000000000", "vip": "000000000000000000"}
 GroupRoleSynchronizationMinecraftIsAuthoritative: true
+GroupRoleSynchronizationOneWay: false
 GroupRoleSynchronizationEnableDenyPermission: false
 GroupRoleSynchronizationPrimaryGroupOnly: false
 GroupRoleSynchronizationOnLink: true

--- a/src/main/resources/synchronization/ja.yml
+++ b/src/main/resources/synchronization/ja.yml
@@ -27,6 +27,7 @@ NicknameSynchronizationFormat: "%displayname%"
 #
 GroupRoleSynchronizationGroupsAndRolesToSync: {"trusted": "000000000000000000", "vip": "000000000000000000"}
 GroupRoleSynchronizationMinecraftIsAuthoritative: true
+GroupRoleSynchronizationOneWay: false
 GroupRoleSynchronizationEnableDenyPermission: false
 GroupRoleSynchronizationPrimaryGroupOnly: false
 GroupRoleSynchronizationOnLink: true

--- a/src/main/resources/synchronization/ja.yml
+++ b/src/main/resources/synchronization/ja.yml
@@ -20,6 +20,8 @@ NicknameSynchronizationFormat: "%displayname%"
 #                                               {"MC_GROUP_NAME": "DISCORD_ROLE_ID"} さらにグループ/ロールのペアを追加するときに使用する形式です
 #                                               ギルドの役割とそのIDのリストを取得するには、 "/discord debug"を実行して最初のブロックを表示してください
 # GroupRoleSynchronizationMinecraftIsAuthoritative: Minecraftグループの変更がDiscordロールの変更をオーバーライドするかどうか
+# GroupRoleSynchronizationOneWay: whether or not to synchronise only one way, the way it is synchronised depends on the value
+#                                 of GroupRoleSynchronizationMinecraftIsAuthoritative.
 # GroupRoleSynchronizationEnableDenyPermission：discordsrv.sync.deny.<グループ> 権限が有効かどうか
 # GroupRoleSynchronizationPrimaryGroupOnly: trueの場合、プレーヤーのプライマリグループのみが同期のためにカウントされます、
 #                                           それ以外の場合、グループ同期は、親グループを含む、プレーヤーが属するすべてのグループをカウントします

--- a/src/main/resources/synchronization/ko.yml
+++ b/src/main/resources/synchronization/ko.yml
@@ -28,6 +28,7 @@ NicknameSynchronizationFormat: "%displayname%"
 #
 GroupRoleSynchronizationGroupsAndRolesToSync: {"trusted": "000000000000000000", "vip": "000000000000000000"}
 GroupRoleSynchronizationMinecraftIsAuthoritative: true
+GroupRoleSynchronizationOneWay: false
 GroupRoleSynchronizationEnableDenyPermission: false
 GroupRoleSynchronizationPrimaryGroupOnly: false
 GroupRoleSynchronizationOnLink: true

--- a/src/main/resources/synchronization/ko.yml
+++ b/src/main/resources/synchronization/ko.yml
@@ -20,6 +20,8 @@ NicknameSynchronizationFormat: "%displayname%"
 #                                               {"MC_GROUP_NAME": "DISCORD_ROLE_ID"} 더 많은 그룹 / 역할 쌍을 추가 할 때 사용되는 형식입니다.
 #                                               디스코드 서버의 Role ID를 보려면 우선, "/discord debug"를 실행한 후 최 상단을 확인해 주세요
 # GroupRoleSynchronizationMinecraftIsAuthoritative: Minecraft 그룹 변경이 Discord 역할 변경을 대체하는지 여부
+# GroupRoleSynchronizationOneWay: whether or not to synchronise only one way, the way it is synchronised depends on the value
+#                                 of GroupRoleSynchronizationMinecraftIsAuthoritative.
 # GroupRoleSynchronizationEnableDenyPermission : discordsrv.sync.deny.<그룹> 권한 사용 여부
 # GroupRoleSynchronizationPrimaryGroupOnly: 참이면 최상위 플레이어 그룹 만 동기화를 위해 계산됩니다.,
 #                                           그렇지 않으면 그룹 동기화는 부모 그룹을 포함하여 플레이어가 속한 모든 그룹을 계산합니다.

--- a/src/main/resources/synchronization/nl.yml
+++ b/src/main/resources/synchronization/nl.yml
@@ -28,6 +28,7 @@ NicknameSynchronizationFormat: "%displayname%"
 #
 GroupRoleSynchronizationGroupsAndRolesToSync: {"trusted": "000000000000000000", "vip": "000000000000000000"}
 GroupRoleSynchronizationMinecraftIsAuthoritative: true
+GroupRoleSynchronizationOneWay: false
 GroupRoleSynchronizationEnableDenyPermission: false
 GroupRoleSynchronizationPrimaryGroupOnly: false
 GroupRoleSynchronizationOnLink: true

--- a/src/main/resources/synchronization/nl.yml
+++ b/src/main/resources/synchronization/nl.yml
@@ -19,10 +19,11 @@ NicknameSynchronizationFormat: "%displayname%"
 # GroupRoleSynchronizationGroupsAndRolesToSync: dit zijn rollen / groepen die je wilt synchroniseren tussen Discord en Minecraft
 #                                               {"MC_GROUP_NAME": "DISCORD_ROLE_ID"} is de indeling die moet worden gevolgd bij het toevoegen van meer groep / rolparen
 #                                               Om je Discord guild's role IDs te krijgen, doe "/discord debug" en kijk in de eerst sectie.
-# GroupRoleSynchronizationMinecraftIsAuthoritative: Minecraft-groepswijzigingen negeren de Discord-rolwijzigingen
+# GroupRoleSynchronizationMinecraftIsAuthoritative: of Minecraft-groepswijzigingen of Discord-rolwijzigingen belangrijker zijn en de ander kunnen overschrijven.
+# GroupRoleSynchronizationOneWay: of er maar een kant op gesynchroneerd mag worden, als GroupRoleSynchronizationMinecraftIsAuthoritative "true" is worden
+#                                 Discord-rolwijzigingen altijd overschreven, is deze waarde "false" dan worden MineCraft-groepswijzigingen altijd overshcreven.
 # GroupRoleSynchronizationEnableDenyPermission: al dan niet discordsrv.sync.deny.<groep> permissies zijn ingeschakeld
-# GroupRoleSynchronizationPrimaryGroupOnly: Hvis det er sant, telles bare spillerens primære gruppeoppgave telling,
-#                                           Ellers teller gruppe synkronisering alle grupper spilleren er i, inkludert foreldregrupper
+# GroupRoleSynchronizationPrimaryGroupOnly: synchroniseer allen de hoofdgroep van de speler en geen andere groepen.
 # GroupRoleSynchronizationOnLink: wel of niet opnieuw synchroniseren wanneer een speler een link maakt
 # GroupRoleSynchronizationCycleTime: aantal minuten tussen het herhaaldelijk activeren van synchronisatie voor alle online spelers
 #

--- a/src/main/resources/synchronization/ru.yml
+++ b/src/main/resources/synchronization/ru.yml
@@ -29,6 +29,7 @@ NicknameSynchronizationFormat: "%displayname%"
 #
 GroupRoleSynchronizationGroupsAndRolesToSync: {"trusted": "000000000000000000", "vip": "000000000000000000"}
 GroupRoleSynchronizationMinecraftIsAuthoritative: true
+GroupRoleSynchronizationOneWay: false
 GroupRoleSynchronizationEnableDenyPermission: false
 GroupRoleSynchronizationPrimaryGroupOnly: false
 GroupRoleSynchronizationOnLink: true

--- a/src/main/resources/synchronization/ru.yml
+++ b/src/main/resources/synchronization/ru.yml
@@ -21,6 +21,8 @@ NicknameSynchronizationFormat: "%displayname%"
 #                                               Чтобы узнать id роли, напишите "/discord debug" и посмотрите в первую секцию.
 # GroupRoleSynchronizationMinecraftIsAuthoritative: Если выдать/забрать группу в Minecraft, то должна ли соответствующая роль 
 #                                                   появиться/пропасть в Discord? true - да, false - нет
+# GroupRoleSynchronizationOneWay: whether or not to synchronise only one way, the way it is synchronised depends on the value
+#                                 of GroupRoleSynchronizationMinecraftIsAuthoritative.
 # GroupRoleSynchronizationEnableDenyPermission: Включены ли в Minecraft права discordsrv.sync.deny.<id роли>
 # GroupRoleSynchronizationPrimaryGroupOnly: true - синхронизируется только главная группа игрока.
 #                                           false - синхронизируются все побочные и родительские группы.

--- a/src/main/resources/synchronization/zh.yml
+++ b/src/main/resources/synchronization/zh.yml
@@ -20,6 +20,8 @@ NicknameSynchronizationFormat: "%displayname%"
 #                                               {"MC_GROUP_NAME": "DISCORD_ROLE_ID"} 是添加更多组/角色对时要采用的格式
 #                                               若想取得Discord伺服器上的身分組ID 執行"/discord debug" 並查看第一區塊
 # GroupRoleSynchronizationMinecraftIsAuthoritative: Minecraft组更改是否覆盖Discord角色更改
+# GroupRoleSynchronizationOneWay: whether or not to synchronise only one way, the way it is synchronised depends on the value
+#                                 of GroupRoleSynchronizationMinecraftIsAuthoritative.
 # GroupRoleSynchronizationEnableDenyPermission：是否启用了 discordsrv.sync.deny.<组> 权限
 # GroupRoleSynchronizationPrimaryGroupOnly: 如果为true，则仅计算玩家的主要组进行同步, 否则，群组同步会计算玩家所在的所有群组，包括上级群组
 # GroupRoleSynchronizationOnLink：播放器链接时是否重新同步

--- a/src/main/resources/synchronization/zh.yml
+++ b/src/main/resources/synchronization/zh.yml
@@ -27,6 +27,7 @@ NicknameSynchronizationFormat: "%displayname%"
 #
 GroupRoleSynchronizationGroupsAndRolesToSync: {"trusted": "000000000000000000", "vip": "000000000000000000"}
 GroupRoleSynchronizationMinecraftIsAuthoritative: true
+GroupRoleSynchronizationOneWay: false
 GroupRoleSynchronizationEnableDenyPermission: false
 GroupRoleSynchronizationPrimaryGroupOnly: false
 GroupRoleSynchronizationOnLink: true


### PR DESCRIPTION
In light of issue #791 I made `GroupRoleSynchronizationMinecraftIsAuthoritative` strictly authoritative (even when synchronising to MineCraft). If preferred I can make a separate config option for this so that `GroupRoleSynchronizationMinecraftIsAuthoritative` maintains its current behaviour. I also added a debug statement that might help to debug any issues related to authoritativeness in the future.