### PR TITLE
Nickname Sync Improvements

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/objects/threads/NicknameUpdater.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/threads/NicknameUpdater.java
@@ -131,7 +131,7 @@ public class NicknameUpdater extends Thread {
 
         nickname = MessageUtil.strip(nickname);
         if (nickname.length() > 32) {
-            DiscordSRV.debug("The new nickname for " + offlinePlayer.getName() + " is too long, reducing it to 32 characters.");
+            DiscordSRV.debug("The new nickname for " + offlinePlayer.getName() + " (" + nickname + ") is too long, reducing it to 32 characters.");
             nickname = nickname.substring(0, 32);
         }
         DiscordUtil.setNickname(member, nickname);

--- a/src/main/java/github/scarsz/discordsrv/objects/threads/NicknameUpdater.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/threads/NicknameUpdater.java
@@ -131,7 +131,7 @@ public class NicknameUpdater extends Thread {
 
         nickname = MessageUtil.strip(nickname);
         if (nickname.length() > 32) {
-            DiscordSRV.debug("The new nickname for " + offlinePlayer.getName() + " is too long, reducing it to 32 characters.");
+            DiscordSRV.error("The new nickname for " + offlinePlayer.getName() + " is too long, reducing it to 32 characters.");
             nickname = nickname.substring(0, 32);
         }
         DiscordUtil.setNickname(member, nickname);

--- a/src/main/java/github/scarsz/discordsrv/objects/threads/NicknameUpdater.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/threads/NicknameUpdater.java
@@ -130,6 +130,10 @@ public class NicknameUpdater extends Thread {
         }
 
         nickname = MessageUtil.strip(nickname);
+        if (nickname.length() > 32) {
+            DiscordSRV.debug("The new nickname for " + offlinePlayer.getName() + " is too long, reducing it to 32 characters.");
+            nickname = nickname.substring(0, 32);
+        }
         DiscordUtil.setNickname(member, nickname);
     }
 }

--- a/src/main/java/github/scarsz/discordsrv/objects/threads/NicknameUpdater.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/threads/NicknameUpdater.java
@@ -131,7 +131,7 @@ public class NicknameUpdater extends Thread {
 
         nickname = MessageUtil.strip(nickname);
         if (nickname.length() > 32) {
-            DiscordSRV.error("The new nickname for " + offlinePlayer.getName() + " is too long, reducing it to 32 characters.");
+            DiscordSRV.debug("The new nickname for " + offlinePlayer.getName() + " is too long, reducing it to 32 characters.");
             nickname = nickname.substring(0, 32);
         }
         DiscordUtil.setNickname(member, nickname);

--- a/src/main/java/github/scarsz/discordsrv/objects/threads/NicknameUpdater.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/threads/NicknameUpdater.java
@@ -95,6 +95,9 @@ public class NicknameUpdater extends Thread {
                     if (member == null) {
                         DiscordSRV.debug(linkedUser + " is not in the Main guild, not setting nickname");
                         continue;
+                    } else if (!onlinePlayer.hasPermission("discordsrv.nicknamesync")) {
+                        DiscordSRV.debug("Not syncing nicknames for " + onlinePlayer.getName() + " because they do not have the discordsrv.nicknamesync permission.");
+                        continue;
                     }
 
                     setNickname(member, onlinePlayer);

--- a/src/main/java/github/scarsz/discordsrv/objects/threads/NicknameUpdater.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/threads/NicknameUpdater.java
@@ -117,7 +117,9 @@ public class NicknameUpdater extends Thread {
 
             nickname = DiscordSRV.config().getString("NicknameSynchronizationFormat")
                     .replace("%displayname%", player.getDisplayName() != null ? player.getDisplayName() : player.getName())
-                    .replace("%username%", player.getName());
+                    .replace("%username%", player.getName())
+                    .replace("%discord_name%", member.getUser().getName())
+                    .replace("%discord_discriminator%", member.getUser().getDiscriminator());
 
             nickname = PlaceholderUtil.replacePlaceholders(nickname, player);
         } else {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -45,6 +45,7 @@ permissions:
       discordsrv.link: true
       discordsrv.linked: true
       discordsrv.discord: true
+      discordsrv.nicknamesync: true
   discordsrv.admin:
     description: parent permission of admin-related functions of DiscordSRV
     default: op
@@ -74,6 +75,9 @@ permissions:
     default: false
   discordsrv.help:
     description: whether or not the player is able to display command help for DiscordSRV
+    default: true
+  discordsrv.nicknamesync:
+    description: whether or not the player should have their nickname synced with Discord, if doing so is enabled in synchronization.yml
     default: true
   discordsrv.updatenotification:
     description: whether or not the player should be told if there's an update to DiscordSRV when joining

--- a/src/main/resources/synchronization/de.yml
+++ b/src/main/resources/synchronization/de.yml
@@ -1,13 +1,17 @@
-# Minecraft -> Discord nickname synchronization
+# Minecraft -> Discord-Spitznamensynchronisation
 #
-# NicknameSynchronizationEnabled: whether or not to set the discord user's nickname to the nickname format automatically
-# NicknameSynchronizationCycleTime: amount of minutes between repeatedly triggering synchronization for all online players
-# NicknameSynchronizationFormat: the nickname format (keep in mind this shouldn't go over 32 characters)
-# %displayname%: player's display name
-#                 example: Jeb
-# %username%:    player's username
-#                 example: Jeb_
-# PlaceholderAPI placeholders are supported for the values
+# NicknameSynchronizationEnabled: Gibt an, ob der Spitzname des Discord-Benutzers automatisch auf das Spitznamenformat gesetzt werden soll
+# NicknameSynchronizationCycleTime: Anzahl der Minuten zwischen dem wiederholten Auslösen der Synchronisation für alle Online-Spieler
+# NicknameSynchronizationFormat: Das Nickname-Format (beachten Sie, dass dies nicht länger als 32 Zeichen sein sollte)
+# %displayname%:            Anzeigename des Spielers
+#                             beispiel: Jeb
+# %username%:               Benutzername des Spielers
+#                             beispiel: Jeb_
+# %discord_name%:           Discord-Benutzername des Spielers
+#                             beispiel: Jeb
+# %discord_discriminator%:  Discord-Diskriminator des Spielers
+#                             beispiel: 4988
+# PlaceholderAPI-Platzhalter werden für die Werte unterstützt
 #
 NicknameSynchronizationEnabled: false
 NicknameSynchronizationCycleTime: 3

--- a/src/main/resources/synchronization/en.yml
+++ b/src/main/resources/synchronization/en.yml
@@ -3,10 +3,14 @@
 # NicknameSynchronizationEnabled: whether or not to set the discord user's nickname to the nickname format automatically
 # NicknameSynchronizationCycleTime: amount of minutes between repeatedly triggering synchronization for all online players
 # NicknameSynchronizationFormat: the nickname format (keep in mind this shouldn't go over 32 characters)
-# %displayname%: player's display name
-#                 example: Jeb
-# %username%:    player's username
-#                 example: Jeb_
+# %displayname%:            player's display name
+#                             example: Jeb
+# %username%:               player's username
+#                             example: Jeb_
+# %discord_name%:           player's discord username
+#                             example: Jeb
+# %discord_discriminator%:  player's discord discriminator
+#                             example: 4988
 # PlaceholderAPI placeholders are supported for the values
 #
 NicknameSynchronizationEnabled: false

--- a/src/main/resources/synchronization/es.yml
+++ b/src/main/resources/synchronization/es.yml
@@ -1,13 +1,17 @@
-# Minecraft -> Discord nickname synchronization
+# Minecraft -> Sincronización de apodos de Discord
 #
-# NicknameSynchronizationEnabled: whether or not to set the discord user's nickname to the nickname format automatically
-# NicknameSynchronizationCycleTime: amount of minutes between repeatedly triggering synchronization for all online players
-# NicknameSynchronizationFormat: the nickname format (keep in mind this shouldn't go over 32 characters)
-# %displayname%: player's display name
-#                 example: Jeb
-# %username%:    player's username
-#                 example: Jeb_
-# PlaceholderAPI placeholders are supported for the values
+# NicknameSynchronizationEnabled: si establecer o no el apodo del usuario de la discordia en el formato de apodo automáticamente
+# NicknameSynchronizationCycleTime: cantidad de minutos entre la activación repetida de la sincronización para todos los jugadores en línea
+# NicknameSynchronizationFormat: el formato del apodo (tenga en cuenta que no debe superar los 32 caracteres)
+# %displayname%:            nombre para mostrar del jugador
+#                             ejemplo: Jeb
+# %username%:               nombre de usuario del jugador
+#                             ejemplo: Jeb_
+# %discord_name%:           nombre de usuario de discord del jugador
+#                             ejemplo: Jeb
+# %discord_discriminator%:  discriminador de discordia del jugador
+#                             ejemplo: 4988
+# Los marcadores de posición de PlaceholderAPI son compatibles con los valores
 #
 NicknameSynchronizationEnabled: false
 NicknameSynchronizationCycleTime: 3

--- a/src/main/resources/synchronization/et.yml
+++ b/src/main/resources/synchronization/et.yml
@@ -3,10 +3,14 @@
 # NicknameSynchronizationEnabled: whether or not to set the discord user's nickname to the nickname format automatically
 # NicknameSynchronizationCycleTime: amount of minutes between repeatedly triggering synchronization for all online players
 # NicknameSynchronizationFormat: the nickname format (keep in mind this shouldn't go over 32 characters)
-# %displayname%: player's display name
-#                 example: Jeb
-# %username%:    player's username
-#                 example: Jeb_
+# %displayname%:            player's display name
+#                             example: Jeb
+# %username%:               player's username
+#                             example: Jeb_
+# %discord_name%:           player's discord username
+#                             example: Jeb
+# %discord_discriminator%:  player's discord discriminator
+#                             example: 4988
 # PlaceholderAPI placeholders are supported for the values
 #
 NicknameSynchronizationEnabled: false

--- a/src/main/resources/synchronization/fr.yml
+++ b/src/main/resources/synchronization/fr.yml
@@ -1,13 +1,17 @@
-# Minecraft -> Discord nickname synchronization
+# Minecraft -> Synchronisation des pseudonymes Discord
 #
-# NicknameSynchronizationEnabled: whether or not to set the discord user's nickname to the nickname format automatically
-# NicknameSynchronizationCycleTime: amount of minutes between repeatedly triggering synchronization for all online players
-# NicknameSynchronizationFormat: the nickname format (keep in mind this shouldn't go over 32 characters)
-# %displayname%: player's display name
-#                 example: Jeb
-# %username%:    player's username
-#                 example: Jeb_
-# PlaceholderAPI placeholders are supported for the values
+# NicknameSynchronizationEnabled: définir automatiquement ou non le pseudonyme de l'utilisateur Discord au format pseudonyme
+# NicknameSynchronizationCycleTime: nombre de minutes entre le déclenchement répété de la synchronisation pour tous les joueurs en ligne
+# NicknameSynchronizationFormat: le format du surnom (gardez à l'esprit que cela ne doit pas dépasser 32 caractères)
+# %displayname%:            le nom d'affichage du joueur
+#                             Exemple: Jeb
+# %username%:               nom d'utilisateur du joueur
+#                             Exemple: Jeb_
+# %discord_name%:           nom d'utilisateur Discord du joueur
+#                             Exemple: Jeb
+# %discord_discriminator%:  discriminateur de Discorde du joueur
+#                             Exemple: 4988
+# Les espaces réservés PlaceholderAPI sont pris en charge pour les valeurs
 #
 NicknameSynchronizationEnabled: false
 NicknameSynchronizationCycleTime: 3

--- a/src/main/resources/synchronization/ja.yml
+++ b/src/main/resources/synchronization/ja.yml
@@ -1,13 +1,17 @@
-# Minecraft -> Discord nickname synchronization
+# Minecraft->不和のニックネームの同期
 #
-# NicknameSynchronizationEnabled: whether or not to set the discord user's nickname to the nickname format automatically
-# NicknameSynchronizationCycleTime: amount of minutes between repeatedly triggering synchronization for all online players
-# NicknameSynchronizationFormat: the nickname format (keep in mind this shouldn't go over 32 characters)
-# %displayname%: player's display name
-#                 example: Jeb
-# %username%:    player's username
-#                 example: Jeb_
-# PlaceholderAPI placeholders are supported for the values
+# NicknameSynchronizationEnabled：不和ユーザーのニックネームをニックネーム形式に自動的に設定するかどうか
+# NicknameSynchronizationCycleTime：すべてのオンラインプレーヤーの同期を繰り返しトリガーする間の分数
+# NicknameSynchronizationFormat：ニックネームの形式（これは32文字を超えてはならないことに注意してください）
+# %displayname%:            プレイヤーの表示名
+#                             例: Jeb
+# %username%:               プレイヤーのユーザー名
+#                             例: Jeb_
+# %discord_name%:           プレイヤーのDiscordユーザー名
+#                             例: Jeb
+# %discord_discriminator%:  プレイヤーのDiscordディスクリミネーター
+#                             例: 4988
+# PlaceholderAPIプレースホルダーは値に対してサポートされています
 #
 NicknameSynchronizationEnabled: false
 NicknameSynchronizationCycleTime: 3

--- a/src/main/resources/synchronization/ko.yml
+++ b/src/main/resources/synchronization/ko.yml
@@ -1,13 +1,17 @@
-# 마인크래프트 -> 디스코드 닉네임 동기화
+# Minecraft-> Discord 닉네임 동기화
 #
-# NicknameSynchronizationEnabled: 디스코드 사용자의 닉네임을 자동으로 변경할지 설정합니다.
-# NicknameSynchronizationCycleTime: 몇분 주기로 모든 온라인 플레이어들의 이름을 동기화할지 설정합니다.
-# NicknameSynchronizationFormat: 닉네임 포맷을 지정합니다. (닉네임이 32자를 넘어가지 않도록 주의해주세요!)
-# %displayname%: 플레이어 별명
-#                 예시: Jeb
-# %username%:    플레이어 이름
-#                 예시: Jeb_
-# PlaceholderAPI 변수도 지원합니다.
+# NicknameSynchronizationEnabled : 불일치 사용자의 닉네임을 닉네임 형식으로 자동 설정할지 여부
+# NicknameSynchronizationCycleTime : 모든 온라인 플레이어에 대해 반복적으로 동기화를 트리거하는 간격 (분)
+# NicknameSynchronizationFormat : 닉네임 형식 (32자를 넘지 않아야 함을 명심하십시오)
+# %displayname%:            플레이어의 표시 이름
+#                            예: Jeb
+# %username%:               플레이어의 사용자 이름
+#                            예: Jeb_
+# %discord_name%:           플레이어의 discord 사용자 이름
+#                            예: 4Jeb
+# %discord_discriminator%: 플레이어의 불일치 판별 자
+#                            예: 4988
+# PlaceholderAPI 자리 표시자는 값에 대해 지원됩니다.
 #
 NicknameSynchronizationEnabled: false
 NicknameSynchronizationCycleTime: 3

--- a/src/main/resources/synchronization/nl.yml
+++ b/src/main/resources/synchronization/nl.yml
@@ -1,13 +1,17 @@
-# Minecraft -> Discord nickname synchronization
+# Minecraft -> Discord-bijnaamsynchronisatie
 #
-# NicknameSynchronizationEnabled: whether or not to set the discord user's nickname to the nickname format automatically
-# NicknameSynchronizationCycleTime: amount of minutes between repeatedly triggering synchronization for all online players
-# NicknameSynchronizationFormat: the nickname format (keep in mind this shouldn't go over 32 characters)
-# %displayname%: player's display name
-#                 example: Jeb
-# %username%:    player's username
-#                 example: Jeb_
-# PlaceholderAPI placeholders are supported for the values
+# NicknameSynchronizationEnabled: het al dan niet automatisch instellen van de bijnaam van de onenigheidsgebruiker in het bijnaamformaat
+# NicknameSynchronizationCycleTime: aantal minuten tussen het herhaaldelijk activeren van synchronisatie voor alle online spelers
+# NicknameSynchronizationFormat: het formaat van de bijnaam (houd er rekening mee dat dit niet langer mag zijn dan 32 tekens)
+# %displayname%:           de weergavenaam van de speler
+#                           voorbeeld: Jeb
+# %username%:              gebruikersnaam van de speler
+#                           voorbeeld: Jeb_
+# %discord_name%:          de discord-gebruikersnaam van de speler
+#                           voorbeeld: Jeb
+# %discord_discriminator%: discord-discriminator van de speler
+#                           voorbeeld: 4988
+# PlaceholderAPI-tijdelijke aanduidingen worden ondersteund voor de waarden
 #
 NicknameSynchronizationEnabled: false
 NicknameSynchronizationCycleTime: 3

--- a/src/main/resources/synchronization/ru.yml
+++ b/src/main/resources/synchronization/ru.yml
@@ -4,9 +4,11 @@
 # NicknameSynchronizationEnabled: Включить - true, отключить - false
 # NicknameSynchronizationCycleTime: Время (в минутах) - как часто DiscordSRV будет синхронизировать ники игроков.
 # NicknameSynchronizationFormat: Формат ников в дискорде.
-# Примеры: 
+# Примеры:
 #     %displayname%: отображаемое имя игрока
-#     %username%: настоящее имя игрока
+#     %username%: имя пользователя игрока
+#     %discord_name%: логин игрока в Discord
+#     %discord_discriminator%: дискорд-дискриминатор игрока
 # Поддерживает шаблоны из PlaceholderAPI.
 #
 NicknameSynchronizationEnabled: false

--- a/src/main/resources/synchronization/zh.yml
+++ b/src/main/resources/synchronization/zh.yml
@@ -1,13 +1,17 @@
-# Minecraft -> Discord nickname synchronization
+# Minecraft-> Discord昵称同步
 #
-# NicknameSynchronizationEnabled: whether or not to set the discord user's nickname to the nickname format automatically
-# NicknameSynchronizationCycleTime: amount of minutes between repeatedly triggering synchronization for all online players
-# NicknameSynchronizationFormat: the nickname format (keep in mind this shouldn't go over 32 characters)
-# %displayname%: player's display name
-#                 example: Jeb
-# %username%:    player's username
-#                 example: Jeb_
-# PlaceholderAPI placeholders are supported for the values
+# NicknameSynchronizationEnabled：是否将不和用户的昵称自动设置为昵称格式
+# NicknameSynchronizationCycleTime：重复触发所有在线播放器同步之间的分钟数
+# NicknameSynchronizationFormat：昵称格式（请注意，该长度不能超过32个字符）
+# %displayname%：          玩家的显示名称
+#                           例子：Jeb
+# %username%：             玩家的用户名
+#                           示例：Jeb_
+# %discord_name%：         玩家的不一致用户名
+#                           例子：Jeb
+# %discord_discriminator%：玩家的不一致识别符
+#                           示例：4988
+# 支持PlaceholderAPI占位符的值
 #
 NicknameSynchronizationEnabled: false
 NicknameSynchronizationCycleTime: 3


### PR DESCRIPTION
 - Adds `%discord_name%` and `%discord_discriminator%` placeholders to the `NicknameSynchronizationFormat` config option (closes #1093 and #1030)
 - Adds a `discordsrv.nicknamesync` permission, which is set to true by default but can be negated if admins don't want a specific group to have names synced (closes #506)