### PR TITLE
Check whether file system access is limited after validating attachment in console channel

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordConsoleListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordConsoleListener.java
@@ -106,9 +106,6 @@ public class DiscordConsoleListener extends ListenerAdapter {
     }
 
     private void handleAttachment(GuildMessageReceivedEvent event, Message.Attachment attachment) {
-        if (DiscordSRV.isFileSystemLimited()) {
-            throw new UnsupportedOperationException("File system access has been limited, can't process attachment.");
-        }
 
         String[] attachmentSplit = attachment.getFileName().split("\\.");
         String attachmentExtension = attachmentSplit[attachmentSplit.length - 1];
@@ -116,6 +113,10 @@ public class DiscordConsoleListener extends ListenerAdapter {
         if (!allowedFileExtensions.contains(attachmentExtension)) {
             DiscordUtil.sendMessage(event.getChannel(), "Attached file \"" + attachment.getFileName() + "\" is of non-plugin extension " + attachmentExtension + ".");
             return;
+        }
+
+        if (DiscordSRV.isFileSystemLimited()) {
+            throw new UnsupportedOperationException("File system access has been limited, can't process attachment.");
         }
 
         File pluginDestination = new File(DiscordSRV.getPlugin().getDataFolder().getParentFile(), attachment.getFileName());


### PR DESCRIPTION
This prevents non-plugin uploads in the console channel from causing an UnsupportedOperationException to be thrown