### PR TITLE
Optimize and add Java matrix

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -8,14 +8,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [8] # Add numbers as Java is updated
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
-          java-version: 8
+          distribution: temurin
+          java-version: ${{ matrix.java }}
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository


### PR DESCRIPTION
This changes the `distribution` to `temurin` (as in my testing, it is much faster than `adopt`), and sets up a matrix so that updating or supporting multiple versions of Java is easier, and it will also now show the correct Java version instead of 1.8.