### PR TITLE
Fix the VentureChat %channelcolor% placeholder being blank in the ChatChannelHookMessageFormat

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/VentureChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/VentureChatHook.java
@@ -195,7 +195,7 @@ public class VentureChatHook implements ChatHook {
                 .replace("%channelname%", chatChannel.getName())
                 .replace("%channelnickname%", chatChannel.getAlias())
                 .replace("%message%", legacy)
-                .replace("%channelcolor%", MessageUtil.toLegacy(MessageUtil.toComponent(MessageUtil.translateLegacy(channelColor != null ? channelColor : ""))));
+                .replace("%channelcolor%", MessageUtil.translateLegacy(channelColor != null ? channelColor : ""));
 
         if (DiscordSRV.config().getBoolean("VentureChatBungee") && chatChannel.getBungee()) {
             if (chatChannel.isFiltered()) message = Format.FilterChat(message);


### PR DESCRIPTION
Closes #1119 