### PR TITLE
Custom linkaccount channel

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordAccountLinkListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordAccountLinkListener.java
@@ -55,6 +55,10 @@ public class DiscordAccountLinkListener extends ListenerAdapter {
         if (reply != null) event.getChannel().sendMessage(reply).queue();
     }
 
+    public void onPrivateMessageReceived(PrivateMessageReceivedEvent event) {
+        DiscordSRV.api.callEvent(new DiscordPrivateMessageReceivedEvent(event));
+    }
+
 
     public void onGuildMemberJoin(GuildMemberJoinEvent event) {
         // add linked role and nickname back to people when they rejoin the server

--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordAccountLinkListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordAccountLinkListener.java
@@ -22,7 +22,6 @@
 
 package github.scarsz.discordsrv.listeners;
 
-import com.github.ucchyocean.lc.lib.org.apache.commons.lang3.StringUtils;
 import github.scarsz.discordsrv.Debug;
 import github.scarsz.discordsrv.DiscordSRV;
 import github.scarsz.discordsrv.api.events.DiscordPrivateMessageReceivedEvent;
@@ -33,6 +32,7 @@ import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.events.message.priv.PrivateMessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 

--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordAccountLinkListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordAccountLinkListener.java
@@ -49,7 +49,7 @@ public class DiscordAccountLinkListener extends ListenerAdapter {
             if (!(event.getChannel() instanceof PrivateChannel)) return;
         } else {
             if (event.getChannel().getId() != option) return;
-            if (DiscordSRV.config().getBooleanElse("LinkAccountDeleteCode", false)) event.getMessage().delete().queue();
+            if (DiscordSRV.config().getBooleanElse("LinkAccountChannelDeleteCode", false)) event.getMessage().delete().queue();
         }
         String reply = DiscordSRV.getPlugin().getAccountLinkManager().process(event.getMessage().getContentRaw(), event.getAuthor().getId());
         if (reply != null) event.getChannel().sendMessage(reply).queue();

--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordAccountLinkListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordAccountLinkListener.java
@@ -22,6 +22,7 @@
 
 package github.scarsz.discordsrv.listeners;
 
+import com.github.ucchyocean.lc.lib.org.apache.commons.lang3.StringUtils;
 import github.scarsz.discordsrv.Debug;
 import github.scarsz.discordsrv.DiscordSRV;
 import github.scarsz.discordsrv.api.events.DiscordPrivateMessageReceivedEvent;
@@ -43,10 +44,11 @@ public class DiscordAccountLinkListener extends ListenerAdapter {
     public void onMessageReceived(MessageReceivedEvent event) {
         // don't process messages sent by bot or webhook
         if (event.getAuthor().isBot() || event.getMessage().isWebhookMessage()) return;
-        if (DiscordSRV.config().getLongElse("LinkAccountChannel", 0) == 0) {
+        String option = DiscordSRV.config().getString("LinkAccountChannel");
+        if (StringUtils.isNotBlank(option.replace("0", ""))) {
             if (!(event.getChannel() instanceof PrivateChannel)) return;
         } else {
-            if (event.getChannel().getIdLong() != DiscordSRV.config().getLongElse("LinkAccountChannel", 0)) return;
+            if (event.getChannel().getId() != option) return;
             if (DiscordSRV.config().getBooleanElse("LinkAccountDeleteCode", false)) event.getMessage().delete().queue();
         }
         String reply = DiscordSRV.getPlugin().getAccountLinkManager().process(event.getMessage().getContentRaw(), event.getAuthor().getId());

--- a/src/main/resources/config/de.yml
+++ b/src/main/resources/config/de.yml
@@ -291,3 +291,9 @@ MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 30
 ServerWatchdogMessageCount: 3
+
+# Link Account Channel Configuration
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false

--- a/src/main/resources/config/de.yml
+++ b/src/main/resources/config/de.yml
@@ -279,7 +279,7 @@ MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-LinkAccountChannel: 0
+LinkAccountChannel: 000000000000000000
 LinkAccountDeleteCode: false
 
 # Server-Watchdog

--- a/src/main/resources/config/de.yml
+++ b/src/main/resources/config/de.yml
@@ -273,8 +273,8 @@ DiscordCannedResponses: {"!ip": "deineserveradresse.net", "!site": "http://deine
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: die Rolle, die dem Discord-Nutzer zugewiesen wird, wenn er Minecraft und Discord verbunden hat
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: Ermöglicht das Senden eines neuen Codes an den Bot, um die Verknüpfung zu lösen und mit dem neuen Code erneut zu verknüpfen
 #
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+# LinkAccountChannel: Die Kanal-ID des Kanals, in dem der Spieler seinen Link-Code senden soll. Behalte es als "000000000000000000" für DMs.
+# LinkAccountDeleteCode: Ob im LinkAccountChannel gesendete Codes nach dem Senden gelöscht werden sollen oder nicht. Funktioniert nur, wenn LinkAccountChannel gesetzt ist.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"

--- a/src/main/resources/config/de.yml
+++ b/src/main/resources/config/de.yml
@@ -273,6 +273,8 @@ DiscordCannedResponses: {"!ip": "deineserveradresse.net", "!site": "http://deine
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: die Rolle, die dem Discord-Nutzer zugewiesen wird, wenn er Minecraft und Discord verbunden hat
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: Ermöglicht das Senden eines neuen Codes an den Bot, um die Verknüpfung zu lösen und mit dem neuen Code erneut zu verknüpfen
 #
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"

--- a/src/main/resources/config/de.yml
+++ b/src/main/resources/config/de.yml
@@ -273,7 +273,7 @@ DiscordCannedResponses: {"!ip": "deineserveradresse.net", "!site": "http://deine
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: die Rolle, die dem Discord-Nutzer zugewiesen wird, wenn er Minecraft und Discord verbunden hat
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: Ermöglicht das Senden eines neuen Codes an den Bot, um die Verknüpfung zu lösen und mit dem neuen Code erneut zu verknüpfen
 #
-# LinkAccountChannel: Die Kanal-ID des Kanals, in dem der Spieler seinen Link-Code senden soll. Behalte es als "000000000000000000" für DMs.
+# LinkAccountChannel: Die Kanal-ID des Kanals, in dem der Spieler seinen Link-Code senden soll. Behalte es als "000000000000000000" für DMs. Achten Sie darauf, CodeGenerated in messages.yml zu aktualisieren, wenn Sie diesen Wert ändern.
 # LinkAccountDeleteCode: Ob im LinkAccountChannel gesendete Codes nach dem Senden gelöscht werden sollen oder nicht. Funktioniert nur, wenn LinkAccountChannel gesetzt ist.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]

--- a/src/main/resources/config/de.yml
+++ b/src/main/resources/config/de.yml
@@ -274,13 +274,13 @@ DiscordCannedResponses: {"!ip": "deineserveradresse.net", "!site": "http://deine
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: Ermöglicht das Senden eines neuen Codes an den Bot, um die Verknüpfung zu lösen und mit dem neuen Code erneut zu verknüpfen
 #
 # LinkAccountChannel: Die Kanal-ID des Kanals, in dem der Spieler seinen Link-Code senden soll. Behalte es als "000000000000000000" für DMs. Achten Sie darauf, CodeGenerated in messages.yml zu aktualisieren, wenn Sie diesen Wert ändern.
-# LinkAccountDeleteCode: Ob im LinkAccountChannel gesendete Codes nach dem Senden gelöscht werden sollen oder nicht. Funktioniert nur, wenn LinkAccountChannel gesetzt ist.
+# LinkAccountChannelDeleteCode: Ob im LinkAccountChannel gesendete Codes nach dem Senden gelöscht werden sollen oder nicht. Funktioniert nur, wenn LinkAccountChannel gesetzt ist.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 LinkAccountChannel: 000000000000000000
-LinkAccountDeleteCode: false
+LinkAccountChannelDeleteCode: false
 
 # Server-Watchdog
 #

--- a/src/main/resources/config/de.yml
+++ b/src/main/resources/config/de.yml
@@ -277,6 +277,8 @@ MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false
 
 # Server-Watchdog
 #
@@ -291,9 +293,3 @@ MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 30
 ServerWatchdogMessageCount: 3
-
-# Link Account Channel Configuration
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
-LinkAccountChannel: 0
-LinkAccountDeleteCode: false

--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -271,10 +271,14 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: the name of a discord role to add a discord user to when they link their account
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: allows sending a new code to the bot to unlink and relink with the new code
 #
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false
 
 # Server watchdog
 #
@@ -290,8 +294,4 @@ ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 30
 ServerWatchdogMessageCount: 3
 
-# Link Account Channel Configuration
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
-LinkAccountChannel: 0
-LinkAccountDeleteCode: false
+

--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -277,7 +277,7 @@ MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-LinkAccountChannel: 0
+LinkAccountChannel: 000000000000000000
 LinkAccountDeleteCode: false
 
 # Server watchdog

--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -271,8 +271,8 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: the name of a discord role to add a discord user to when they link their account
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: allows sending a new code to the bot to unlink and relink with the new code
 #
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms. be sure to update CodeGenerated in messages.yml when changing this value
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+# LinkAccountChannel: The channel ID of the channel the player should send their link code in. Keep it as "000000000000000000" for DMs.
+# LinkAccountDeleteCode: Whether or not to delete codes sent in the LinkAccountChannel after they're sent. Only works if LinkAccountChannel is set.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"

--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -271,7 +271,7 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: the name of a discord role to add a discord user to when they link their account
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: allows sending a new code to the bot to unlink and relink with the new code
 #
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms. be sure to update CodeGenerated in messages.yml when changing this value
 # LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]

--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -272,13 +272,13 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: allows sending a new code to the bot to unlink and relink with the new code
 #
 # LinkAccountChannel: The channel ID of the channel the player should send their link code in. Keep it as "000000000000000000" for DMs. Be sure to update CodeGenerated in messages.yml when changing this value.
-# LinkAccountDeleteCode: Whether or not to delete codes sent in the LinkAccountChannel after they're sent. Only works if LinkAccountChannel is set.
+# LinkAccountChannelDeleteCode: Whether or not to delete codes sent in the LinkAccountChannel after they're sent. Only works if LinkAccountChannel is set.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 LinkAccountChannel: 000000000000000000
-LinkAccountDeleteCode: false
+LinkAccountChannelDeleteCode: false
 
 # Server watchdog
 #

--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -271,7 +271,7 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: the name of a discord role to add a discord user to when they link their account
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: allows sending a new code to the bot to unlink and relink with the new code
 #
-# LinkAccountChannel: The channel ID of the channel the player should send their link code in. Keep it as "000000000000000000" for DMs.
+# LinkAccountChannel: The channel ID of the channel the player should send their link code in. Keep it as "000000000000000000" for DMs. Be sure to update CodeGenerated in messages.yml when changing this value.
 # LinkAccountDeleteCode: Whether or not to delete codes sent in the LinkAccountChannel after they're sent. Only works if LinkAccountChannel is set.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]

--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -289,3 +289,9 @@ MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 30
 ServerWatchdogMessageCount: 3
+
+# Link Account Channel Configuration
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false

--- a/src/main/resources/config/es.yml
+++ b/src/main/resources/config/es.yml
@@ -277,7 +277,7 @@ MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-LinkAccountChannel: 0
+LinkAccountChannel: 000000000000000000
 LinkAccountDeleteCode: false
 
 # Perro guardián del servidor

--- a/src/main/resources/config/es.yml
+++ b/src/main/resources/config/es.yml
@@ -272,13 +272,13 @@ DiscordCannedResponses: {"!ip": "cambiaratuserverip.me", "!site": "http://tusiti
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: permite enviar un nuevo código al bot para desvincularlo y volver a vincularlo con el nuevo código
 #
 # LinkAccountChannel: El ID del canal en el que el jugador debe enviar su código de enlace. Guárdelo como "000000000000000000" para los mensajes directos. Asegúrese de actualizar CodeGenerated en mensajes.yml al cambiar este valor.
-# LinkAccountDeleteCode: Si eliminar o no los códigos enviados en LinkAccountChannel después de enviarlos. Solo funciona si se establece LinkAccountChannel.
+# LinkAccountChannelDeleteCode: Si eliminar o no los códigos enviados en LinkAccountChannel después de enviarlos. Solo funciona si se establece LinkAccountChannel.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 LinkAccountChannel: 000000000000000000
-LinkAccountDeleteCode: false
+LinkAccountChannelDeleteCode: false
 
 # Perro guardián del servidor
 #

--- a/src/main/resources/config/es.yml
+++ b/src/main/resources/config/es.yml
@@ -271,7 +271,7 @@ DiscordCannedResponses: {"!ip": "cambiaratuserverip.me", "!site": "http://tusiti
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: el nombre de un rol de Discord para agregar al usuario de Discord cuando vincula su cuenta
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: permite enviar un nuevo código al bot para desvincularlo y volver a vincularlo con el nuevo código
 #
-# LinkAccountChannel: El ID del canal en el que el jugador debe enviar su código de enlace. Guárdelo como "000000000000000000" para los mensajes directos.
+# LinkAccountChannel: El ID del canal en el que el jugador debe enviar su código de enlace. Guárdelo como "000000000000000000" para los mensajes directos. Asegúrese de actualizar CodeGenerated en mensajes.yml al cambiar este valor.
 # LinkAccountDeleteCode: Si eliminar o no los códigos enviados en LinkAccountChannel después de enviarlos. Solo funciona si se establece LinkAccountChannel.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]

--- a/src/main/resources/config/es.yml
+++ b/src/main/resources/config/es.yml
@@ -271,8 +271,8 @@ DiscordCannedResponses: {"!ip": "cambiaratuserverip.me", "!site": "http://tusiti
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: el nombre de un rol de Discord para agregar al usuario de Discord cuando vincula su cuenta
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: permite enviar un nuevo código al bot para desvincularlo y volver a vincularlo con el nuevo código
 #
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+# LinkAccountChannel: El ID del canal en el que el jugador debe enviar su código de enlace. Guárdelo como "000000000000000000" para los mensajes directos.
+# LinkAccountDeleteCode: Si eliminar o no los códigos enviados en LinkAccountChannel después de enviarlos. Solo funciona si se establece LinkAccountChannel.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"

--- a/src/main/resources/config/es.yml
+++ b/src/main/resources/config/es.yml
@@ -275,6 +275,8 @@ MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false
 
 # Perro guardián del servidor
 #
@@ -290,8 +292,3 @@ ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 30
 ServerWatchdogMessageCount: 3
 
-# Link Account Channel Configuration
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
-LinkAccountChannel: 0
-LinkAccountDeleteCode: false

--- a/src/main/resources/config/es.yml
+++ b/src/main/resources/config/es.yml
@@ -271,6 +271,8 @@ DiscordCannedResponses: {"!ip": "cambiaratuserverip.me", "!site": "http://tusiti
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: el nombre de un rol de Discord para agregar al usuario de Discord cuando vincula su cuenta
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: permite enviar un nuevo código al bot para desvincularlo y volver a vincularlo con el nuevo código
 #
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"

--- a/src/main/resources/config/es.yml
+++ b/src/main/resources/config/es.yml
@@ -289,3 +289,9 @@ MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 30
 ServerWatchdogMessageCount: 3
+
+# Link Account Channel Configuration
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false

--- a/src/main/resources/config/et.yml
+++ b/src/main/resources/config/et.yml
@@ -272,13 +272,13 @@ DiscordCannedResponses: {"!ip": "sinuserveriip.ee", "!site": "https://sinusaidia
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: allows sending a new code to the bot to unlink and relink with the new code
 #
 # LinkAccountChannel: Selle kanali kanali ID, mille mängija peaks oma lingikoodi saatma. DM-ide puhul hoidke seda kujul "000000000000000000". Selle väärtuse muutmisel värskendage kindlasti failis messages.yml CodeGenerated.
-# LinkAccountDeleteCode: Kas kustutada LinkAccountChannelis saadetud koodid pärast nende saatmist või mitte. Töötab ainult siis, kui LinkAccountChannel on määratud.
+# LinkAccountChannelDeleteCode: Kas kustutada LinkAccountChannelis saadetud koodid pärast nende saatmist või mitte. Töötab ainult siis, kui LinkAccountChannel on määratud.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 LinkAccountChannel: 000000000000000000
-LinkAccountDeleteCode: false
+LinkAccountChannelDeleteCode: false
 
 # Server watchdog
 #

--- a/src/main/resources/config/et.yml
+++ b/src/main/resources/config/et.yml
@@ -277,7 +277,7 @@ MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-LinkAccountChannel: 0
+LinkAccountChannel: 000000000000000000
 LinkAccountDeleteCode: false
 
 # Server watchdog

--- a/src/main/resources/config/et.yml
+++ b/src/main/resources/config/et.yml
@@ -271,8 +271,8 @@ DiscordCannedResponses: {"!ip": "sinuserveriip.ee", "!site": "https://sinusaidia
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: the name of a discord role to add a discord user to when they link their account
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: allows sending a new code to the bot to unlink and relink with the new code
 #
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+# LinkAccountChannel: Selle kanali kanali ID, mille mängija peaks oma lingikoodi saatma. DM-ide puhul hoidke seda kujul "000000000000000000".
+# LinkAccountDeleteCode: Kas kustutada LinkAccountChannelis saadetud koodid pärast nende saatmist või mitte. Töötab ainult siis, kui LinkAccountChannel on määratud.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"

--- a/src/main/resources/config/et.yml
+++ b/src/main/resources/config/et.yml
@@ -271,6 +271,8 @@ DiscordCannedResponses: {"!ip": "sinuserveriip.ee", "!site": "https://sinusaidia
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: the name of a discord role to add a discord user to when they link their account
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: allows sending a new code to the bot to unlink and relink with the new code
 #
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"

--- a/src/main/resources/config/et.yml
+++ b/src/main/resources/config/et.yml
@@ -271,7 +271,7 @@ DiscordCannedResponses: {"!ip": "sinuserveriip.ee", "!site": "https://sinusaidia
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: the name of a discord role to add a discord user to when they link their account
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: allows sending a new code to the bot to unlink and relink with the new code
 #
-# LinkAccountChannel: Selle kanali kanali ID, mille mängija peaks oma lingikoodi saatma. DM-ide puhul hoidke seda kujul "000000000000000000".
+# LinkAccountChannel: Selle kanali kanali ID, mille mängija peaks oma lingikoodi saatma. DM-ide puhul hoidke seda kujul "000000000000000000". Selle väärtuse muutmisel värskendage kindlasti failis messages.yml CodeGenerated.
 # LinkAccountDeleteCode: Kas kustutada LinkAccountChannelis saadetud koodid pärast nende saatmist või mitte. Töötab ainult siis, kui LinkAccountChannel on määratud.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]

--- a/src/main/resources/config/et.yml
+++ b/src/main/resources/config/et.yml
@@ -275,6 +275,8 @@ MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false
 
 # Server watchdog
 #
@@ -289,9 +291,3 @@ MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 30
 ServerWatchdogMessageCount: 3
-
-# Link Account Channel Configuration
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
-LinkAccountChannel: 0
-LinkAccountDeleteCode: false

--- a/src/main/resources/config/et.yml
+++ b/src/main/resources/config/et.yml
@@ -289,3 +289,9 @@ MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 30
 ServerWatchdogMessageCount: 3
+
+# Link Account Channel Configuration
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false

--- a/src/main/resources/config/fr.yml
+++ b/src/main/resources/config/fr.yml
@@ -269,13 +269,13 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: permet d'envoyer un nouveau code au bot pour dissocier et relier le nouveau code
 #
 # LinkAccountChannel: L'identifiant de la chaîne dans laquelle le joueur doit envoyer son code de lien. Conservez-le sous la forme "000000000000000000" pour les DM. Assurez-vous de mettre à jour CodeGenerated dans messages.yml lors de la modification de cette valeur.
-# LinkAccountDeleteCode: S'il faut ou non supprimer les codes envoyés dans le LinkAccountChannel après leur envoi. Ne fonctionne que si LinkAccountChannel est défini.
+# LinkAccountChannelDeleteCode: S'il faut ou non supprimer les codes envoyés dans le LinkAccountChannel après leur envoi. Ne fonctionne que si LinkAccountChannel est défini.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 LinkAccountChannel: 000000000000000000
-LinkAccountDeleteCode: false
+LinkAccountChannelDeleteCode: false
 
 # Surveilleur de serveur
 #

--- a/src/main/resources/config/fr.yml
+++ b/src/main/resources/config/fr.yml
@@ -272,7 +272,8 @@ MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false
 # Surveilleur de serveur
 #
 # Surveille constamment la dernière fois que votre serveur a effectué une tick de jeu
@@ -286,9 +287,3 @@ MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 30
 ServerWatchdogMessageCount: 3
-
-# Link Account Channel Configuration
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
-LinkAccountChannel: 0
-LinkAccountDeleteCode: false

--- a/src/main/resources/config/fr.yml
+++ b/src/main/resources/config/fr.yml
@@ -268,8 +268,8 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedSetDiscordNicknameAsInGameName: le nom discord du joueur doit-il être modifié par son nom Minecraft ?
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: permet d'envoyer un nouveau code au bot pour dissocier et relier le nouveau code
 #
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+# LinkAccountChannel: L'identifiant de la chaîne dans laquelle le joueur doit envoyer son code de lien. Conservez-le sous la forme "000000000000000000" pour les DM.
+# LinkAccountDeleteCode: S'il faut ou non supprimer les codes envoyés dans le LinkAccountChannel après leur envoi. Ne fonctionne que si LinkAccountChannel est défini.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"

--- a/src/main/resources/config/fr.yml
+++ b/src/main/resources/config/fr.yml
@@ -268,12 +268,15 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedSetDiscordNicknameAsInGameName: le nom discord du joueur doit-il être modifié par son nom Minecraft ?
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: permet d'envoyer un nouveau code au bot pour dissocier et relier le nouveau code
 #
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 LinkAccountChannel: 0
 LinkAccountDeleteCode: false
+
 # Surveilleur de serveur
 #
 # Surveille constamment la dernière fois que votre serveur a effectué une tick de jeu

--- a/src/main/resources/config/fr.yml
+++ b/src/main/resources/config/fr.yml
@@ -268,7 +268,7 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedSetDiscordNicknameAsInGameName: le nom discord du joueur doit-il être modifié par son nom Minecraft ?
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: permet d'envoyer un nouveau code au bot pour dissocier et relier le nouveau code
 #
-# LinkAccountChannel: L'identifiant de la chaîne dans laquelle le joueur doit envoyer son code de lien. Conservez-le sous la forme "000000000000000000" pour les DM.
+# LinkAccountChannel: L'identifiant de la chaîne dans laquelle le joueur doit envoyer son code de lien. Conservez-le sous la forme "000000000000000000" pour les DM. Assurez-vous de mettre à jour CodeGenerated dans messages.yml lors de la modification de cette valeur.
 # LinkAccountDeleteCode: S'il faut ou non supprimer les codes envoyés dans le LinkAccountChannel après leur envoi. Ne fonctionne que si LinkAccountChannel est défini.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]

--- a/src/main/resources/config/fr.yml
+++ b/src/main/resources/config/fr.yml
@@ -286,3 +286,9 @@ MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 30
 ServerWatchdogMessageCount: 3
+
+# Link Account Channel Configuration
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false

--- a/src/main/resources/config/fr.yml
+++ b/src/main/resources/config/fr.yml
@@ -274,7 +274,7 @@ MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-LinkAccountChannel: 0
+LinkAccountChannel: 000000000000000000
 LinkAccountDeleteCode: false
 
 # Surveilleur de serveur

--- a/src/main/resources/config/ja.yml
+++ b/src/main/resources/config/ja.yml
@@ -278,7 +278,7 @@ MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-LinkAccountChannel: 0
+LinkAccountChannel: 000000000000000000
 LinkAccountDeleteCode: false
 
 # Server ウォッチドッグ

--- a/src/main/resources/config/ja.yml
+++ b/src/main/resources/config/ja.yml
@@ -291,3 +291,10 @@ MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 60
 ServerWatchdogMessageCount: 3
+
+
+# Link Account Channel Configuration
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false

--- a/src/main/resources/config/ja.yml
+++ b/src/main/resources/config/ja.yml
@@ -272,8 +272,8 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: Discordユーザーが自分のアカウントをリンクするときに追加するDiscordロール名
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 新しいコードをボットに送信して新しいコードとのリンクを解除して再リンクすることを許可する
 #
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+# LinkAccountChannel: プレーヤーがリンクコードを送信する必要があるチャネルのチャネルID。DMの場合は「000000000000000000」のままにします。
+# LinkAccountDeleteCode: 送信後にLinkAccountChannelで送信されたコードを削除するかどうか。 LinkAccountChannelが設定されている場合にのみ機能します。
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"

--- a/src/main/resources/config/ja.yml
+++ b/src/main/resources/config/ja.yml
@@ -273,13 +273,13 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 新しいコードをボットに送信して新しいコードとのリンクを解除して再リンクすることを許可する
 #
 # LinkAccountChannel: プレーヤーがリンクコードを送信する必要があるチャネルのチャネルID。DMの場合は「000000000000000000」のままにします。この値を変更するときは、messages.ymlのCodeGeneratedを必ず更新してください。
-# LinkAccountDeleteCode: 送信後にLinkAccountChannelで送信されたコードを削除するかどうか。 LinkAccountChannelが設定されている場合にのみ機能します。
+# LinkAccountChannelDeleteCode: 送信後にLinkAccountChannelで送信されたコードを削除するかどうか。 LinkAccountChannelが設定されている場合にのみ機能します。
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 LinkAccountChannel: 000000000000000000
-LinkAccountDeleteCode: false
+LinkAccountChannelDeleteCode: false
 
 # Server ウォッチドッグ
 #

--- a/src/main/resources/config/ja.yml
+++ b/src/main/resources/config/ja.yml
@@ -276,6 +276,8 @@ MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false
 
 # Server ウォッチドッグ
 #
@@ -293,8 +295,3 @@ ServerWatchdogTimeout: 60
 ServerWatchdogMessageCount: 3
 
 
-# Link Account Channel Configuration
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
-LinkAccountChannel: 0
-LinkAccountDeleteCode: false

--- a/src/main/resources/config/ja.yml
+++ b/src/main/resources/config/ja.yml
@@ -272,7 +272,7 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: Discordユーザーが自分のアカウントをリンクするときに追加するDiscordロール名
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 新しいコードをボットに送信して新しいコードとのリンクを解除して再リンクすることを許可する
 #
-# LinkAccountChannel: プレーヤーがリンクコードを送信する必要があるチャネルのチャネルID。DMの場合は「000000000000000000」のままにします。
+# LinkAccountChannel: プレーヤーがリンクコードを送信する必要があるチャネルのチャネルID。DMの場合は「000000000000000000」のままにします。この値を変更するときは、messages.ymlのCodeGeneratedを必ず更新してください。
 # LinkAccountDeleteCode: 送信後にLinkAccountChannelで送信されたコードを削除するかどうか。 LinkAccountChannelが設定されている場合にのみ機能します。
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]

--- a/src/main/resources/config/ja.yml
+++ b/src/main/resources/config/ja.yml
@@ -272,6 +272,8 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: Discordユーザーが自分のアカウントをリンクするときに追加するDiscordロール名
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 新しいコードをボットに送信して新しいコードとのリンクを解除して再リンクすることを許可する
 #
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"

--- a/src/main/resources/config/ko.yml
+++ b/src/main/resources/config/ko.yml
@@ -274,6 +274,8 @@ MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false
 
 # 서버 와치독(Watchdog)
 #
@@ -289,8 +291,3 @@ ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 30
 ServerWatchdogMessageCount: 3
 
-# Link Account Channel Configuration
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
-LinkAccountChannel: 0
-LinkAccountDeleteCode: false

--- a/src/main/resources/config/ko.yml
+++ b/src/main/resources/config/ko.yml
@@ -276,7 +276,7 @@ MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-LinkAccountChannel: 0
+LinkAccountChannel: 000000000000000000
 LinkAccountDeleteCode: false
 
 # 서버 와치독(Watchdog)

--- a/src/main/resources/config/ko.yml
+++ b/src/main/resources/config/ko.yml
@@ -270,7 +270,7 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: 연동된 유저에 설정할 Roles를 설정합니다.
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 봇에 새 코드를 보내어 새 코드와의 링크를 해제하고 다시 링크 할 수 있습니다.
 #
-# LinkAccountChannel: 플레이어가 링크 코드를 보내야 하는 채널의 채널 ID입니다. DM의 경우 "000000000000000000"으로 유지하십시오.
+# LinkAccountChannel: 플레이어가 링크 코드를 보내야 하는 채널의 채널 ID입니다. DM의 경우 "000000000000000000"으로 유지하십시오. 이 값을 변경할 때 messages.yml에서 CodeGenerated를 업데이트해야 합니다.
 # LinkAccountDeleteCode: LinkAccountChannel에서 보낸 코드를 보낸 후 삭제할지 여부입니다. LinkAccountChannel이 설정된 경우에만 작동합니다.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]

--- a/src/main/resources/config/ko.yml
+++ b/src/main/resources/config/ko.yml
@@ -270,6 +270,8 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: 연동된 유저에 설정할 Roles를 설정합니다.
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 봇에 새 코드를 보내어 새 코드와의 링크를 해제하고 다시 링크 할 수 있습니다.
 #
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"

--- a/src/main/resources/config/ko.yml
+++ b/src/main/resources/config/ko.yml
@@ -288,3 +288,9 @@ MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 30
 ServerWatchdogMessageCount: 3
+
+# Link Account Channel Configuration
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false

--- a/src/main/resources/config/ko.yml
+++ b/src/main/resources/config/ko.yml
@@ -270,8 +270,8 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: 연동된 유저에 설정할 Roles를 설정합니다.
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 봇에 새 코드를 보내어 새 코드와의 링크를 해제하고 다시 링크 할 수 있습니다.
 #
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+# LinkAccountChannel: 플레이어가 링크 코드를 보내야 하는 채널의 채널 ID입니다. DM의 경우 "000000000000000000"으로 유지하십시오.
+# LinkAccountDeleteCode: LinkAccountChannel에서 보낸 코드를 보낸 후 삭제할지 여부입니다. LinkAccountChannel이 설정된 경우에만 작동합니다.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"

--- a/src/main/resources/config/ko.yml
+++ b/src/main/resources/config/ko.yml
@@ -271,13 +271,13 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 봇에 새 코드를 보내어 새 코드와의 링크를 해제하고 다시 링크 할 수 있습니다.
 #
 # LinkAccountChannel: 플레이어가 링크 코드를 보내야 하는 채널의 채널 ID입니다. DM의 경우 "000000000000000000"으로 유지하십시오. 이 값을 변경할 때 messages.yml에서 CodeGenerated를 업데이트해야 합니다.
-# LinkAccountDeleteCode: LinkAccountChannel에서 보낸 코드를 보낸 후 삭제할지 여부입니다. LinkAccountChannel이 설정된 경우에만 작동합니다.
+# LinkAccountChannelDeleteCode: LinkAccountChannel에서 보낸 코드를 보낸 후 삭제할지 여부입니다. LinkAccountChannel이 설정된 경우에만 작동합니다.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 LinkAccountChannel: 000000000000000000
-LinkAccountDeleteCode: false
+LinkAccountChannelDeleteCode: false
 
 # 서버 와치독(Watchdog)
 #

--- a/src/main/resources/config/nl.yml
+++ b/src/main/resources/config/nl.yml
@@ -272,13 +272,13 @@ DiscordCannedResponses: {"!ip": "serverip.me", "!site": "http://jesiteulr.nl"}
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: hiermee kan een nieuwe code naar de bot worden verzonden om te ontkoppelen en opnieuw te koppelen aan de nieuwe code
 #
 # LinkAccountChannel: De kanaal-ID van het kanaal waarnaar de speler zijn linkcode moet sturen. Bewaar deze als "000000000000000000" voor DM's. Zorg ervoor dat u CodeGenerated in messages.yml bijwerkt wanneer u deze waarde wijzigt.
-# LinkAccountDeleteCode: Of codes die zijn verzonden in het LinkAccountChannel moeten worden verwijderd nadat ze zijn verzonden. Werkt alleen als LinkAccountChannel is ingesteld.
+# LinkAccountChannelDeleteCode: Of codes die zijn verzonden in het LinkAccountChannel moeten worden verwijderd nadat ze zijn verzonden. Werkt alleen als LinkAccountChannel is ingesteld.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 LinkAccountChannel: 000000000000000000
-LinkAccountDeleteCode: false
+LinkAccountChannelDeleteCode: false
 
 # Server watchdog
 #

--- a/src/main/resources/config/nl.yml
+++ b/src/main/resources/config/nl.yml
@@ -277,7 +277,7 @@ MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-LinkAccountChannel: 0
+LinkAccountChannel: 000000000000000000
 LinkAccountDeleteCode: false
 
 # Server watchdog

--- a/src/main/resources/config/nl.yml
+++ b/src/main/resources/config/nl.yml
@@ -290,8 +290,4 @@ ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 30
 ServerWatchdogMessageCount: 3
 
-# Link Account Channel Configuration
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
-LinkAccountChannel: 0
-LinkAccountDeleteCode: false
+

--- a/src/main/resources/config/nl.yml
+++ b/src/main/resources/config/nl.yml
@@ -271,10 +271,14 @@ DiscordCannedResponses: {"!ip": "serverip.me", "!site": "http://jesiteulr.nl"}
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: De naam van de discord role als ze hun account gekoppeld hebben.
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: hiermee kan een nieuwe code naar de bot worden verzonden om te ontkoppelen en opnieuw te koppelen aan de nieuwe code
 #
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false
 
 # Server watchdog
 #

--- a/src/main/resources/config/nl.yml
+++ b/src/main/resources/config/nl.yml
@@ -271,8 +271,8 @@ DiscordCannedResponses: {"!ip": "serverip.me", "!site": "http://jesiteulr.nl"}
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: De naam van de discord role als ze hun account gekoppeld hebben.
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: hiermee kan een nieuwe code naar de bot worden verzonden om te ontkoppelen en opnieuw te koppelen aan de nieuwe code
 #
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+# LinkAccountChannel: De kanaal-ID van het kanaal waarnaar de speler zijn linkcode moet sturen. Bewaar deze als "000000000000000000" voor DM's.
+# LinkAccountDeleteCode: Of codes die zijn verzonden in het LinkAccountChannel moeten worden verwijderd nadat ze zijn verzonden. Werkt alleen als LinkAccountChannel is ingesteld.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"

--- a/src/main/resources/config/nl.yml
+++ b/src/main/resources/config/nl.yml
@@ -289,3 +289,9 @@ MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 30
 ServerWatchdogMessageCount: 3
+
+# Link Account Channel Configuration
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false

--- a/src/main/resources/config/nl.yml
+++ b/src/main/resources/config/nl.yml
@@ -271,7 +271,7 @@ DiscordCannedResponses: {"!ip": "serverip.me", "!site": "http://jesiteulr.nl"}
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: De naam van de discord role als ze hun account gekoppeld hebben.
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: hiermee kan een nieuwe code naar de bot worden verzonden om te ontkoppelen en opnieuw te koppelen aan de nieuwe code
 #
-# LinkAccountChannel: De kanaal-ID van het kanaal waarnaar de speler zijn linkcode moet sturen. Bewaar deze als "000000000000000000" voor DM's.
+# LinkAccountChannel: De kanaal-ID van het kanaal waarnaar de speler zijn linkcode moet sturen. Bewaar deze als "000000000000000000" voor DM's. Zorg ervoor dat u CodeGenerated in messages.yml bijwerkt wanneer u deze waarde wijzigt.
 # LinkAccountDeleteCode: Of codes die zijn verzonden in het LinkAccountChannel moeten worden verwijderd nadat ze zijn verzonden. Werkt alleen als LinkAccountChannel is ingesteld.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]

--- a/src/main/resources/config/pl.yml
+++ b/src/main/resources/config/pl.yml
@@ -277,7 +277,7 @@ MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-LinkAccountChannel: 0
+LinkAccountChannel: 000000000000000000
 LinkAccountDeleteCode: false
 
 # Watchdog serwera

--- a/src/main/resources/config/pl.yml
+++ b/src/main/resources/config/pl.yml
@@ -271,6 +271,8 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: nazwa roli niezgody, do której należy dodać użytkownika niezgody po połączeniu konta
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: umożliwia wysłanie nowego kodu do bota w celu odłączenia i ponownego połączenia z nowym kodem
 #
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"

--- a/src/main/resources/config/pl.yml
+++ b/src/main/resources/config/pl.yml
@@ -271,7 +271,7 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: nazwa roli niezgody, do której należy dodać użytkownika niezgody po połączeniu konta
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: umożliwia wysłanie nowego kodu do bota w celu odłączenia i ponownego połączenia z nowym kodem
 #
-# LinkAccountChannel: Identyfikator kanału, na który gracz powinien wysłać swój kod linku. W przypadku czatów zachowaj go jako „0000000000000000000”.
+# LinkAccountChannel: Identyfikator kanału, na który gracz powinien wysłać swój kod linku. W przypadku czatów zachowaj go jako „0000000000000000000”. Pamiętaj, aby zaktualizować CodeGenerated w messages.yml podczas zmiany tej wartości.
 # LinkAccountDeleteCode: Czy usuwać kody wysłane w LinkAccountChannel po ich wysłaniu. Działa tylko wtedy, gdy ustawiono LinkAccountChannel.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]

--- a/src/main/resources/config/pl.yml
+++ b/src/main/resources/config/pl.yml
@@ -272,13 +272,13 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: umożliwia wysłanie nowego kodu do bota w celu odłączenia i ponownego połączenia z nowym kodem
 #
 # LinkAccountChannel: Identyfikator kanału, na który gracz powinien wysłać swój kod linku. W przypadku czatów zachowaj go jako „0000000000000000000”. Pamiętaj, aby zaktualizować CodeGenerated w messages.yml podczas zmiany tej wartości.
-# LinkAccountDeleteCode: Czy usuwać kody wysłane w LinkAccountChannel po ich wysłaniu. Działa tylko wtedy, gdy ustawiono LinkAccountChannel.
+# LinkAccountChannelDeleteCode: Czy usuwać kody wysłane w LinkAccountChannel po ich wysłaniu. Działa tylko wtedy, gdy ustawiono LinkAccountChannel.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 LinkAccountChannel: 000000000000000000
-LinkAccountDeleteCode: false
+LinkAccountChannelDeleteCode: false
 
 # Watchdog serwera
 #

--- a/src/main/resources/config/pl.yml
+++ b/src/main/resources/config/pl.yml
@@ -271,8 +271,8 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: nazwa roli niezgody, do której należy dodać użytkownika niezgody po połączeniu konta
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: umożliwia wysłanie nowego kodu do bota w celu odłączenia i ponownego połączenia z nowym kodem
 #
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+# LinkAccountChannel: Identyfikator kanału, na który gracz powinien wysłać swój kod linku. W przypadku czatów zachowaj go jako „0000000000000000000”.
+# LinkAccountDeleteCode: Czy usuwać kody wysłane w LinkAccountChannel po ich wysłaniu. Działa tylko wtedy, gdy ustawiono LinkAccountChannel.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"

--- a/src/main/resources/config/pl.yml
+++ b/src/main/resources/config/pl.yml
@@ -275,6 +275,8 @@ MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false
 
 # Watchdog serwera
 #
@@ -290,8 +292,4 @@ ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 30
 ServerWatchdogMessageCount: 3
 
-# Link Account Channel Configuration
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
-LinkAccountChannel: 0
-LinkAccountDeleteCode: false
+

--- a/src/main/resources/config/pl.yml
+++ b/src/main/resources/config/pl.yml
@@ -289,3 +289,9 @@ MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 30
 ServerWatchdogMessageCount: 3
+
+# Link Account Channel Configuration
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false

--- a/src/main/resources/config/ru.yml
+++ b/src/main/resources/config/ru.yml
@@ -271,7 +271,7 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: имя Discord роли, в которую будут добавлены пользователи, после того как привяжут свои аккаунты
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: можно ли отправить новый код боту, чтобы перепривязать аккаунт
 #
-# LinkAccountChannel: Идентификатор канала, на который игрок должен отправить свой код ссылки. Сохраните его как «000000000000000000» для личных сообщений.
+# LinkAccountChannel: Идентификатор канала, на который игрок должен отправить свой код ссылки. Сохраните его как «000000000000000000» для личных сообщений. Обязательно обновите CodeGenerated в messages.yml при изменении этого значения.
 # LinkAccountDeleteCode: Следует ли удалять коды, отправленные в LinkAccountChannel, после их отправки. Работает, только если установлен LinkAccountChannel.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]

--- a/src/main/resources/config/ru.yml
+++ b/src/main/resources/config/ru.yml
@@ -277,7 +277,7 @@ MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-LinkAccountChannel: 0
+LinkAccountChannel: 000000000000000000
 LinkAccountDeleteCode: false
 
 # Мониторинг сервера

--- a/src/main/resources/config/ru.yml
+++ b/src/main/resources/config/ru.yml
@@ -275,6 +275,8 @@ MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false
 
 # Мониторинг сервера
 #
@@ -290,8 +292,3 @@ ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 30
 ServerWatchdogMessageCount: 3
 
-# Link Account Channel Configuration
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
-LinkAccountChannel: 0
-LinkAccountDeleteCode: false

--- a/src/main/resources/config/ru.yml
+++ b/src/main/resources/config/ru.yml
@@ -272,13 +272,13 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: можно ли отправить новый код боту, чтобы перепривязать аккаунт
 #
 # LinkAccountChannel: Идентификатор канала, на который игрок должен отправить свой код ссылки. Сохраните его как «000000000000000000» для личных сообщений. Обязательно обновите CodeGenerated в messages.yml при изменении этого значения.
-# LinkAccountDeleteCode: Следует ли удалять коды, отправленные в LinkAccountChannel, после их отправки. Работает, только если установлен LinkAccountChannel.
+# LinkAccountChannelDeleteCode: Следует ли удалять коды, отправленные в LinkAccountChannel, после их отправки. Работает, только если установлен LinkAccountChannel.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 LinkAccountChannel: 000000000000000000
-LinkAccountDeleteCode: false
+LinkAccountChannelDeleteCode: false
 
 # Мониторинг сервера
 #

--- a/src/main/resources/config/ru.yml
+++ b/src/main/resources/config/ru.yml
@@ -271,6 +271,8 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: имя Discord роли, в которую будут добавлены пользователи, после того как привяжут свои аккаунты
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: можно ли отправить новый код боту, чтобы перепривязать аккаунт
 #
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"

--- a/src/main/resources/config/ru.yml
+++ b/src/main/resources/config/ru.yml
@@ -289,3 +289,9 @@ MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 30
 ServerWatchdogMessageCount: 3
+
+# Link Account Channel Configuration
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false

--- a/src/main/resources/config/ru.yml
+++ b/src/main/resources/config/ru.yml
@@ -271,8 +271,8 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: имя Discord роли, в которую будут добавлены пользователи, после того как привяжут свои аккаунты
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: можно ли отправить новый код боту, чтобы перепривязать аккаунт
 #
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+# LinkAccountChannel: Идентификатор канала, на который игрок должен отправить свой код ссылки. Сохраните его как «000000000000000000» для личных сообщений.
+# LinkAccountDeleteCode: Следует ли удалять коды, отправленные в LinkAccountChannel, после их отправки. Работает, только если установлен LinkAccountChannel.
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"

--- a/src/main/resources/config/zh.yml
+++ b/src/main/resources/config/zh.yml
@@ -290,3 +290,9 @@ MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 30
 ServerWatchdogMessageCount: 3
+
+# Link Account Channel Configuration
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false

--- a/src/main/resources/config/zh.yml
+++ b/src/main/resources/config/zh.yml
@@ -272,8 +272,8 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: 當使用者已連結帳號時將其加入該身分組
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 允许向机器人发送新代码以取消链接并与新代码重新链接
 #
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
+# LinkAccountChannel: 玩家应发送链接代码的频道的频道 ID。对于 DM，将其保留为“000000000000000000”。
+# LinkAccountDeleteCode: LinkAccountChannel 中发送的代码发送后是否删除。仅在设置了 LinkAccountChannel 时才有效。
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"

--- a/src/main/resources/config/zh.yml
+++ b/src/main/resources/config/zh.yml
@@ -273,13 +273,13 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 允许向机器人发送新代码以取消链接并与新代码重新链接
 #
 # LinkAccountChannel: 玩家应发送链接代码的频道的频道 ID。对于 DM，将其保留为“000000000000000000”。更改此值时，请务必更新 messages.yml 中的 CodeGenerated。
-# LinkAccountDeleteCode: LinkAccountChannel 中发送的代码发送后是否删除。仅在设置了 LinkAccountChannel 时才有效。
+# LinkAccountChannelDeleteCode: LinkAccountChannel 中发送的代码发送后是否删除。仅在设置了 LinkAccountChannel 时才有效。
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 LinkAccountChannel: 000000000000000000
-LinkAccountDeleteCode: false
+LinkAccountChannelDeleteCode: false
 
 # 伺服器監視器
 #

--- a/src/main/resources/config/zh.yml
+++ b/src/main/resources/config/zh.yml
@@ -276,6 +276,8 @@ MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+LinkAccountChannel: 0
+LinkAccountDeleteCode: false
 
 # 伺服器監視器
 #
@@ -290,9 +292,3 @@ MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 ServerWatchdogEnabled: true
 ServerWatchdogTimeout: 30
 ServerWatchdogMessageCount: 3
-
-# Link Account Channel Configuration
-# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
-# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
-LinkAccountChannel: 0
-LinkAccountDeleteCode: false

--- a/src/main/resources/config/zh.yml
+++ b/src/main/resources/config/zh.yml
@@ -272,6 +272,8 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: 當使用者已連結帳號時將其加入該身分組
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 允许向机器人发送新代码以取消链接并与新代码重新链接
 #
+# LinkAccountChannel: Channel id of channel user should send code in. Leave 0 for dms
+# LinkAccountDeleteCode: Delete code sent in channel after its sent. Only works if it's not a dm channel
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"

--- a/src/main/resources/config/zh.yml
+++ b/src/main/resources/config/zh.yml
@@ -278,7 +278,7 @@ MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-LinkAccountChannel: 0
+LinkAccountChannel: 000000000000000000
 LinkAccountDeleteCode: false
 
 # 伺服器監視器

--- a/src/main/resources/config/zh.yml
+++ b/src/main/resources/config/zh.yml
@@ -272,7 +272,7 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: 當使用者已連結帳號時將其加入該身分組
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 允许向机器人发送新代码以取消链接并与新代码重新链接
 #
-# LinkAccountChannel: 玩家应发送链接代码的频道的频道 ID。对于 DM，将其保留为“000000000000000000”。
+# LinkAccountChannel: 玩家应发送链接代码的频道的频道 ID。对于 DM，将其保留为“000000000000000000”。更改此值时，请务必更新 messages.yml 中的 CodeGenerated。
 # LinkAccountDeleteCode: LinkAccountChannel 中发送的代码发送后是否删除。仅在设置了 LinkAccountChannel 时才有效。
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]


### PR DESCRIPTION
This feature was requested years ago and you never added it. So here i do it for you

DiscordPrivateMessageReceivedEvent is no longer fired in the linkaccount listener. I don't know how you guys would like to do with it. So i just removed it completely. Let me know if you want me to do something else