### PR TITLE
Change PlayerQuitEvent priority to LOWEST

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerJoinLeaveListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerJoinLeaveListener.java
@@ -102,7 +102,7 @@ public class PlayerJoinLeaveListener implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.LOWEST) //priority needs to be different to MONITOR to avoid problems with permissions check when PEX is used, is at lowest so that it executes before VanishNoPacket's player leave listener and is able to see whether the player is vanished
+    @EventHandler(priority = EventPriority.LOWEST) //priority needs to be different to MONITOR to avoid problems with permissions check when PEX is used, it is at lowest so that it executes before VanishNoPacket's player leave listener and is able to see whether the player is vanished
     public void PlayerQuitEvent(PlayerQuitEvent event) {
         final Player player = event.getPlayer();
         if (PlayerUtil.isVanished(player)) {

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerJoinLeaveListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerJoinLeaveListener.java
@@ -102,7 +102,7 @@ public class PlayerJoinLeaveListener implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.LOWEST) //priority needs to be different to MONITOR to avoid problems with permissions check when PEX is used, is at lowest so that it executes before VanishNoPacket's player leave listener and is able to see if the player is vanished or not
+    @EventHandler(priority = EventPriority.LOWEST) //priority needs to be different to MONITOR to avoid problems with permissions check when PEX is used, is at lowest so that it executes before VanishNoPacket's player leave listener and is able to see whether the player is vanished
     public void PlayerQuitEvent(PlayerQuitEvent event) {
         final Player player = event.getPlayer();
         if (PlayerUtil.isVanished(player)) {

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerJoinLeaveListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerJoinLeaveListener.java
@@ -102,7 +102,7 @@ public class PlayerJoinLeaveListener implements Listener {
         }
     }
 
-    @EventHandler //priority needs to be different to MONITOR to avoid problems with permissions check when PEX is used
+    @EventHandler(priority = EventPriority.LOWEST) //priority needs to be different to MONITOR to avoid problems with permissions check when PEX is used, is at lowest so that it executes before VanishNoPacket's player leave listener and is able to see if the player is vanished or not
     public void PlayerQuitEvent(PlayerQuitEvent event) {
         final Player player = event.getPlayer();
         if (PlayerUtil.isVanished(player)) {


### PR DESCRIPTION
VanishNoPacket's leave listener is at priority `NORMAL`, and DiscordSRV needs to receive this event before so that it is actually able to see if the player is vanished (the player is removed from the vanish list after they quit).