### PR TITLE
Retrieve triggering Bukkit event from Death and Achievement events

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePostProcessEvent.java
@@ -58,7 +58,7 @@ public class AchievementMessagePostProcessEvent extends GameEvent implements Can
         this.webhookAvatarUrl = webhookAvatarUrl;
         setCancelled(cancelled);
     }
-    
+
     @Deprecated
     public AchievementMessagePostProcessEvent(String channel, Message discordMessage, Player player, String achievementName, boolean usingWebhooks, String webhookName, String webhookAvatarUrl, boolean cancelled) {
         super(player);

--- a/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePostProcessEvent.java
@@ -38,6 +38,7 @@ public class AchievementMessagePostProcessEvent extends GameEvent implements Can
     @Getter @Setter private boolean cancelled;
 
     @Getter private String achievementName;
+    @Getter private org.bukkit.event.Event triggeringBukkitEvent;
     @Getter @Setter private String channel;
 
     @Getter @Setter private Message discordMessage;
@@ -45,11 +46,12 @@ public class AchievementMessagePostProcessEvent extends GameEvent implements Can
     @Getter @Setter private String webhookName;
     @Getter @Setter private String webhookAvatarUrl;
 
-    public AchievementMessagePostProcessEvent(String channel, Message discordMessage, Player player, String achievementName, boolean usingWebhooks, String webhookName, String webhookAvatarUrl, boolean cancelled) {
+    public AchievementMessagePostProcessEvent(String channel, Message discordMessage, Player player, String achievementName, org.bukkit.event.Event triggeringBukkitEvent, boolean usingWebhooks, String webhookName, String webhookAvatarUrl, boolean cancelled) {
         super(player);
         this.channel = channel;
         this.discordMessage = discordMessage;
         this.achievementName = achievementName;
+        this.triggeringBukkitEvent = triggeringBukkitEvent;
         this.usingWebhooks = usingWebhooks;
         this.webhookName = webhookName;
         this.webhookAvatarUrl = webhookAvatarUrl;

--- a/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePostProcessEvent.java
@@ -28,6 +28,7 @@ import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
 
 /**
  * <p>Called after DiscordSRV has processed a achievement/advancement message but before being sent to Discord.
@@ -38,7 +39,7 @@ public class AchievementMessagePostProcessEvent extends GameEvent implements Can
     @Getter @Setter private boolean cancelled;
 
     @Getter private String achievementName;
-    @Getter private org.bukkit.event.Event triggeringBukkitEvent;
+    @Getter private Event triggeringBukkitEvent;
     @Getter @Setter private String channel;
 
     @Getter @Setter private Message discordMessage;
@@ -46,7 +47,7 @@ public class AchievementMessagePostProcessEvent extends GameEvent implements Can
     @Getter @Setter private String webhookName;
     @Getter @Setter private String webhookAvatarUrl;
 
-    public AchievementMessagePostProcessEvent(String channel, Message discordMessage, Player player, String achievementName, org.bukkit.event.Event triggeringBukkitEvent, boolean usingWebhooks, String webhookName, String webhookAvatarUrl, boolean cancelled) {
+    public AchievementMessagePostProcessEvent(String channel, Message discordMessage, Player player, String achievementName, Event triggeringBukkitEvent, boolean usingWebhooks, String webhookName, String webhookAvatarUrl, boolean cancelled) {
         super(player);
         this.channel = channel;
         this.discordMessage = discordMessage;
@@ -57,7 +58,19 @@ public class AchievementMessagePostProcessEvent extends GameEvent implements Can
         this.webhookAvatarUrl = webhookAvatarUrl;
         setCancelled(cancelled);
     }
-
+    
+    @Deprecated
+    public AchievementMessagePostProcessEvent(String channel, Message discordMessage, Player player, String achievementName, boolean usingWebhooks, String webhookName, String webhookAvatarUrl, boolean cancelled) {
+        super(player);
+        this.channel = channel;
+        this.discordMessage = discordMessage;
+        this.achievementName = achievementName;
+        this.usingWebhooks = usingWebhooks;
+        this.webhookName = webhookName;
+        this.webhookAvatarUrl = webhookAvatarUrl;
+        setCancelled(cancelled);
+    }
+    
     @Deprecated
     public AchievementMessagePostProcessEvent(String channel, String processedMessage, Player player, String achievementName, boolean cancelled) {
         super(player);

--- a/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePreProcessEvent.java
@@ -36,14 +36,16 @@ public class AchievementMessagePreProcessEvent extends GameEvent implements Canc
     @Getter @Setter private boolean cancelled;
 
     @Getter @Setter private String achievementName;
+    @Getter private org.bukkit.event.Event triggeringBukkitEvent;
     @Getter @Setter private String channel;
     @Getter @Setter private MessageFormat messageFormat;
 
-    public AchievementMessagePreProcessEvent(String channel, MessageFormat messageFormat, Player player, String achievementName) {
+    public AchievementMessagePreProcessEvent(String channel, MessageFormat messageFormat, Player player, String achievementName, org.bukkit.event.Event triggeringBukkitEvent) {
         super(player);
         this.channel = channel;
         this.messageFormat = messageFormat;
         this.achievementName = achievementName;
+        this.triggeringBukkitEvent = triggeringBukkitEvent;
     }
 
     @Deprecated

--- a/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePreProcessEvent.java
@@ -48,7 +48,7 @@ public class AchievementMessagePreProcessEvent extends GameEvent implements Canc
         this.achievementName = achievementName;
         this.triggeringBukkitEvent = triggeringBukkitEvent;
     }
-    
+
     @Deprecated
     public AchievementMessagePreProcessEvent(String channel, MessageFormat messageFormat, Player player, String achievementName) {
         super(player);

--- a/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePreProcessEvent.java
@@ -27,6 +27,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
 
 /**
  * <p>Called before DiscordSRV has processed a achievement/advancement message, modifications may be overwritten by DiscordSRV's processing.</p>
@@ -36,16 +37,24 @@ public class AchievementMessagePreProcessEvent extends GameEvent implements Canc
     @Getter @Setter private boolean cancelled;
 
     @Getter @Setter private String achievementName;
-    @Getter private org.bukkit.event.Event triggeringBukkitEvent;
+    @Getter private Event triggeringBukkitEvent;
     @Getter @Setter private String channel;
     @Getter @Setter private MessageFormat messageFormat;
 
-    public AchievementMessagePreProcessEvent(String channel, MessageFormat messageFormat, Player player, String achievementName, org.bukkit.event.Event triggeringBukkitEvent) {
+    public AchievementMessagePreProcessEvent(String channel, MessageFormat messageFormat, Player player, String achievementName, Event triggeringBukkitEvent) {
         super(player);
         this.channel = channel;
         this.messageFormat = messageFormat;
         this.achievementName = achievementName;
         this.triggeringBukkitEvent = triggeringBukkitEvent;
+    }
+    
+    @Deprecated
+    public AchievementMessagePreProcessEvent(String channel, MessageFormat messageFormat, Player player, String achievementName) {
+        super(player);
+        this.channel = channel;
+        this.messageFormat = messageFormat;
+        this.achievementName = achievementName;
     }
 
     @Deprecated

--- a/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePostProcessEvent.java
@@ -58,7 +58,7 @@ public class DeathMessagePostProcessEvent extends GameEvent implements Cancellab
         this.webhookAvatarUrl = webhookAvatarUrl;
         setCancelled(cancelled);
     }
-    
+
     @Deprecated
     public DeathMessagePostProcessEvent(String channel, Message discordMessage, Player player, String deathMessage, boolean usingWebhooks, String webhookName, String webhookAvatarUrl, boolean cancelled) {
         super(player);

--- a/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePostProcessEvent.java
@@ -28,6 +28,7 @@ import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
+import org.bukkit.event.entity.PlayerDeathEvent;
 
 /**
  * <p>Called after DiscordSRV has processed a death message but before being sent to Discord.
@@ -38,7 +39,7 @@ public class DeathMessagePostProcessEvent extends GameEvent implements Cancellab
     @Getter @Setter private boolean cancelled;
 
     @Getter private String deathMessage;
-    @Getter private org.bukkit.event.Event triggeringBukkitEvent;
+    @Getter private PlayerDeathEvent triggeringBukkitEvent;
     @Getter @Setter private String channel;
 
     @Getter @Setter private Message discordMessage;
@@ -46,12 +47,24 @@ public class DeathMessagePostProcessEvent extends GameEvent implements Cancellab
     @Getter @Setter private String webhookName;
     @Getter @Setter private String webhookAvatarUrl;
 
-    public DeathMessagePostProcessEvent(String channel, Message discordMessage, Player player, String deathMessage, org.bukkit.event.Event triggeringBukkitEvent, boolean usingWebhooks, String webhookName, String webhookAvatarUrl, boolean cancelled) {
+    public DeathMessagePostProcessEvent(String channel, Message discordMessage, Player player, String deathMessage, PlayerDeathEvent triggeringBukkitEvent, boolean usingWebhooks, String webhookName, String webhookAvatarUrl, boolean cancelled) {
         super(player);
         this.channel = channel;
         this.discordMessage = discordMessage;
         this.deathMessage = deathMessage;
         this.triggeringBukkitEvent = triggeringBukkitEvent;
+        this.usingWebhooks = usingWebhooks;
+        this.webhookName = webhookName;
+        this.webhookAvatarUrl = webhookAvatarUrl;
+        setCancelled(cancelled);
+    }
+    
+    @Deprecated
+    public DeathMessagePostProcessEvent(String channel, Message discordMessage, Player player, String deathMessage, boolean usingWebhooks, String webhookName, String webhookAvatarUrl, boolean cancelled) {
+        super(player);
+        this.channel = channel;
+        this.discordMessage = discordMessage;
+        this.deathMessage = deathMessage;
         this.usingWebhooks = usingWebhooks;
         this.webhookName = webhookName;
         this.webhookAvatarUrl = webhookAvatarUrl;

--- a/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePostProcessEvent.java
@@ -38,6 +38,7 @@ public class DeathMessagePostProcessEvent extends GameEvent implements Cancellab
     @Getter @Setter private boolean cancelled;
 
     @Getter private String deathMessage;
+    @Getter private org.bukkit.event.Event triggeringBukkitEvent;
     @Getter @Setter private String channel;
 
     @Getter @Setter private Message discordMessage;
@@ -45,11 +46,12 @@ public class DeathMessagePostProcessEvent extends GameEvent implements Cancellab
     @Getter @Setter private String webhookName;
     @Getter @Setter private String webhookAvatarUrl;
 
-    public DeathMessagePostProcessEvent(String channel, Message discordMessage, Player player, String deathMessage, boolean usingWebhooks, String webhookName, String webhookAvatarUrl, boolean cancelled) {
+    public DeathMessagePostProcessEvent(String channel, Message discordMessage, Player player, String deathMessage, org.bukkit.event.Event triggeringBukkitEvent, boolean usingWebhooks, String webhookName, String webhookAvatarUrl, boolean cancelled) {
         super(player);
         this.channel = channel;
         this.discordMessage = discordMessage;
         this.deathMessage = deathMessage;
+        this.triggeringBukkitEvent = triggeringBukkitEvent;
         this.usingWebhooks = usingWebhooks;
         this.webhookName = webhookName;
         this.webhookAvatarUrl = webhookAvatarUrl;

--- a/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePreProcessEvent.java
@@ -27,6 +27,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
+import org.bukkit.event.entity.PlayerDeathEvent;
 
 /**
  * <p>Called before DiscordSRV has processed a death message, modifications may be overwritten by DiscordSRV's processing.</p>
@@ -36,16 +37,24 @@ public class DeathMessagePreProcessEvent extends GameEvent implements Cancellabl
     @Getter @Setter private boolean cancelled;
 
     @Getter @Setter private String deathMessage;
-    @Getter private org.bukkit.event.Event triggeringBukkitEvent;
+    @Getter private PlayerDeathEvent triggeringBukkitEvent;
     @Getter @Setter private String channel;
     @Getter @Setter private MessageFormat messageFormat;
 
-    public DeathMessagePreProcessEvent(String channel, MessageFormat messageFormat, Player player, String deathMessage, org.bukkit.event.Event triggeringBukkitEvent) {
+    public DeathMessagePreProcessEvent(String channel, MessageFormat messageFormat, Player player, String deathMessage, PlayerDeathEvent triggeringBukkitEvent) {
         super(player);
         this.channel = channel;
         this.messageFormat = messageFormat;
         this.deathMessage = deathMessage;
         this.triggeringBukkitEvent = triggeringBukkitEvent;
+    }
+    
+    @Deprecated
+    public DeathMessagePreProcessEvent(String channel, MessageFormat messageFormat, Player player, String deathMessage) {
+        super(player);
+        this.channel = channel;
+        this.messageFormat = messageFormat;
+        this.deathMessage = deathMessage;
     }
 
     @Deprecated

--- a/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePreProcessEvent.java
@@ -48,7 +48,7 @@ public class DeathMessagePreProcessEvent extends GameEvent implements Cancellabl
         this.deathMessage = deathMessage;
         this.triggeringBukkitEvent = triggeringBukkitEvent;
     }
-    
+
     @Deprecated
     public DeathMessagePreProcessEvent(String channel, MessageFormat messageFormat, Player player, String deathMessage) {
         super(player);

--- a/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePreProcessEvent.java
@@ -36,14 +36,16 @@ public class DeathMessagePreProcessEvent extends GameEvent implements Cancellabl
     @Getter @Setter private boolean cancelled;
 
     @Getter @Setter private String deathMessage;
+    @Getter private org.bukkit.event.Event triggeringBukkitEvent;
     @Getter @Setter private String channel;
     @Getter @Setter private MessageFormat messageFormat;
 
-    public DeathMessagePreProcessEvent(String channel, MessageFormat messageFormat, Player player, String deathMessage) {
+    public DeathMessagePreProcessEvent(String channel, MessageFormat messageFormat, Player player, String deathMessage, org.bukkit.event.Event triggeringBukkitEvent) {
         super(player);
         this.channel = channel;
         this.messageFormat = messageFormat;
         this.deathMessage = deathMessage;
+        this.triggeringBukkitEvent = triggeringBukkitEvent;
     }
 
     @Deprecated

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerAchievementsListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerAchievementsListener.java
@@ -106,7 +106,7 @@ public class PlayerAchievementsListener {
         MessageFormat messageFormat = DiscordSRV.getPlugin().getMessageFromConfiguration("MinecraftPlayerAchievementMessage");
         if (messageFormat == null) return;
 
-        AchievementMessagePreProcessEvent preEvent = DiscordSRV.api.callEvent(new AchievementMessagePreProcessEvent(channelName, messageFormat, player, achievementName));
+        AchievementMessagePreProcessEvent preEvent = DiscordSRV.api.callEvent(new AchievementMessagePreProcessEvent(channelName, messageFormat, player, achievementName, event));
         if (preEvent.isCancelled()) {
             DiscordSRV.debug("AchievementMessagePreProcessEvent was cancelled, message send aborted");
             return;
@@ -148,7 +148,7 @@ public class PlayerAchievementsListener {
         String webhookName = translator.apply(messageFormat.getWebhookName(), false);
         String webhookAvatarUrl = translator.apply(messageFormat.getWebhookAvatarUrl(), false);
 
-        AchievementMessagePostProcessEvent postEvent = DiscordSRV.api.callEvent(new AchievementMessagePostProcessEvent(channelName, discordMessage, player, achievementName, messageFormat.isUseWebhooks(), webhookName, webhookAvatarUrl, preEvent.isCancelled()));
+        AchievementMessagePostProcessEvent postEvent = DiscordSRV.api.callEvent(new AchievementMessagePostProcessEvent(channelName, discordMessage, player, achievementName, event, messageFormat.isUseWebhooks(), webhookName, webhookAvatarUrl, preEvent.isCancelled()));
         if (postEvent.isCancelled()) {
             DiscordSRV.debug("AchievementMessagePostProcessEvent was cancelled, message send aborted");
             return;

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerAdvancementDoneListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerAdvancementDoneListener.java
@@ -86,7 +86,7 @@ public class PlayerAdvancementDoneListener implements Listener {
         // turn "story/advancement_name" into "Advancement Name"
         String advancementTitle = getTitle(advancement);
 
-        AchievementMessagePreProcessEvent preEvent = DiscordSRV.api.callEvent(new AchievementMessagePreProcessEvent(channelName, messageFormat, player, advancementTitle));
+        AchievementMessagePreProcessEvent preEvent = DiscordSRV.api.callEvent(new AchievementMessagePreProcessEvent(channelName, messageFormat, player, advancementTitle, event));
         if (preEvent.isCancelled()) {
             DiscordSRV.debug("AchievementMessagePreProcessEvent was cancelled, message send aborted");
             return;
@@ -128,7 +128,7 @@ public class PlayerAdvancementDoneListener implements Listener {
         String webhookName = translator.apply(messageFormat.getWebhookName(), false);
         String webhookAvatarUrl = translator.apply(messageFormat.getWebhookAvatarUrl(), false);
 
-        AchievementMessagePostProcessEvent postEvent = DiscordSRV.api.callEvent(new AchievementMessagePostProcessEvent(channelName, discordMessage, player, advancementTitle, messageFormat.isUseWebhooks(), webhookName, webhookAvatarUrl, preEvent.isCancelled()));
+        AchievementMessagePostProcessEvent postEvent = DiscordSRV.api.callEvent(new AchievementMessagePostProcessEvent(channelName, discordMessage, player, advancementTitle, event, messageFormat.isUseWebhooks(), webhookName, webhookAvatarUrl, preEvent.isCancelled()));
         if (postEvent.isCancelled()) {
             DiscordSRV.debug("AchievementMessagePostProcessEvent was cancelled, message send aborted");
             return;

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerDeathListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerDeathListener.java
@@ -66,7 +66,7 @@ public class PlayerDeathListener implements Listener {
         MessageFormat messageFormat = DiscordSRV.getPlugin().getMessageFromConfiguration("MinecraftPlayerDeathMessage");
         if (messageFormat == null) return;
 
-        DeathMessagePreProcessEvent preEvent = DiscordSRV.api.callEvent(new DeathMessagePreProcessEvent(channelName, messageFormat, player, deathMessage));
+        DeathMessagePreProcessEvent preEvent = DiscordSRV.api.callEvent(new DeathMessagePreProcessEvent(channelName, messageFormat, player, deathMessage, event));
         if (preEvent.isCancelled()) {
             DiscordSRV.debug("DeathMessagePreProcessEvent was cancelled, message send aborted");
             return;
@@ -114,7 +114,7 @@ public class PlayerDeathListener implements Listener {
             return;
         }
 
-        DeathMessagePostProcessEvent postEvent = DiscordSRV.api.callEvent(new DeathMessagePostProcessEvent(channelName, discordMessage, player, deathMessage, messageFormat.isUseWebhooks(), webhookName, webhookAvatarUrl, preEvent.isCancelled()));
+        DeathMessagePostProcessEvent postEvent = DiscordSRV.api.callEvent(new DeathMessagePostProcessEvent(channelName, discordMessage, player, deathMessage, event, messageFormat.isUseWebhooks(), webhookName, webhookAvatarUrl, preEvent.isCancelled()));
         if (postEvent.isCancelled()) {
             DiscordSRV.debug("DeathMessagePostProcessEvent was cancelled, message send aborted");
             return;


### PR DESCRIPTION
Retrieve triggering Bukkit event from Death and Achievement events so listeners will be able to use the information provided from Bukkit to modify the DiscordSRV Event.