### PR TITLE
Fix nickname sync being run on join regardless of whether the player has permission

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/objects/threads/NicknameUpdater.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/threads/NicknameUpdater.java
@@ -95,9 +95,6 @@ public class NicknameUpdater extends Thread {
                     if (member == null) {
                         DiscordSRV.debug(linkedUser + " is not in the Main guild, not setting nickname");
                         continue;
-                    } else if (!onlinePlayer.hasPermission("discordsrv.nicknamesync")) {
-                        DiscordSRV.debug("Not syncing nicknames for " + onlinePlayer.getName() + " because they do not have the discordsrv.nicknamesync permission.");
-                        continue;
                     }
 
                     setNickname(member, onlinePlayer);
@@ -119,6 +116,11 @@ public class NicknameUpdater extends Thread {
         String nickname;
         if (offlinePlayer.isOnline()) {
             Player player = offlinePlayer.getPlayer();
+
+            if (!player.hasPermission("discordsrv.nicknamesync")) {
+                DiscordSRV.debug("Not syncing nicknames for " + player.getName() + " because they do not have the discordsrv.nicknamesync permission.");
+                return;
+            }
 
             nickname = DiscordSRV.config().getString("NicknameSynchronizationFormat")
                     .replace("%displayname%", player.getDisplayName() != null ? player.getDisplayName() : player.getName())


### PR DESCRIPTION
When writing the permission feature I completely forgot that nickname sync is called when the player joins