### PR TITLE
Cancelling double leave message - paper bug

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerJoinLeaveListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerJoinLeaveListener.java
@@ -106,6 +106,11 @@ public class PlayerJoinLeaveListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST) //priority needs to be different to MONITOR to avoid problems with permissions check when PEX is used, it is at lowest so that it executes before VanishNoPacket's player leave listener and is able to see whether the player is vanished
     public void PlayerQuitEvent(PlayerQuitEvent event) {
         final Player player = event.getPlayer();
+        if(!player.isOnline()) {
+            DiscordSRV.debug(Debug.MINECRAFT_TO_DISCORD, "Leave event for player " + event.getPlayer().getName() + " was fired twice. We're cancelling one.");
+            return;
+        }
+
         if (PlayerUtil.isVanished(player)) {
             DiscordSRV.debug(Debug.MINECRAFT_TO_DISCORD, "Not sending a quit message for " + event.getPlayer().getName() + " because a vanish plugin reported them as vanished");
             return;


### PR DESCRIPTION
There's currently a bug in paper where the leave event would sometimes fire twice resulting in the leave message appearing twice in discord.
![Screenshot from 2021-09-17 20-59-55](https://user-images.githubusercontent.com/60141446/133866884-a1feaf32-4340-4041-9fd9-64429feb6884.png)
This pull request adds a condition to the leave event to ignore the second message. 