### PR TITLE
Replaced calls to replacePlaceholders() with replacePlaceholdersToDiscord() in WebhookUtil

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/util/WebhookUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/WebhookUtil.java
@@ -99,8 +99,8 @@ public class WebhookUtil {
                     .replace("%displayname%", displayName)
                     .replace("%username%", player.getName())
                     .replace("%message%", message);
-            chatMessage = PlaceholderUtil.replacePlaceholders(chatMessage, player);
-            username = PlaceholderUtil.replacePlaceholders(username, player);
+            chatMessage = PlaceholderUtil.replacePlaceholdersToDiscord(chatMessage, player);
+            username = PlaceholderUtil.replacePlaceholdersToDiscord(username, player);
             username = MessageUtil.strip(username);
 
             String userId = DiscordSRV.getPlugin().getAccountLinkManager().getDiscordId(player.getUniqueId());


### PR DESCRIPTION
Replaced calls to PlaceholderUtil.replacePlaceholders() with PlaceholderUtil.replacePlaceholdersToDiscord() in order to allow WebHooks to mention roles
