### PR TITLE
Minor patch: Enable builtin DiscordSRV placeholders for Experiment_WebhookChatMessageFormat

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/util/WebhookUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/WebhookUtil.java
@@ -74,6 +74,8 @@ public class WebhookUtil {
                     .replace("%displayname%", MessageUtil.strip(player.getDisplayName()))
                     .replace("%username%", player.getName());
             String chatMessage = DiscordSRV.config().getString("Experiment_WebhookChatMessageFormat")
+                    .replace("%displayname%", MessageUtil.strip(player.getDisplayName()))
+                    .replace("%username%", player.getName())
                     .replace("%message%", message);
             chatMessage = PlaceholderUtil.replacePlaceholders(chatMessage, player);
             username = PlaceholderUtil.replacePlaceholders(username, player);


### PR DESCRIPTION
When I submitted a PR for this feature I had overlooked the default DiscordSRV placeholders, and since I was testing with PAPI I didn't notice before submitting. This PR resolves that and adds the %displayname% and %username%, just like in the username format.