### PR TITLE
Specify that the JDBC connection string error is safe to ignore if the user is not trying to use JDBC

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/objects/managers/link/JdbcAccountLinkManager.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/managers/link/JdbcAccountLinkManager.java
@@ -83,7 +83,7 @@ public class JdbcAccountLinkManager extends AbstractAccountLinkManager {
             Matcher matcher = JDBC_PATTERN.matcher(jdbc);
         
             if (!matcher.matches()) {
-                if (!quiet) DiscordSRV.error("Not using JDBC because the JDBC connection string is invalid!");
+                if (!quiet) DiscordSRV.error("Not using JDBC because the JDBC connection string is invalid! If you are not trying to use JDBC, this is safe to ignore.");
                 return false;
             }
 


### PR DESCRIPTION
Recently in #support, a number of people have posted this error and asked if it was something to worry about/how they should go about fixing it. This aims to tell them that it is something which is safe to ignore provided they are not trying to use JDBC.