### PR TITLE
Fire discordsrv events when processing venture chat messages from VentureChatEvent

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/api/events/GameChatMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/GameChatMessagePostProcessEvent.java
@@ -30,6 +30,8 @@ import org.bukkit.event.Cancellable;
 /**
  * <p>Called after DiscordSRV has processed a Minecraft chat message but before being sent to Discord.
  * Modification is allow and will effect the message sent to Discord.</p>
+ * 
+ * <p>If a messages is coming from VentureChat over Bungee then {@link VentureChatMessagePostProcessEvent} would be called instead</p>
  */
 public class GameChatMessagePostProcessEvent extends GameEvent implements Cancellable {
 

--- a/src/main/java/github/scarsz/discordsrv/api/events/GameChatMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/GameChatMessagePostProcessEvent.java
@@ -31,7 +31,7 @@ import org.bukkit.event.Cancellable;
  * <p>Called after DiscordSRV has processed a Minecraft chat message but before being sent to Discord.
  * Modification is allow and will effect the message sent to Discord.</p>
  * 
- * <p>If a messages is coming from VentureChat over Bungee then {@link VentureChatMessagePostProcessEvent} would be called instead</p>
+ * <p>If a messages is coming from VentureChat over Bungee then {@link VentureChatMessagePostProcessEvent} would be called instead, due to the lack of the Player object</p>
  */
 public class GameChatMessagePostProcessEvent extends GameEvent implements Cancellable {
 

--- a/src/main/java/github/scarsz/discordsrv/api/events/GameChatMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/GameChatMessagePreProcessEvent.java
@@ -35,6 +35,8 @@ import org.bukkit.event.Cancellable;
  * <p>At the time this event is called, {@link #getMessage()} would return what the person <i>said</i>, not
  * the final message. You could change what they said using the {@link #setMessage(String)} method or use
  * {@link #setCancelled(boolean)} to cancel it from being processed altogether</p>
+ * 
+ * <p>If a messages is coming from VentureChat over Bungee then {@link VentureChatMessagePreProcessEvent} would be called instead</p>
  */
 public class GameChatMessagePreProcessEvent extends GameEvent implements Cancellable {
 

--- a/src/main/java/github/scarsz/discordsrv/api/events/GameChatMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/GameChatMessagePreProcessEvent.java
@@ -36,7 +36,7 @@ import org.bukkit.event.Cancellable;
  * the final message. You could change what they said using the {@link #setMessage(String)} method or use
  * {@link #setCancelled(boolean)} to cancel it from being processed altogether</p>
  * 
- * <p>If a messages is coming from VentureChat over Bungee then {@link VentureChatMessagePreProcessEvent} would be called instead</p>
+ * <p>If a messages is coming from VentureChat over Bungee then {@link VentureChatMessagePreProcessEvent} would be called instead, due to the lack of the Player object</p>
  */
 public class GameChatMessagePreProcessEvent extends GameEvent implements Cancellable {
 

--- a/src/main/java/github/scarsz/discordsrv/api/events/VentureChatEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/VentureChatEvent.java
@@ -1,0 +1,36 @@
+/*-
+ * LICENSE
+ * DiscordSRV
+ * -------------
+ * Copyright (C) 2016 - 2021 Austin "Scarsz" Shapiro
+ * -------------
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * END
+ */
+
+package github.scarsz.discordsrv.api.events;
+
+import lombok.Getter;
+import mineverse.Aust1n46.chat.api.events.VentureChatEvent;
+
+abstract class VentureChatMessageEvent extends Event {
+
+    @Getter final private VentureChatEvent ventureChatEvent;
+
+    VentureChatMessageEvent(VentureChatEvent ventureChatEvent) {
+        this.ventureChatEvent = ventureChatEvent;
+    }
+
+}

--- a/src/main/java/github/scarsz/discordsrv/api/events/VentureChatMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/VentureChatMessagePostProcessEvent.java
@@ -29,7 +29,7 @@ import lombok.Setter;
 import mineverse.Aust1n46.chat.api.events.VentureChatEvent;
 
 /**
- * <p>Called after DiscordSRV has processed a Minecraft chat message but before being sent to Discord.
+ * <p>Called after DiscordSRV has processed a VentureChat message but before being sent to Discord.
  * Modification is allow and will effect the message sent to Discord.</p>
  */
 public class VentureChatMessagePostProcessEvent extends VentureChatMessageEvent implements Cancellable {

--- a/src/main/java/github/scarsz/discordsrv/api/events/VentureChatMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/VentureChatMessagePostProcessEvent.java
@@ -1,0 +1,49 @@
+/*-
+ * LICENSE
+ * DiscordSRV
+ * -------------
+ * Copyright (C) 2016 - 2021 Austin "Scarsz" Shapiro
+ * -------------
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * END
+ */
+
+package github.scarsz.discordsrv.api.events;
+
+import org.bukkit.event.Cancellable;
+
+import lombok.Getter;
+import lombok.Setter;
+import mineverse.Aust1n46.chat.api.events.VentureChatEvent;
+
+/**
+ * <p>Called after DiscordSRV has processed a Minecraft chat message but before being sent to Discord.
+ * Modification is allow and will effect the message sent to Discord.</p>
+ */
+public class VentureChatMessagePostProcessEvent extends VentureChatMessageEvent implements Cancellable {
+
+    @Getter @Setter private boolean cancelled;
+
+    @Getter @Setter private String channel;
+    @Getter @Setter private String processedMessage;
+
+    public VentureChatMessagePostProcessEvent(String channel, String processedMessage, VentureChatEvent ventureChatEvent, boolean cancelled) {
+        super(ventureChatEvent);
+        this.channel = channel;
+        this.processedMessage = processedMessage;
+        setCancelled(cancelled);
+    }
+
+}

--- a/src/main/java/github/scarsz/discordsrv/api/events/VentureChatMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/VentureChatMessagePostProcessEvent.java
@@ -29,7 +29,7 @@ import lombok.Setter;
 import mineverse.Aust1n46.chat.api.events.VentureChatEvent;
 
 /**
- * <p>Called after DiscordSRV has processed a VentureChat message but before being sent to Discord.
+ * <p>Called after DiscordSRV has processed a VentureChat message from Bungee (when the VentureChatBungee config option is enabled) but before being sent to Discord.
  * Modification is allow and will effect the message sent to Discord.</p>
  */
 public class VentureChatMessagePostProcessEvent extends VentureChatMessageEvent implements Cancellable {

--- a/src/main/java/github/scarsz/discordsrv/api/events/VentureChatMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/VentureChatMessagePreProcessEvent.java
@@ -1,0 +1,68 @@
+/*-
+ * LICENSE
+ * DiscordSRV
+ * -------------
+ * Copyright (C) 2016 - 2021 Austin "Scarsz" Shapiro
+ * -------------
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * END
+ */
+
+package github.scarsz.discordsrv.api.events;
+
+import github.scarsz.discordsrv.util.MessageUtil;
+import lombok.Getter;
+import lombok.Setter;
+import mineverse.Aust1n46.chat.api.events.VentureChatEvent;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+
+/**
+ * <p>Called before DiscordSRV has processed a Minecraft chat message, modifications may be overwritten by DiscordSRV's processing.</p>
+ *
+ * <p>At the time this event is called, {@link #getMessage()} would return what the person <i>said</i>, not
+ * the final message. You could change what they said using the {@link #setMessage(String)} method or use
+ * {@link #setCancelled(boolean)} to cancel it from being processed altogether</p>
+ */
+public class VentureChatMessagePreProcessEvent extends VentureChatMessageEvent implements Cancellable {
+
+    @Getter @Setter private boolean cancelled;
+
+    @Getter @Setter private String channel;
+    @Getter @Setter private Component messageComponent;
+
+    public VentureChatMessagePreProcessEvent(String channel, Component message, VentureChatEvent ventureChatEvent) {
+        super(ventureChatEvent);
+        this.channel = channel;
+        this.messageComponent = message;
+    }
+
+    @Deprecated
+    public VentureChatMessagePreProcessEvent(String channel, String message, VentureChatEvent ventureChatEvent) {
+        this(channel, MessageUtil.toComponent(message, true), ventureChatEvent);
+    }
+
+    @Deprecated
+    public String getMessage() {
+        return MessageUtil.toLegacy(messageComponent);
+    }
+
+    @Deprecated
+    public void setMessage(String legacy) {
+        this.messageComponent = MessageUtil.toComponent(legacy, true);
+    }
+
+}

--- a/src/main/java/github/scarsz/discordsrv/api/events/VentureChatMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/VentureChatMessagePreProcessEvent.java
@@ -31,7 +31,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 
 /**
- * <p>Called before DiscordSRV has processed a Minecraft chat message, modifications may be overwritten by DiscordSRV's processing.</p>
+ * <p>Called before DiscordSRV has processed a VentureChat message, modifications may be overwritten by DiscordSRV's processing.</p>
  *
  * <p>At the time this event is called, {@link #getMessage()} would return what the person <i>said</i>, not
  * the final message. You could change what they said using the {@link #setMessage(String)} method or use

--- a/src/main/java/github/scarsz/discordsrv/api/events/VentureChatMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/VentureChatMessagePreProcessEvent.java
@@ -31,7 +31,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 
 /**
- * <p>Called before DiscordSRV has processed a VentureChat message, modifications may be overwritten by DiscordSRV's processing.</p>
+ * <p>Called before DiscordSRV has processed a VentureChat message from Bungee (when the VentureChatBungee config option is enabled), modifications may be overwritten by DiscordSRV's processing.</p>
  *
  * <p>At the time this event is called, {@link #getMessage()} would return what the person <i>said</i>, not
  * the final message. You could change what they said using the {@link #setMessage(String)} method or use

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/VentureChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/VentureChatHook.java
@@ -25,8 +25,6 @@ package github.scarsz.discordsrv.hooks.chat;
 import com.comphenix.protocol.events.PacketContainer;
 import github.scarsz.discordsrv.Debug;
 import github.scarsz.discordsrv.DiscordSRV;
-import github.scarsz.discordsrv.api.events.GameChatMessagePostProcessEvent;
-import github.scarsz.discordsrv.api.events.GameChatMessagePreProcessEvent;
 import github.scarsz.discordsrv.api.events.VentureChatMessagePostProcessEvent;
 import github.scarsz.discordsrv.api.events.VentureChatMessagePreProcessEvent;
 import github.scarsz.discordsrv.util.*;

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/VentureChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/VentureChatHook.java
@@ -117,7 +117,7 @@ public class VentureChatHook implements ChatHook {
         
         VentureChatMessagePreProcessEvent preEvent = DiscordSRV.api.callEvent(new VentureChatMessagePreProcessEvent(channel, message, event));
         if (preEvent.isCancelled()) {
-            DiscordSRV.debug(Debug.MINECRAFT_TO_DISCORD, "GameChatMessagePreProcessEvent was cancelled, message send aborted");
+            DiscordSRV.debug(Debug.MINECRAFT_TO_DISCORD, "VentureChatMessagePreProcessEvent was cancelled, message send aborted");
             return;
         }
         channel = preEvent.getChannel(); // update channel from event in case any listeners modified it
@@ -168,7 +168,7 @@ public class VentureChatHook implements ChatHook {
         
         VentureChatMessagePostProcessEvent postEvent = DiscordSRV.api.callEvent(new VentureChatMessagePostProcessEvent(channel, discordMessage, event, preEvent.isCancelled()));
         if (postEvent.isCancelled()) {
-        	DiscordSRV.debug(Debug.MINECRAFT_TO_DISCORD, "GameChatMessagePostProcessEvent was cancelled, message send aborted");
+        	DiscordSRV.debug(Debug.MINECRAFT_TO_DISCORD, "VentureChatMessagePostProcessEvent was cancelled, message send aborted");
             return;
         }
         channel = postEvent.getChannel(); // update channel from event in case any listeners modified it

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/VentureChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/VentureChatHook.java
@@ -166,7 +166,7 @@ public class VentureChatHook implements ChatHook {
         
         VentureChatMessagePostProcessEvent postEvent = DiscordSRV.api.callEvent(new VentureChatMessagePostProcessEvent(channel, discordMessage, event, preEvent.isCancelled()));
         if (postEvent.isCancelled()) {
-        	DiscordSRV.debug(Debug.MINECRAFT_TO_DISCORD, "VentureChatMessagePostProcessEvent was cancelled, message send aborted");
+            DiscordSRV.debug(Debug.MINECRAFT_TO_DISCORD, "VentureChatMessagePostProcessEvent was cancelled, message send aborted");
             return;
         }
         channel = postEvent.getChannel(); // update channel from event in case any listeners modified it


### PR DESCRIPTION
This PR adds `VentureChatMessagePreProcessEvent` and `VentureChatMessagePostProcessEvent` to the `VentureChatHook` to allow other plugins to modify how venture chat messages look like before setting to discord. (Like how `GameChatMessagePreProcessEvent` and `GameChatMessagePostProcessEvent` works)