### PR TITLE
Implement degraded client notice & legacifying of messages for LunarClient

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -52,6 +52,7 @@ import github.scarsz.discordsrv.objects.log4j.JdaFilter;
 import github.scarsz.discordsrv.objects.managers.AccountLinkManager;
 import github.scarsz.discordsrv.objects.managers.CommandManager;
 import github.scarsz.discordsrv.objects.managers.GroupSynchronizationManager;
+import github.scarsz.discordsrv.objects.managers.IncompatibleClientManager;
 import github.scarsz.discordsrv.objects.managers.link.FileAccountLinkManager;
 import github.scarsz.discordsrv.objects.managers.link.JdbcAccountLinkManager;
 import github.scarsz.discordsrv.objects.threads.*;
@@ -155,6 +156,7 @@ public class DiscordSRV extends JavaPlugin {
     @Getter private AccountLinkManager accountLinkManager;
     @Getter private CommandManager commandManager = new CommandManager();
     @Getter private GroupSynchronizationManager groupSynchronizationManager = new GroupSynchronizationManager();
+    @Getter private IncompatibleClientManager incompatibleClientManager = new IncompatibleClientManager();
 
     // Threads
     @Getter private ChannelTopicUpdater channelTopicUpdater;
@@ -1085,6 +1087,10 @@ public class DiscordSRV extends JavaPlugin {
         } catch (Exception ignored) {
             new PlayerAchievementsListener();
         }
+
+        // register incompatible client manager
+        Bukkit.getPluginManager().registerEvents(incompatibleClientManager, this);
+        Bukkit.getMessenger().registerIncomingPluginChannel(this, "lunarclient:pm", incompatibleClientManager);
 
         // plugin hooks
         for (String hookClassName : new String[]{

--- a/src/main/java/github/scarsz/discordsrv/objects/managers/IncompatibleClientManager.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/managers/IncompatibleClientManager.java
@@ -1,0 +1,119 @@
+/*-
+ * LICENSE
+ * DiscordSRV
+ * -------------
+ * Copyright (C) 2016 - 2021 Austin "Scarsz" Shapiro
+ * -------------
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * END
+ */
+
+package github.scarsz.discordsrv.objects.managers;
+
+import github.scarsz.discordsrv.DiscordSRV;
+import github.scarsz.discordsrv.util.LangUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+
+public class IncompatibleClientManager implements PluginMessageListener, Listener {
+
+    private static final Method CLIENT_BRAND_NAME_METHOD;
+
+    static {
+        Method method = null;
+        try {
+            method = Player.class.getMethod("getClientBrandName");
+        } catch (NoSuchMethodError | NoSuchMethodException ignored) {}
+        CLIENT_BRAND_NAME_METHOD = method;
+    }
+
+    private final Set<UUID> incompatibleClients = new HashSet<>();
+
+    public boolean isIncompatible(Player player) {
+        return incompatibleClients.contains(player.getUniqueId());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        if (CLIENT_BRAND_NAME_METHOD == null) return;
+
+        // Client brand is not available during this time, so we run check brand 2s and 10s after this point
+        Bukkit.getScheduler().runTaskLaterAsynchronously(
+                DiscordSRV.getPlugin(), () -> checkBrand(event.getPlayer()), 40L);
+        Bukkit.getScheduler().runTaskLaterAsynchronously(
+                DiscordSRV.getPlugin(), () -> checkBrand(event.getPlayer()), 200L);
+    }
+
+    private void checkBrand(Player player) {
+        if (player == null || !player.isOnline()) {
+            return;
+        }
+
+        String brand;
+        try {
+            brand = (String) CLIENT_BRAND_NAME_METHOD.invoke(player);
+        } catch (IllegalAccessException | InvocationTargetException ignored) {
+            return;
+        }
+
+        if (brand != null && brand.toLowerCase(Locale.ROOT).startsWith("lunarclient")) {
+            addIncompatible(player, "LunarClient");
+        }
+    }
+
+    @Override
+    public void onPluginMessageReceived(@NotNull String channel, @NotNull Player player, byte[] bytes) {
+        if (channel.toLowerCase(Locale.ROOT).startsWith("lunarclient")) {
+            addIncompatible(player, "LunarClient");
+        }
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void addIncompatible(Player player, String client) {
+        if (!incompatibleClients.add(player.getUniqueId())) {
+            return;
+        }
+
+        if (!DiscordSRV.config().getBooleanElse("EnableIncompatibleClientAlert", true)) {
+            return;
+        }
+
+        // Skip Adventure for this in case the client can't even receive that
+        player.sendMessage(ChatColor.RED + LangUtil.InternalMessage.INCOMPATIBLE_CLIENT.toString().replace("{client}", client));
+
+        DiscordSRV.info(player.getName() + " was sent a notice for having a degraded user experience due to " + client
+                                + " (You can use EnableIncompatibleClientAlert to disable the message if you'd like (Not recommended))");
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        incompatibleClients.remove(event.getPlayer().getUniqueId());
+    }
+}

--- a/src/main/java/github/scarsz/discordsrv/objects/managers/IncompatibleClientManager.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/managers/IncompatibleClientManager.java
@@ -32,6 +32,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerRegisterChannelEvent;
 import org.bukkit.plugin.messaging.PluginMessageListener;
 import org.jetbrains.annotations.NotNull;
 
@@ -88,8 +89,17 @@ public class IncompatibleClientManager implements PluginMessageListener, Listene
         }
     }
 
+    @EventHandler
+    public void onPlayerRegisterChannel(PlayerRegisterChannelEvent event) {
+        checkChannel(event.getPlayer(), event.getChannel());
+    }
+
     @Override
     public void onPluginMessageReceived(@NotNull String channel, @NotNull Player player, byte[] bytes) {
+        checkChannel(player, channel);
+    }
+
+    private void checkChannel(Player player, String channel) {
         if (channel.toLowerCase(Locale.ROOT).startsWith("lunarclient")) {
             addIncompatible(player, "LunarClient");
         }

--- a/src/main/java/github/scarsz/discordsrv/util/LangUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/LangUtil.java
@@ -315,6 +315,18 @@ public class LangUtil {
                     "w tym między innymi prywatne wiadomości lub wiadomości na czacie graczy bez /komend\n" +
                     "\n" +
                     "\n");
+        }}), INCOMPATIBLE_CLIENT(new HashMap<Language, String>() {{
+            put(Language.EN, "Your user experience is degraded due to using {client}, some commands may not work as expected.");
+            put(Language.FR, "Votre expérience utilisateur est dégradée en raison de l'utilisation de {client}, certaines commandes peuvent ne pas fonctionner comme prévu.");
+            put(Language.DE, "Ihre Benutzererfahrung ist durch die Verwendung von {client} beeinträchtigt. Einige Befehle funktionieren möglicherweise nicht wie erwartet.");
+            put(Language.JA, "{client}を使用しているため、ユーザーエクスペリエンスが低下し、一部のコマンドが期待どおりに機能しない場合があります。 ");
+            put(Language.KO, "{client} 사용으로 인해 사용자 경험이 저하되고 일부 명령이 예상대로 작동하지 않을 수 있습니다.");
+            put(Language.NL, "Uw gebruikerservaring is verslechterd door het gebruik van {client}. Sommige opdrachten werken mogelijk niet zoals verwacht.");
+            put(Language.ES, "Su experiencia de usuario se degrada debido al uso de {cliente}, es posible que algunos comandos no funcionen como se esperaba.");
+            put(Language.RU, "Ваше взаимодействие с пользователем ухудшается из-за использования {client}, некоторые команды могут работать не так, как ожидалось.");
+            put(Language.ET, "Teie kasutuskogemus on {client} kasutamise tõttu halvenenud, mõned käsud ei pruugi ootuspäraselt töötada.");
+            put(Language.ZH, "您的用户体验因使用 {client} 而下降，某些命令可能无法按预期工作。");
+            put(Language.PL, "Twoje doświadczenie użytkownika jest pogorszone z powodu korzystania z {client}, niektóre polecenia mogą nie działać zgodnie z oczekiwaniami.");
         }}), CONSOLE_FORWARDING_ASSIGNED_TO_CHANNEL(new HashMap<Language, String>() {{
             put(Language.EN, "Console forwarding assigned to channel");
             put(Language.FR, "Réacheminement de la console affecté au canal");

--- a/src/main/java/github/scarsz/discordsrv/util/MessageUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/MessageUtil.java
@@ -45,6 +45,7 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
 import java.util.*;
 import java.util.regex.Matcher;
@@ -339,9 +340,26 @@ public class MessageUtil {
      */
     public static void sendMessage(Iterable<? extends CommandSender> commandSenders, Component adventureMessage) {
         Set<Audience> audiences = new HashSet<>();
-        commandSenders.forEach(sender -> audiences.add(getAudiences().sender(sender)));
+        Set<Audience> degradedAudiences = new HashSet<>();
+        commandSenders.forEach(sender -> {
+            Audience audience = getAudiences().sender(sender);
+            if (sender instanceof Player && DiscordSRV.getPlugin().getIncompatibleClientManager().isIncompatible((Player) sender)) {
+                degradedAudiences.add(audience);
+            } else {
+                audiences.add(audience);
+            }
+        });
+
         try {
-            Audience.audience(audiences).sendMessage(Identity.nil(), adventureMessage);
+            if (!audiences.isEmpty()) {
+                Audience.audience(audiences).sendMessage(Identity.nil(), adventureMessage);
+            }
+
+            if (!degradedAudiences.isEmpty()) {
+                // Put it through legacy serializer for degraded audiences
+                Component degraded = LEGACY_SERIALIZER.deserialize(LEGACY_SERIALIZER.serialize(adventureMessage));
+                Audience.audience(degradedAudiences).sendMessage(Identity.nil(), degraded);
+            }
         } catch (NoClassDefFoundError e) {
             // might happen with 1.7
             if (e.getMessage().equals("org/bukkit/command/ProxiedCommandSender")) {

--- a/src/main/resources/config/de.yml
+++ b/src/main/resources/config/de.yml
@@ -95,6 +95,9 @@ Experiment_MCDiscordReserializer_InBroadcast: false
 
 # Andere
 CancelConsoleCommandIfLoggingFailed: true
+# LunarClient does not support hover/click components in messages. Users of LunarClient will receive an automated
+# message stating that their user experience is worsened by the use of the client, if this option is enabled
+EnableIncompatibleClientAlert: true
 ForcedLanguage: none
 PrintGuildsAndChannels: true
 ForceTLSv12: true

--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -95,6 +95,9 @@ Experiment_MCDiscordReserializer_InBroadcast: false
 
 # Other
 CancelConsoleCommandIfLoggingFailed: true
+# LunarClient does not support hover/click components in messages. Users of LunarClient will receive an automated
+# message stating that their user experience is worsened by the use of the client, if this option is enabled
+EnableIncompatibleClientAlert: true
 ForcedLanguage: none
 PrintGuildsAndChannels: true
 ForceTLSv12: true

--- a/src/main/resources/config/es.yml
+++ b/src/main/resources/config/es.yml
@@ -95,6 +95,9 @@ Experiment_MCDiscordReserializer_InBroadcast: false
 
 # Otras
 CancelConsoleCommandIfLoggingFailed: true
+# LunarClient does not support hover/click components in messages. Users of LunarClient will receive an automated
+# message stating that their user experience is worsened by the use of the client, if this option is enabled
+EnableIncompatibleClientAlert: true
 ForcedLanguage: none
 PrintGuildsAndChannels: true
 ForceTLSv12: true

--- a/src/main/resources/config/et.yml
+++ b/src/main/resources/config/et.yml
@@ -95,6 +95,9 @@ Experiment_MCDiscordReserializer_InBroadcast: false
 
 # Other
 CancelConsoleCommandIfLoggingFailed: true
+# LunarClient does not support hover/click components in messages. Users of LunarClient will receive an automated
+# message stating that their user experience is worsened by the use of the client, if this option is enabled
+EnableIncompatibleClientAlert: true
 ForcedLanguage: none
 PrintGuildsAndChannels: true
 ForceTLSv12: true

--- a/src/main/resources/config/fr.yml
+++ b/src/main/resources/config/fr.yml
@@ -95,6 +95,9 @@ Experiment_MCDiscordReserializer_InBroadcast: false
 
 # Autres
 CancelConsoleCommandIfLoggingFailed: true
+# LunarClient does not support hover/click components in messages. Users of LunarClient will receive an automated
+# message stating that their user experience is worsened by the use of the client, if this option is enabled
+EnableIncompatibleClientAlert: true
 ForcedLanguage: none
 PrintGuildsAndChannels: true
 ForceTLSv12: true

--- a/src/main/resources/config/ja.yml
+++ b/src/main/resources/config/ja.yml
@@ -95,6 +95,9 @@ Experiment_MCDiscordReserializer_InBroadcast: false
 
 # その他
 CancelConsoleCommandIfLoggingFailed: true
+# LunarClient does not support hover/click components in messages. Users of LunarClient will receive an automated
+# message stating that their user experience is worsened by the use of the client, if this option is enabled
+EnableIncompatibleClientAlert: true
 ForcedLanguage: none
 PrintGuildsAndChannels: true
 ForceTLSv12: true

--- a/src/main/resources/config/ko.yml
+++ b/src/main/resources/config/ko.yml
@@ -96,6 +96,9 @@ Experiment_MCDiscordReserializer_InBroadcast: false
 
 # 다른
 CancelConsoleCommandIfLoggingFailed: true
+# LunarClient does not support hover/click components in messages. Users of LunarClient will receive an automated
+# message stating that their user experience is worsened by the use of the client, if this option is enabled
+EnableIncompatibleClientAlert: true
 ForcedLanguage: none
 PrintGuildsAndChannels: true
 ForceTLSv12: true

--- a/src/main/resources/config/nl.yml
+++ b/src/main/resources/config/nl.yml
@@ -95,6 +95,9 @@ Experiment_MCDiscordReserializer_InBroadcast: false
 
 # Andere
 CancelConsoleCommandIfLoggingFailed: true
+# LunarClient does not support hover/click components in messages. Users of LunarClient will receive an automated
+# message stating that their user experience is worsened by the use of the client, if this option is enabled
+EnableIncompatibleClientAlert: true
 ForcedLanguage: none
 PrintGuildsAndChannels: true
 ForceTLSv12: true

--- a/src/main/resources/config/pl.yml
+++ b/src/main/resources/config/pl.yml
@@ -95,6 +95,9 @@ Experiment_MCDiscordReserializer_InBroadcast: false
 
 # Inny
 CancelConsoleCommandIfLoggingFailed: true
+# LunarClient does not support hover/click components in messages. Users of LunarClient will receive an automated
+# message stating that their user experience is worsened by the use of the client, if this option is enabled
+EnableIncompatibleClientAlert: true
 ForcedLanguage: none
 PrintGuildsAndChannels: true
 ForceTLSv12: true

--- a/src/main/resources/config/ru.yml
+++ b/src/main/resources/config/ru.yml
@@ -95,6 +95,9 @@ Experiment_MCDiscordReserializer_InBroadcast: false
 
 # Другие
 CancelConsoleCommandIfLoggingFailed: true
+# LunarClient does not support hover/click components in messages. Users of LunarClient will receive an automated
+# message stating that their user experience is worsened by the use of the client, if this option is enabled
+EnableIncompatibleClientAlert: true
 ForcedLanguage: none
 PrintGuildsAndChannels: true
 ForceTLSv12: true

--- a/src/main/resources/config/zh.yml
+++ b/src/main/resources/config/zh.yml
@@ -97,6 +97,9 @@ Experiment_MCDiscordReserializer_InBroadcast: false
 
 # 其他
 CancelConsoleCommandIfLoggingFailed: true
+# LunarClient does not support hover/click components in messages. Users of LunarClient will receive an automated
+# message stating that their user experience is worsened by the use of the client, if this option is enabled
+EnableIncompatibleClientAlert: true
 ForcedLanguage: none
 PrintGuildsAndChannels: true
 ForceTLSv12: true


### PR DESCRIPTION
For users stumbling upon this PR,

Due to LunarClient hiding messages containing click to copy functionality (this also happens for vanilla commands, eg. the `/seed` command) and not showing any intention to fix this even after being notified of the issue (multiple times over 5+ months), we have decided to add a notification for users using LunarClient letting them know that some commands may not work as expected, as this functionality should work as it does on the vanilla client instead of **completely hiding the message**.

[Image](https://i.imgur.com/uyU5RyV.png) of their support *manually* closing a ticket without comment regarding this issue. The ticket was closed before the last message. The last message was sent in hopes of response to no avail.