### PR TITLE
Bump Adventure/MiniMessage versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -545,33 +545,32 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.9.3</version>
+            <version>4.10.1</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-legacy</artifactId>
-            <version>4.9.3</version>
+            <version>4.10.1</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-gson</artifactId>
-            <version>4.9.3</version>
+            <version>4.10.1</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-plain</artifactId>
-            <version>4.9.3</version>
+            <version>4.10.1</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-bukkit</artifactId>
-            <version>4.0.1</version>
+            <version>4.1.0</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
-            <!-- Releases aren't a thing, right? This is a (specific) snapshot build on nexus.scarsz.me -->
-            <version>4.1.0-20210316.192746</version>
+            <version>4.10.1</version>
         </dependency>
 
         <!-- plugin hooks -->

--- a/src/main/java/github/scarsz/discordsrv/util/MessageUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/MessageUtil.java
@@ -179,7 +179,7 @@ public class MessageUtil {
             component = component.content("").style(Style.empty()).children(children);
             return component;
         } else {
-            Component component = MiniMessage.get().parse(message);
+            Component component = MiniMessage.miniMessage().deserialize(message);
             component = component.replaceText(
                     TextReplacementConfig.builder()
                             .match(DEFAULT_URL_PATTERN)
@@ -233,7 +233,7 @@ public class MessageUtil {
      * @return the converted MiniMessage
      */
     public static String toMiniMessage(Component component) {
-        return MiniMessage.get().serialize(component);
+        return MiniMessage.miniMessage().serialize(component);
     }
 
     /**


### PR DESCRIPTION
Noticed a few issues with MiniMessage's parsing, with the older version used in DSRV.
Updated all Adventure related dependencies (serializers, api, mm, platform-bukkit) to newer versions.
Tested locally (Paper 1.18.2 b290), no side effects found and I haven't had any parsing issues since. 