### PR TITLE
More appropriate watchdog timeout default message.

### DIFF
--- a/src/main/resources/messages/en.yml
+++ b/src/main/resources/messages/en.yml
@@ -397,7 +397,7 @@ DiscordChatChannelServerShutdownMessage: ":octagonal_sign: **Server has stopped*
 #                        you can @mention the owner of the server by using "%guildowner%"
 #                        you can put the date and time of the crash in the message by using %date%
 #
-ServerWatchdogMessage: "`%date%` %guildowner%, the server room is on :fire::bangbang:"
+ServerWatchdogMessage: "`%date%` %guildowner%, Server game tick taking too long :bangbang:"
 
 # Account link messages
 # These are messages used when accounts are linked


### PR DESCRIPTION
Was pretty worried when I saw this @me this afternoon while away from home thinking some sort of temperature warning threshold were met, or any kind of alarming scenario. Instead it was just a plugin on the Survival instance acting up and making the server's gameticks take a while, activating this watchdog message.

Changed to a more appropriate default message.