### PR TITLE
Make AvatarURL use mc-heads.net

### DIFF
--- a/src/main/resources/config/de.yml
+++ b/src/main/resources/config/de.yml
@@ -41,8 +41,7 @@ DebugJDA: false
 DebugJDARestActions: false
 CancelConsoleCommandIfLoggingFailed: true
 ForcedLanguage: none
-# https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafatar.com/avatars/{uuid-nodashes}?overlay&size={size}
+AvatarUrl: https://mc-heads.net/avatar/{texture}/{size}.png
 Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnect=true&useSSL=false"
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"

--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -41,8 +41,7 @@ DebugJDA: false
 DebugJDARestActions: false
 CancelConsoleCommandIfLoggingFailed: true
 ForcedLanguage: none
-# https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafatar.com/avatars/{uuid-nodashes}.png?size={size}&overlay#{texture}
+AvatarUrl: https://mc-heads.net/avatar/{texture}/{size}.png
 Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnect=true&useSSL=false"
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"

--- a/src/main/resources/config/es.yml
+++ b/src/main/resources/config/es.yml
@@ -41,8 +41,7 @@ DebugJDA: false
 DebugJDARestActions: false
 CancelConsoleCommandIfLoggingFailed: true
 ForcedLanguage: none
-# https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafatar.com/avatars/{uuid-nodashes}.png?size={size}&overlay#{texture}
+AvatarUrl: https://mc-heads.net/avatar/{texture}/{size}.png
 Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnect=true&useSSL=false"
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"

--- a/src/main/resources/config/et.yml
+++ b/src/main/resources/config/et.yml
@@ -41,8 +41,7 @@ DebugJDA: false
 DebugJDARestActions: false
 CancelConsoleCommandIfLoggingFailed: true
 ForcedLanguage: none
-# https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafatar.com/avatars/{uuid-nodashes}.png?size={size}&overlay#{texture}
+AvatarUrl: https://mc-heads.net/avatar/{texture}/{size}.png
 Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnect=true&useSSL=false"
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"

--- a/src/main/resources/config/fr.yml
+++ b/src/main/resources/config/fr.yml
@@ -41,8 +41,7 @@ DebugJDA: false
 DebugJDARestActions: false
 CancelConsoleCommandIfLoggingFailed: true
 ForcedLanguage: none
-# https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafatar.com/avatars/{uuid-nodashes}.png?size={size}&overlay#{texture}
+AvatarUrl: https://mc-heads.net/avatar/{texture}/{size}.png
 Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnect=true&useSSL=false"
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"

--- a/src/main/resources/config/ja.yml
+++ b/src/main/resources/config/ja.yml
@@ -41,8 +41,7 @@ DebugJDA: false
 DebugJDARestActions: false
 CancelConsoleCommandIfLoggingFailed: true
 ForcedLanguage: none
-# https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafatar.com/avatars/{uuid-nodashes}.png?size={size}&overlay#{texture}
+AvatarUrl: https://mc-heads.net/avatar/{texture}/{size}.png
 Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnect=true&useSSL=false"
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"

--- a/src/main/resources/config/ko.yml
+++ b/src/main/resources/config/ko.yml
@@ -42,8 +42,7 @@ DebugJDA: false
 DebugJDARestActions: false
 CancelConsoleCommandIfLoggingFailed: true
 ForcedLanguage: none
-# https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafatar.com/avatars/{uuid-nodashes}.png?size={size}&overlay#{texture}
+AvatarUrl: https://mc-heads.net/avatar/{texture}/{size}.png
 Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnect=true&useSSL=false"
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"

--- a/src/main/resources/config/nl.yml
+++ b/src/main/resources/config/nl.yml
@@ -41,8 +41,7 @@ DebugJDA: false
 DebugJDARestActions: false
 CancelConsoleCommandIfLoggingFailed: true
 ForcedLanguage: none
-# https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafatar.com/avatars/{uuid-nodashes}.png?size={size}&overlay#{texture}
+AvatarUrl: https://mc-heads.net/avatar/{texture}/{size}.png
 Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnect=true&useSSL=false"
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"

--- a/src/main/resources/config/pl.yml
+++ b/src/main/resources/config/pl.yml
@@ -41,8 +41,7 @@ DebugJDA: false
 DebugJDARestActions: false
 CancelConsoleCommandIfLoggingFailed: true
 ForcedLanguage: none
-# https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafatar.com/avatars/{uuid-nodashes}.png?size={size}&overlay#{texture}
+AvatarUrl: https://mc-heads.net/avatar/{texture}/{size}.png
 Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnect=true&useSSL=false"
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"

--- a/src/main/resources/config/ru.yml
+++ b/src/main/resources/config/ru.yml
@@ -41,8 +41,7 @@ DebugJDA: false
 DebugJDARestActions: false
 CancelConsoleCommandIfLoggingFailed: true
 ForcedLanguage: none
-# https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafatar.com/avatars/{uuid-nodashes}.png?size={size}&overlay#{texture}
+AvatarUrl: https://mc-heads.net/avatar/{texture}/{size}.png
 Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnect=true&useSSL=false"
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"

--- a/src/main/resources/config/zh.yml
+++ b/src/main/resources/config/zh.yml
@@ -41,8 +41,7 @@ DebugJDA: false
 DebugJDARestActions: false
 CancelConsoleCommandIfLoggingFailed: true
 ForcedLanguage: none
-# https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafatar.com/avatars/{uuid-nodashes}.png?size={size}&overlay#{texture}
+AvatarUrl: https://mc-heads.net/avatar/{texture}/{size}.png
 Experiment_JdbcAccountLinkBackend: "jdbc:mysql://HOST:PORT/DATABASE?autoReconnect=true&useSSL=false"
 Experiment_JdbcTablePrefix: "discordsrv"
 Experiment_JdbcUsername: "username"


### PR DESCRIPTION
Using mc-heads.net means the {texture} placeholder can be used to get the head so Discord caching is not an issue. Another benefit of this is people using offline mode servers would not have to change the URL.