### PR TITLE
Fixed issue where players could embed a link in their message if the server is using webhooks.

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/util/WebhookUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/WebhookUtil.java
@@ -98,7 +98,7 @@ public class WebhookUtil {
             String chatMessage = DiscordSRV.config().getString("Experiment_WebhookChatMessageFormat")
                     .replace("%displayname%", displayName)
                     .replace("%username%", player.getName())
-                    .replace("%message%", message);
+                    .replace("%message%", message.replace("[", "\\["));
             chatMessage = PlaceholderUtil.replacePlaceholdersToDiscord(chatMessage, player);
             username = PlaceholderUtil.replacePlaceholdersToDiscord(username, player);
             username = MessageUtil.strip(username);


### PR DESCRIPTION
Because the messages are sent as a webhook, Discord allows embedding links into text. Players shouldn't be allowed to do this because they can hide links in their messages which can be opened without seeing what the link is. This potentially allows players to include IP grabbers or other malicious links without people being able to tell. Hovering over the message also does not reveal the link, you would have to copy the link first.
This is fixed by replacing every instance of a `[` character in the message with `\[`, this way Discord does not format it and it shows as how they typed it in game.

![Before](https://user-images.githubusercontent.com/56408488/129477657-109dd979-32ba-4826-8333-7a46ae4d9f0d.png)
![After](https://user-images.githubusercontent.com/56408488/129477654-7fa3470a-2e49-48ba-8a46-9e0af1f43d94.png)
