### PR TITLE
Add SuperVanish join/leave hook

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -358,6 +358,10 @@
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -624,6 +628,16 @@
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
             <version>4.5.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- vanish plugin hooks -->
+
+        <!-- supervanish -->
+        <dependency>
+            <groupId>com.github.MyzelYam</groupId>
+            <artifactId>SuperVanish</artifactId>
+            <version>6.2.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/github/scarsz/discordsrv/hooks/vanish/SuperVanishHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/vanish/SuperVanishHook.java
@@ -42,13 +42,14 @@ public class SuperVanishHook implements VanishHook {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerShow(PostPlayerShowEvent event) {
-        if (event.isSilent()) {
+        SuperVanish plugin = (SuperVanish) getPlugin();
+        if (!plugin.getSettings().getBoolean("MessageOptions.FakeJoinQuitMessages.BroadcastFakeJoinOnReappear") ||
+                event.isSilent()) {
             return;
         }
 
         final Player player = event.getPlayer();
 
-        SuperVanish plugin = (SuperVanish) getPlugin();
         String joinMessage = plugin.replacePlaceholders("VanishMessage", player);
 
         MessageFormat messageFormat = DiscordSRV.getPlugin().getMessageFromConfiguration("MinecraftPlayerJoinMessage");
@@ -75,7 +76,9 @@ public class SuperVanishHook implements VanishHook {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerHide(PostPlayerHideEvent event) {
-        if (event.isSilent()) {
+        SuperVanish plugin = (SuperVanish) getPlugin();
+        if (!plugin.getSettings().getBoolean("MessageOptions.FakeJoinQuitMessages.BroadcastFakeQuitOnVanish") ||
+                event.isSilent()) {
             return;
         }
 
@@ -88,7 +91,6 @@ public class SuperVanishHook implements VanishHook {
 
         final String name = player.getName();
 
-        SuperVanish plugin = (SuperVanish) getPlugin();
         String joinMessage = plugin.replacePlaceholders("ReappearMessage", player);
 
         // no quit message, user shouldn't have one from permission

--- a/src/main/java/github/scarsz/discordsrv/hooks/vanish/SuperVanishHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/vanish/SuperVanishHook.java
@@ -22,26 +22,91 @@
 
 package github.scarsz.discordsrv.hooks.vanish;
 
+import de.myzelyam.api.vanish.PostPlayerHideEvent;
+import de.myzelyam.api.vanish.PostPlayerShowEvent;
+import de.myzelyam.api.vanish.VanishAPI;
+import de.myzelyam.supervanish.SuperVanish;
 import github.scarsz.discordsrv.DiscordSRV;
+import github.scarsz.discordsrv.objects.MessageFormat;
+import github.scarsz.discordsrv.util.GamePermissionUtil;
+import github.scarsz.discordsrv.util.LangUtil;
 import github.scarsz.discordsrv.util.PluginUtil;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.plugin.Plugin;
-
-import java.lang.reflect.Method;
 
 @SuppressWarnings("unchecked")
 public class SuperVanishHook implements VanishHook {
 
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerShow(PostPlayerShowEvent event) {
+        if (event.isSilent()) {
+            return;
+        }
+
+        final Player player = event.getPlayer();
+
+        SuperVanish plugin = (SuperVanish) getPlugin();
+        String joinMessage = plugin.replacePlaceholders("VanishMessage", player);
+
+        MessageFormat messageFormat = DiscordSRV.getPlugin().getMessageFromConfiguration("MinecraftPlayerJoinMessage");
+
+        // make sure join messages enabled
+        if (messageFormat == null) return;
+
+        final String name = player.getName();
+
+        // check if player has permission to not have join messages
+        if (GamePermissionUtil.hasPermission(event.getPlayer(), "discordsrv.silentjoin")) {
+            DiscordSRV.info(LangUtil.InternalMessage.SILENT_JOIN.toString()
+                    .replace("{player}", name)
+            );
+            return;
+        }
+
+        // player doesn't have silent join permission, send join message
+
+        // schedule command to run in a second to be able to capture display name
+        Bukkit.getScheduler().runTaskLaterAsynchronously(DiscordSRV.getPlugin(), () ->
+                DiscordSRV.getPlugin().sendJoinMessage(event.getPlayer(), joinMessage), 20);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerHide(PostPlayerHideEvent event) {
+        if (event.isSilent()) {
+            return;
+        }
+
+        final Player player = event.getPlayer();
+
+        MessageFormat messageFormat = DiscordSRV.getPlugin().getMessageFromConfiguration("MinecraftPlayerLeaveMessage");
+
+        // make sure quit messages enabled
+        if (messageFormat == null) return;
+
+        final String name = player.getName();
+
+        SuperVanish plugin = (SuperVanish) getPlugin();
+        String joinMessage = plugin.replacePlaceholders("ReappearMessage", player);
+
+        // no quit message, user shouldn't have one from permission
+        if (GamePermissionUtil.hasPermission(event.getPlayer(), "discordsrv.silentquit")) {
+            DiscordSRV.info(LangUtil.InternalMessage.SILENT_QUIT.toString()
+                    .replace("{player}", name)
+            );
+            return;
+        }
+
+        // player doesn't have silent quit, show quit message
+        Bukkit.getScheduler().runTaskAsynchronously(DiscordSRV.getPlugin(),
+                () -> DiscordSRV.getPlugin().sendLeaveMessage(event.getPlayer(), joinMessage));
+    }
+
     @Override
     public boolean isVanished(Player player) {
-        try {
-            Class<?> vanishAPI = Class.forName("de.myzelyam.api.vanish.VanishAPI");
-            Method isInvisible = vanishAPI.getMethod("isInvisible", Player.class);
-            return (boolean) isInvisible.invoke(null, player);
-        } catch (Exception e) {
-            DiscordSRV.error(e);
-            return false;
-        }
+        return VanishAPI.isInvisible(player);
     }
 
     @Override


### PR DESCRIPTION
Adds a dependency due to not using reflection, but I think it should be fine since this is how the chat hooks are implemented too.

- Respects `discordsrv.silentjoin` and `discordsrv.silentquit`.
- Respect SuperVanish's silent setting
- Uses join/leave message set in DiscordSRV config