### PR TITLE
Markdown escaping improvements

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/objects/SingleCommandSender.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/SingleCommandSender.java
@@ -132,7 +132,7 @@ public class SingleCommandSender implements ConsoleCommandSender {
 
     @Override
     public void sendMessage(String message) {
-        DiscordUtil.sendMessage(event.getChannel(), message, DiscordSRV.config().getInt("DiscordChatChannelConsoleCommandExpiration") * 1000);
+        DiscordUtil.sendMessage(event.getChannel(), DiscordUtil.escapeMarkdown(message), DiscordSRV.config().getInt("DiscordChatChannelConsoleCommandExpiration") * 1000);
 
         // expire request message after specified time
         if (!alreadyQueuedDelete && DiscordSRV.config().getInt("DiscordChatChannelConsoleCommandExpiration") > 0 && DiscordSRV.config().getBoolean("DiscordChatChannelConsoleCommandExpirationDeleteRequest")) {

--- a/src/main/java/github/scarsz/discordsrv/util/DiscordUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/DiscordUtil.java
@@ -196,7 +196,7 @@ public class DiscordUtil {
      * @return String with markdown escaped
      */
     public static String escapeMarkdown(String text) {
-        return text == null ? "" : text.replace("_", "\\_").replace("*", "\\*").replace("~", "\\~");
+        return text == null ? "" : text.replace("_", "\\_").replace("*", "\\*").replace("~", "\\~").replace("|", "\\|").replace(">", "\\>").replace("`", "\\`");
     }
 
     /**


### PR DESCRIPTION
The first commit resolves issues with commands such as `!c list` where users have underscores in their names.

The second commit escapes other markdown characters (`|`, `>` and `) that were not previously escaped.