### PR TITLE
Add support for IDs and @everyone in role-related config options

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -2060,11 +2060,11 @@ public class DiscordSRV extends JavaPlugin {
         // if we have a whitelist in the config
         if (DiscordSRV.config().getBoolean("DiscordChatChannelRolesSelectionAsWhitelist")) {
             selectedRoles = member.getRoles().stream()
-                    .filter(role -> discordRolesSelection.contains(DiscordUtil.getRoleName(role)))
+                    .filter(role -> discordRolesSelection.contains(DiscordUtil.getRoleName(role)) || discordRolesSelection.contains(role.getId()))
                     .collect(Collectors.toList());
         } else { // if we have a blacklist in the settings
             selectedRoles = member.getRoles().stream()
-                    .filter(role -> !discordRolesSelection.contains(DiscordUtil.getRoleName(role)))
+                    .filter(role -> !(discordRolesSelection.contains(DiscordUtil.getRoleName(role)) || discordRolesSelection.contains(role.getId())))
                     .collect(Collectors.toList());
         }
         selectedRoles.removeIf(role -> StringUtils.isBlank(role.getName()));

--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordAccountLinkListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordAccountLinkListener.java
@@ -51,7 +51,7 @@ public class DiscordAccountLinkListener extends ListenerAdapter {
         // add linked role and nickname back to people when they rejoin the server
         UUID uuid = DiscordSRV.getPlugin().getAccountLinkManager().getUuid(event.getUser().getId());
         if (uuid != null) {
-            Role roleToAdd = DiscordUtil.getRoleByName(event.getMember().getGuild(), DiscordSRV.config().getString("MinecraftDiscordAccountLinkedRoleNameToAddUserTo"));
+            Role roleToAdd = DiscordUtil.resolveRole(DiscordSRV.config().getString("MinecraftDiscordAccountLinkedRoleNameToAddUserTo"));
             if (roleToAdd != null) DiscordUtil.addRoleToMember(event.getMember(), roleToAdd);
             else DiscordSRV.debug("Couldn't add user to null role");
 

--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordChatListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordChatListener.java
@@ -170,7 +170,7 @@ public class DiscordChatListener extends ListenerAdapter {
         List<String> rolesAllowedToColor = DiscordSRV.config().getStringList("DiscordChatChannelRolesAllowedToUseColorCodesInChat");
         boolean shouldStripColors = !rolesAllowedToColor.contains("@everyone");
         for (Role role : event.getMember().getRoles())
-            if (rolesAllowedToColor.contains(role.getName())) shouldStripColors = false;
+            if (rolesAllowedToColor.contains(role.getName()) || rolesAllowedToColor.contains(role.getId())) shouldStripColors = false;
         if (shouldStripColors) message = MessageUtil.stripLegacy(message);
 
         // get the correct format message

--- a/src/main/java/github/scarsz/discordsrv/objects/managers/GroupSynchronizationManager.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/managers/GroupSynchronizationManager.java
@@ -380,7 +380,7 @@ public class GroupSynchronizationManager extends ListenerAdapter implements List
 
         if (addLinkedRole) {
             try {
-                Role role = DiscordUtil.getJda().getRolesByName(DiscordSRV.config().getString("MinecraftDiscordAccountLinkedRoleNameToAddUserTo"), true).stream().findFirst().orElse(null);
+                Role role = DiscordUtil.resolveRole(DiscordSRV.config().getString("MinecraftDiscordAccountLinkedRoleNameToAddUserTo"));
                 if (role != null) {
                     roleChanges.computeIfAbsent(role.getGuild(), guild -> new HashMap<>())
                             .computeIfAbsent("add", s -> new HashSet<>())
@@ -551,7 +551,7 @@ public class GroupSynchronizationManager extends ListenerAdapter implements List
             try {
                 // remove user from linked role
                 String linkRole = DiscordSRV.config().getString("MinecraftDiscordAccountLinkedRoleNameToAddUserTo");
-                Role role = StringUtils.isNotBlank(linkRole) ? DiscordUtil.getJda().getRolesByName(linkRole, true).stream().findFirst().orElse(null) : null;
+                Role role = StringUtils.isNotBlank(linkRole) ? DiscordUtil.resolveRole(linkRole) : null;
                 if (role != null) {
                     roles.computeIfAbsent(role.getGuild(), guild -> new HashSet<>()).add(role);
                 } else {

--- a/src/main/java/github/scarsz/discordsrv/util/DebugUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/DebugUtil.java
@@ -299,7 +299,7 @@ public class DebugUtil {
         String roleName = DiscordSRV.config().getStringElse("MinecraftDiscordAccountLinkedRoleNameToAddUserTo", null);
         if (DiscordUtil.getJda() != null && roleName != null) {
             try {
-                Role role = DiscordUtil.getJda().getRolesByName(roleName, true).stream().findFirst().orElse(null);
+                Role role = DiscordUtil.resolveRole(roleName);
                 if (role != null && DiscordSRV.getPlugin().getGroupSynchronizables().values().stream().anyMatch(roleId -> roleId.equals(role.getId()))) {
                     messages.add(new Message(Message.Type.LINKED_ROLE_GROUP_SYNC));
                 }

--- a/src/main/java/github/scarsz/discordsrv/util/DiscordUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/DiscordUtil.java
@@ -39,6 +39,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextColor;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 import java.awt.Color;
 import java.io.File;
@@ -581,8 +582,9 @@ public class DiscordUtil {
     }
 
     public static boolean memberHasRole(Member member, Set<String> rolesToCheck) {
+        if (rolesToCheck.contains("@everyone")) return true;
         Set<String> rolesLowercase = rolesToCheck.stream().map(String::toLowerCase).collect(Collectors.toSet());
-        return member.getRoles().stream().anyMatch(role -> rolesLowercase.contains(role.getName().toLowerCase()));
+        return member.getRoles().stream().anyMatch(role -> rolesLowercase.contains(role.getName().toLowerCase()) || rolesLowercase.contains(role.getId()));
     }
 
     public static final Color DISCORD_DEFAULT_COLOR = new Color(153, 170, 181, 1);
@@ -754,9 +756,9 @@ public class DiscordUtil {
             return null;
         }
     }
-    public static Role getRoleByName(Guild guild, String roleName) {
-        return guild.getRoles().stream()
-                .filter(role -> role.getName().equalsIgnoreCase(roleName))
+    public static Role resolveRole(String resolvable) {
+        return getJda().getRoles().stream()
+                .filter(role -> role.getName().equalsIgnoreCase(resolvable) || role.getId().equals(resolvable))
                 .findFirst()
                 .orElse(null);
     }


### PR DESCRIPTION
Closes #1173

This allows @everyone as well as role IDs to be used in places such as `DiscordChatChannelConsoleCommandRolesAllowed` - Since `MinecraftDiscordAccountLinkedRoleNameToAddUserTo` now supports IDs as well it may also be a good idea to change the name of this option if possible