### PR TITLE
Always remove non-authoritative groups/roles

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/objects/managers/GroupSynchronizationManager.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/managers/GroupSynchronizationManager.java
@@ -511,9 +511,8 @@ public class GroupSynchronizationManager extends ListenerAdapter implements List
     }
 
     public void removeSynchronizables(OfflinePlayer player) {
-        if (!DiscordSRV.config().getBoolean("GroupRoleSynchronizationMinecraftIsAuthoritative")
-                && DiscordSRV.config().getBoolean("GroupRoleSynchronizationOneWay")) {
-            // one way Discord -> Minecraft
+        if (!DiscordSRV.config().getBoolean("GroupRoleSynchronizationMinecraftIsAuthoritative")) {
+            // Discord is authoritative, remove minecraft groups
             Permission permission = getPermissions();
 
             List<String> fail = new ArrayList<>();
@@ -527,7 +526,7 @@ public class GroupSynchronizationManager extends ListenerAdapter implements List
                     }
                 }
             }
-            DiscordSRV.debug(player.getName() + " removed from their groups (group sync is one way Discord -> Minecraft). succeeded: " + success + ", failed: " + fail);
+            DiscordSRV.debug(player.getName() + " removed from their groups (Discord is authoritative). succeeded: " + success + ", failed: " + fail);
         } else {
             removeSynchronizedRoles(player);
         }


### PR DESCRIPTION
When Discord is authoritative and two way sync is enabled, all synchronizable groups are currently lost if the sync is not one-way.
Discord groups are cleared on unlink, and the lack of groups are synced back to Minecraft on link, causing people to lose their ranks on both sides.

I have not tested my changes, as I don't have a plugin dev setup at the moment.