### PR TITLE
Group chat channel console command responses

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/objects/SingleCommandSender.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/SingleCommandSender.java
@@ -138,7 +138,7 @@ public class SingleCommandSender implements ConsoleCommandSender {
     @Override
     public void sendMessage(String message) {
         if (this.bufferCollecting) { // If the buffer has started collecting messages, we should just add this one to it.
-            if (DiscordUtil.escapeMarkdown(this.messageBuffer.toString() + "\n" + message).length() > 1998) { // If the message will be too long (allowing for markdown escaping and the newline)
+            if (DiscordUtil.escapeMarkdown(this.messageBuffer + "\n" + message).length() > 1998) { // If the message will be too long (allowing for markdown escaping and the newline)
                 // Send the message, then clear the buffer and add this message to the empty buffer
                 DiscordUtil.sendMessage(event.getChannel(), DiscordUtil.escapeMarkdown(this.messageBuffer.toString()), DiscordSRV.config().getInt("DiscordChatChannelConsoleCommandExpiration") * 1000);
                 this.messageBuffer = new StringJoiner("\n");
@@ -151,7 +151,7 @@ public class SingleCommandSender implements ConsoleCommandSender {
             this.messageBuffer.add(message); // This message is the first one in the buffer
             Bukkit.getScheduler().runTaskLater(DiscordSRV.getPlugin(), () -> { // Collect messages for 3 ticks, then send
                 this.bufferCollecting = false;
-                if (this.messageBuffer.toString().equalsIgnoreCase("")) return; // There's nothing in the buffer to send, leave it
+                if (this.messageBuffer.length() == 0) return; // There's nothing in the buffer to send, leave it
                 DiscordUtil.sendMessage(event.getChannel(), DiscordUtil.escapeMarkdown(this.messageBuffer.toString()), DiscordSRV.config().getInt("DiscordChatChannelConsoleCommandExpiration") * 1000);
                 this.messageBuffer = new StringJoiner("\n");
             }, 3L);

--- a/src/main/java/github/scarsz/discordsrv/objects/SingleCommandSender.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/SingleCommandSender.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
@@ -130,9 +130,31 @@ public class SingleCommandSender implements ConsoleCommandSender {
 
     private boolean alreadyQueuedDelete = false;
 
+    private String messageBuffer = "";
+    private boolean bufferCollecting = false;
+
+    // To prevent spam and potential rate-limiting when getting multi-line command responses, responses will be grouped together and sent in as few messages as is practical.
     @Override
     public void sendMessage(String message) {
-        DiscordUtil.sendMessage(event.getChannel(), DiscordUtil.escapeMarkdown(message), DiscordSRV.config().getInt("DiscordChatChannelConsoleCommandExpiration") * 1000);
+        if (this.bufferCollecting) { // If the buffer has started collecting messages, we should just add this one to it.
+            if (DiscordUtil.escapeMarkdown(this.messageBuffer + "\n" + message).length() > 1998) { // If the message will be too long (allowing for markdown escaping and the newline)
+                // Send the message, then clear the buffer and add this message to the empty buffer
+                DiscordUtil.sendMessage(event.getChannel(), DiscordUtil.escapeMarkdown(this.messageBuffer), DiscordSRV.config().getInt("DiscordChatChannelConsoleCommandExpiration") * 1000);
+                this.messageBuffer = message;
+            } else { // If adding this message to the buffer won't send it over the 2000 character limit
+                this.messageBuffer += "\n" + message;
+            }
+        } else { // Messages aren't currently being collected, let's start doing that
+            this.bufferCollecting = true;
+            this.messageBuffer = message; // This message is the first one in the buffer
+            Bukkit.getScheduler().runTaskLater(DiscordSRV.getPlugin(), () -> { // Collect messages for 3 ticks, then send
+                this.bufferCollecting = false;
+                if (this.messageBuffer.equals("")) return; // There's nothing in the buffer to send, leave it
+                DiscordUtil.sendMessage(event.getChannel(), DiscordUtil.escapeMarkdown(this.messageBuffer), DiscordSRV.config().getInt("DiscordChatChannelConsoleCommandExpiration") * 1000);
+                this.messageBuffer = "";
+            }, 3L);
+        }
+
 
         // expire request message after specified time
         if (!alreadyQueuedDelete && DiscordSRV.config().getInt("DiscordChatChannelConsoleCommandExpiration") > 0 && DiscordSRV.config().getBoolean("DiscordChatChannelConsoleCommandExpirationDeleteRequest")) {


### PR DESCRIPTION
This changes the `SingleCommandSender#sendMessage` method to collect responses for 3 ticks before sending a response to the chat channel.

## Why?
When running a command such as `!c entities`,  a number of messages are sent to the chat channel, which causes rate-limiting and blocks up the channel for a good few seconds. This PR aims to at least mitigate a significant portion of that impact by grouping as many of those messages as possible into one single response.