### PR TITLE
Link accounts via guild text channel

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordAccountLinkListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordAccountLinkListener.java
@@ -36,7 +36,6 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 
-import java.util.Objects;
 import java.util.UUID;
 
 public class DiscordAccountLinkListener extends ListenerAdapter {
@@ -62,7 +61,7 @@ public class DiscordAccountLinkListener extends ListenerAdapter {
 
         // if message is not in the link channel, don't process it
         TextChannel linkChannel = DiscordSRV.getPlugin().getDestinationTextChannelForGameChannelName("link");
-        if (!Objects.equals(event.getChannel(), linkChannel)) return;
+        if (!event.getChannel().equals(linkChannel)) return;
 
         String reply = DiscordSRV.getPlugin().getAccountLinkManager().process(event.getMessage().getContentRaw(), event.getAuthor().getId());
         if (reply != null) event.getMessage().reply(reply).queue();

--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordAccountLinkListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordAccountLinkListener.java
@@ -24,11 +24,11 @@ package github.scarsz.discordsrv.listeners;
 
 import github.scarsz.discordsrv.Debug;
 import github.scarsz.discordsrv.DiscordSRV;
-import github.scarsz.discordsrv.api.events.DiscordGuildMessageReceivedEvent;
 import github.scarsz.discordsrv.api.events.DiscordPrivateMessageReceivedEvent;
 import github.scarsz.discordsrv.util.DiscordUtil;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.events.message.priv.PrivateMessageReceivedEvent;
@@ -36,7 +36,7 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 
-import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 public class DiscordAccountLinkListener extends ListenerAdapter {
@@ -49,7 +49,7 @@ public class DiscordAccountLinkListener extends ListenerAdapter {
         DiscordSRV.api.callEvent(new DiscordPrivateMessageReceivedEvent(event));
 
         // don't link accounts if config option is disabled
-        if (!DiscordSRV.config().getBoolean("MinecraftDiscordAccountEnablePM")) return;
+        if (!DiscordSRV.config().getBoolean("MinecraftDiscordAccountLinkedUsePM")) return;
 
         String reply = DiscordSRV.getPlugin().getAccountLinkManager().process(event.getMessage().getContentRaw(), event.getAuthor().getId());
         if (reply != null) event.getMessage().reply(reply).queue();
@@ -60,11 +60,9 @@ public class DiscordAccountLinkListener extends ListenerAdapter {
         // don't process messages sent by the bot
         if (event.getAuthor().getId().equals(event.getJDA().getSelfUser().getId())) return;
 
-        // if the channel is not for linking, do not link the account
-        List<Object> channels = DiscordSRV.config().getList("MinecraftDiscordAccountChannels");
-        if (!channels.contains(event.getChannel().getId())
-                && !channels.contains(event.getChannel().getIdLong())
-                && !channels.contains(event.getChannel().getName())) return;
+        // if message is not in the link channel, don't process it
+        TextChannel linkChannel = DiscordSRV.getPlugin().getDestinationTextChannelForGameChannelName("link");
+        if (!Objects.equals(event.getChannel(), linkChannel)) return;
 
         String reply = DiscordSRV.getPlugin().getAccountLinkManager().process(event.getMessage().getContentRaw(), event.getAuthor().getId());
         if (reply != null) event.getMessage().reply(reply).queue();

--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordAccountLinkListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordAccountLinkListener.java
@@ -60,8 +60,6 @@ public class DiscordAccountLinkListener extends ListenerAdapter {
         // don't process messages sent by the bot
         if (event.getAuthor().getId().equals(event.getJDA().getSelfUser().getId())) return;
 
-        DiscordSRV.api.callEvent(new DiscordGuildMessageReceivedEvent(event));
-
         // if the channel is not for linking, do not link the account
         List<Object> channels = DiscordSRV.config().getList("MinecraftDiscordAccountChannels");
         if (!channels.contains(event.getChannel().getId())

--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordAccountLinkListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordAccountLinkListener.java
@@ -24,16 +24,19 @@ package github.scarsz.discordsrv.listeners;
 
 import github.scarsz.discordsrv.Debug;
 import github.scarsz.discordsrv.DiscordSRV;
+import github.scarsz.discordsrv.api.events.DiscordGuildMessageReceivedEvent;
 import github.scarsz.discordsrv.api.events.DiscordPrivateMessageReceivedEvent;
 import github.scarsz.discordsrv.util.DiscordUtil;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
+import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.events.message.priv.PrivateMessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 
+import java.util.List;
 import java.util.UUID;
 
 public class DiscordAccountLinkListener extends ListenerAdapter {
@@ -45,8 +48,28 @@ public class DiscordAccountLinkListener extends ListenerAdapter {
 
         DiscordSRV.api.callEvent(new DiscordPrivateMessageReceivedEvent(event));
 
+        // don't link accounts if config option is disabled
+        if (!DiscordSRV.config().getBoolean("MinecraftDiscordAccountEnablePM")) return;
+
         String reply = DiscordSRV.getPlugin().getAccountLinkManager().process(event.getMessage().getContentRaw(), event.getAuthor().getId());
-        if (reply != null) event.getChannel().sendMessage(reply).queue();
+        if (reply != null) event.getMessage().reply(reply).queue();
+    }
+
+    @Override
+    public void onGuildMessageReceived(GuildMessageReceivedEvent event) {
+        // don't process messages sent by the bot
+        if (event.getAuthor().getId().equals(event.getJDA().getSelfUser().getId())) return;
+
+        DiscordSRV.api.callEvent(new DiscordGuildMessageReceivedEvent(event));
+
+        // if the channel is not for linking, do not link the account
+        List<Object> channels = DiscordSRV.config().getList("MinecraftDiscordAccountChannels");
+        if (!channels.contains(event.getChannel().getId())
+                && !channels.contains(event.getChannel().getIdLong())
+                && !channels.contains(event.getChannel().getName())) return;
+
+        String reply = DiscordSRV.getPlugin().getAccountLinkManager().process(event.getMessage().getContentRaw(), event.getAuthor().getId());
+        if (reply != null) event.getMessage().reply(reply).queue();
     }
 
     @Override

--- a/src/main/resources/config/de.yml
+++ b/src/main/resources/config/de.yml
@@ -288,11 +288,15 @@ DiscordCannedResponses: {"!ip": "deineserveradresse.net", "!site": "http://deine
 #
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: der Name oder die ID einer Discord-Rolle, die dem Discord-Nutzer zugewiesen wird, wenn er Minecraft und Discord verbunden hat
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: Ermöglicht das Senden eines neuen Codes an den Bot, um die Verknüpfung zu lösen und mit dem neuen Code erneut zu verknüpfen
+# MinecraftDiscordAccountEnablePM: Erlauben Sie die Verknüpfung von Konten mit PM
+# MinecraftDiscordAccountChannels: den Namen oder die ID eines Discord-Kanals, um Konten zu verknüpfen
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+MinecraftDiscordAccountEnablePM: true
+MinecraftDiscordAccountChannels: []
 
 # Server-Watchdog
 #

--- a/src/main/resources/config/de.yml
+++ b/src/main/resources/config/de.yml
@@ -290,12 +290,14 @@ DiscordCannedResponses: {"!ip": "deineserveradresse.net", "!site": "http://deine
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: der Name oder die ID einer Discord-Rolle, die dem Discord-Nutzer zugewiesen wird, wenn er Minecraft und Discord verbunden hat
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: Ermöglicht das Senden eines neuen Codes an den Bot, um die Verknüpfung zu lösen und mit dem neuen Code erneut zu verknüpfen
 # MinecraftDiscordAccountLinkedUsePM: Verknüpfung von Konten über PMs
+# MinecraftDiscordAccountLinkedMessageDeleteSeconds: Zeit (in Sekunden) vor dem Löschen der Nachricht bei der Verknüpfung in einem Textkanal. Setzen Sie den Wert auf 0, wenn Sie die Nachricht nicht löschen wollen.
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 MinecraftDiscordAccountLinkedUsePM: true
+MinecraftDiscordAccountLinkedMessageDeleteSeconds: 0
 
 # Server-Watchdog
 #

--- a/src/main/resources/config/de.yml
+++ b/src/main/resources/config/de.yml
@@ -23,6 +23,7 @@ BotToken: "BOTTOKEN"
 # für Dynmap-Nachrichten: dynmap
 # für Watchdog-Nachrichten: watchdog
 # for /discord broadcast: broadcasts (sofern nicht im Befehl angegeben)
+# für Account-Link: link
 #
 # Der erste Teil von Kanalpaaren ist nicht der Discord-Kanalname!
 # Führen Sie ein "/discord reload" aus, nachdem Sie diese Option zum Anwenden geändert haben
@@ -288,15 +289,13 @@ DiscordCannedResponses: {"!ip": "deineserveradresse.net", "!site": "http://deine
 #
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: der Name oder die ID einer Discord-Rolle, die dem Discord-Nutzer zugewiesen wird, wenn er Minecraft und Discord verbunden hat
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: Ermöglicht das Senden eines neuen Codes an den Bot, um die Verknüpfung zu lösen und mit dem neuen Code erneut zu verknüpfen
-# MinecraftDiscordAccountEnablePM: Erlauben Sie die Verknüpfung von Konten mit PM
-# MinecraftDiscordAccountChannels: den Namen oder die ID eines Discord-Kanals, um Konten zu verknüpfen
+# MinecraftDiscordAccountLinkedUsePM: Verknüpfung von Konten über PMs
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-MinecraftDiscordAccountEnablePM: true
-MinecraftDiscordAccountChannels: []
+MinecraftDiscordAccountLinkedUsePM: true
 
 # Server-Watchdog
 #

--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -286,11 +286,15 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 #
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: the name or id of a discord role to add a discord user to when they link their account
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: allows sending a new code to the bot to unlink and relink with the new code
+# MinecraftDiscordAccountEnablePM: allows linking accounts using PM
+# MinecraftDiscordAccountChannels: the name or id of a discord channel to link accounts
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+MinecraftDiscordAccountEnablePM: true
+MinecraftDiscordAccountChannels: []
 
 # Server watchdog
 #

--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -23,7 +23,7 @@ BotToken: "BOTTOKEN"
 # for dynmap messages: dynmap
 # for watchdog messages: watchdog
 # for /discord broadcast: broadcasts (unless specified in the command)
-# for account link: link
+# for account linking: link
 #
 # The first part of channel pairs is not the Discord channel name!
 # Run "/discord reload" after changing this option to apply
@@ -288,12 +288,14 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: the name or id of a discord role to add a discord user to when they link their account
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: allows sending a new code to the bot to unlink and relink with the new code
 # MinecraftDiscordAccountLinkedUsePM: link accounts using PMs
+# MinecraftDiscordAccountLinkedMessageDeleteSeconds: Time (in seconds) before deleting the message when linked in a text channel. Set to 0 if you do not want to delete the message.
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 MinecraftDiscordAccountLinkedUsePM: true
+MinecraftDiscordAccountLinkedMessageDeleteSeconds: 0
 
 # Server watchdog
 #

--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -23,6 +23,7 @@ BotToken: "BOTTOKEN"
 # for dynmap messages: dynmap
 # for watchdog messages: watchdog
 # for /discord broadcast: broadcasts (unless specified in the command)
+# for account link: link
 #
 # The first part of channel pairs is not the Discord channel name!
 # Run "/discord reload" after changing this option to apply
@@ -286,15 +287,13 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 #
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: the name or id of a discord role to add a discord user to when they link their account
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: allows sending a new code to the bot to unlink and relink with the new code
-# MinecraftDiscordAccountEnablePM: allows linking accounts using PM
-# MinecraftDiscordAccountChannels: the name or id of a discord channel to link accounts
+# MinecraftDiscordAccountLinkedUsePM: link accounts using PMs
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-MinecraftDiscordAccountEnablePM: true
-MinecraftDiscordAccountChannels: []
+MinecraftDiscordAccountLinkedUsePM: true
 
 # Server watchdog
 #

--- a/src/main/resources/config/es.yml
+++ b/src/main/resources/config/es.yml
@@ -288,12 +288,14 @@ DiscordCannedResponses: {"!ip": "cambiaratuserverip.me", "!site": "http://tusiti
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: el nombre o ID de un rol de Discord para agregar al usuario de Discord cuando vincula su cuenta
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: permite enviar un nuevo código al bot para desvincularlo y volver a vincularlo con el nuevo código
 # MinecraftDiscordAccountLinkedUsePM: Vinculación de cuentas mediante PMs
+# MinecraftDiscordAccountLinkedMessageDeleteSeconds: Tiempo (en segundos) antes de borrar el mensaje cuando se enlaza en un canal de texto. Ponga 0 si no quiere borrar el mensaje.
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 MinecraftDiscordAccountLinkedUsePM: true
+MinecraftDiscordAccountLinkedMessageDeleteSeconds: 0
 
 # Perro guardián del servidor
 #

--- a/src/main/resources/config/es.yml
+++ b/src/main/resources/config/es.yml
@@ -286,11 +286,15 @@ DiscordCannedResponses: {"!ip": "cambiaratuserverip.me", "!site": "http://tusiti
 #
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: el nombre o ID de un rol de Discord para agregar al usuario de Discord cuando vincula su cuenta
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: permite enviar un nuevo código al bot para desvincularlo y volver a vincularlo con el nuevo código
+# MinecraftDiscordAccountEnablePM: Permitir la vinculación de cuentas mediante PM
+# MinecraftDiscordAccountChannels: el nombre o la identificación de un canal de discordia para vincular las cuentas
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+MinecraftDiscordAccountEnablePM: true
+MinecraftDiscordAccountChannels: []
 
 # Perro guardián del servidor
 #

--- a/src/main/resources/config/es.yml
+++ b/src/main/resources/config/es.yml
@@ -23,6 +23,7 @@ BotToken: "BOTTOKEN"
 # para mensajes de dynmap: dynmap
 # para mensajes de perro guardián: watchdog
 # para /discord broadcast: broadcasts (a menos que se especifique en el comando)
+# Enlace de la cuenta: link
 #
 # ¡La primera parte de los pares de canales no es el nombre del canal de Discord!
 # Ejecute "/discord reload" después de cambiar esta opción para aplicar
@@ -286,15 +287,13 @@ DiscordCannedResponses: {"!ip": "cambiaratuserverip.me", "!site": "http://tusiti
 #
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: el nombre o ID de un rol de Discord para agregar al usuario de Discord cuando vincula su cuenta
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: permite enviar un nuevo código al bot para desvincularlo y volver a vincularlo con el nuevo código
-# MinecraftDiscordAccountEnablePM: Permitir la vinculación de cuentas mediante PM
-# MinecraftDiscordAccountChannels: el nombre o la identificación de un canal de discordia para vincular las cuentas
+# MinecraftDiscordAccountLinkedUsePM: Vinculación de cuentas mediante PMs
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-MinecraftDiscordAccountEnablePM: true
-MinecraftDiscordAccountChannels: []
+MinecraftDiscordAccountLinkedUsePM: true
 
 # Perro guardián del servidor
 #

--- a/src/main/resources/config/et.yml
+++ b/src/main/resources/config/et.yml
@@ -288,12 +288,14 @@ DiscordCannedResponses: {"!ip": "sinuserveriip.ee", "!site": "https://sinusaidia
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: the name or id of a discord role to add a discord user to when they link their account
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: allows sending a new code to the bot to unlink and relink with the new code
 # MinecraftDiscordAccountLinkedUsePM: Kontode ühendamine PM-i abil
+# MinecraftDiscordAccountLinkedMessageDeleteSeconds: Aeg (sekundites) enne sõnumi kustutamist, kui linkimine toimub tekstikanalis. Määra 0, kui te ei soovi sõnumit kustutada.
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 MinecraftDiscordAccountLinkedUsePM: true
+MinecraftDiscordAccountLinkedMessageDeleteSeconds: 0
 
 # Server watchdog
 #

--- a/src/main/resources/config/et.yml
+++ b/src/main/resources/config/et.yml
@@ -286,11 +286,15 @@ DiscordCannedResponses: {"!ip": "sinuserveriip.ee", "!site": "https://sinusaidia
 #
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: the name or id of a discord role to add a discord user to when they link their account
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: allows sending a new code to the bot to unlink and relink with the new code
+# MinecraftDiscordAccountEnablePM: Võimaldab kontode sidumist PM-i abil
+# MinecraftDiscordAccountChannels: discord-kanali nimi või id kontode ühendamiseks
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+MinecraftDiscordAccountEnablePM: true
+MinecraftDiscordAccountChannels: []
 
 # Server watchdog
 #

--- a/src/main/resources/config/et.yml
+++ b/src/main/resources/config/et.yml
@@ -23,6 +23,7 @@ BotToken: "BOTTOKEN"
 # for dynmap messages: dynmap
 # for watchdog messages: watchdog
 # for /discord broadcast: broadcasts (unless specified in the command)
+# for account link: link
 #
 # The first part of channel pairs is not the Discord channel name!
 # Run "/discord reload" after changing this option to apply
@@ -286,15 +287,13 @@ DiscordCannedResponses: {"!ip": "sinuserveriip.ee", "!site": "https://sinusaidia
 #
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: the name or id of a discord role to add a discord user to when they link their account
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: allows sending a new code to the bot to unlink and relink with the new code
-# MinecraftDiscordAccountEnablePM: Võimaldab kontode sidumist PM-i abil
-# MinecraftDiscordAccountChannels: discord-kanali nimi või id kontode ühendamiseks
+# MinecraftDiscordAccountLinkedUsePM: Kontode ühendamine PM-i abil
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-MinecraftDiscordAccountEnablePM: true
-MinecraftDiscordAccountChannels: []
+MinecraftDiscordAccountLinkedUsePM: true
 
 # Server watchdog
 #

--- a/src/main/resources/config/fr.yml
+++ b/src/main/resources/config/fr.yml
@@ -285,13 +285,14 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedSetDiscordNicknameAsInGameName: le nom discord du joueur doit-il être modifié par son nom Minecraft ?
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: permet d'envoyer un nouveau code au bot pour dissocier et relier le nouveau code
 # MinecraftDiscordAccountLinkedUsePM: Lier des comptes à l'aide de PMs
+# MinecraftDiscordAccountLinkedMessageDeleteSeconds: Temps (en secondes) avant la suppression du message lors de la liaison dans un canal texte. Mettez la valeur 0 si vous ne voulez pas supprimer le message.
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 MinecraftDiscordAccountLinkedUsePM: true
-
+MinecraftDiscordAccountLinkedMessageDeleteSeconds: 0
 
 # Surveilleur de serveur
 #

--- a/src/main/resources/config/fr.yml
+++ b/src/main/resources/config/fr.yml
@@ -283,11 +283,15 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleToAddUserTo: le nom ou ID d'un rôle à mettre au joueur qui vient de lié son compte
 # MinecraftDiscordAccountLinkedSetDiscordNicknameAsInGameName: le nom discord du joueur doit-il être modifié par son nom Minecraft ?
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: permet d'envoyer un nouveau code au bot pour dissocier et relier le nouveau code
+# MinecraftDiscordAccountEnablePM: Permettre la liaison des comptes à l'aide de PM
+# MinecraftDiscordAccountChannels: le nom ou l'identifiant d'un canal discord pour lier les comptes
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+MinecraftDiscordAccountEnablePM: true
+MinecraftDiscordAccountChannels: []
 
 # Surveilleur de serveur
 #

--- a/src/main/resources/config/fr.yml
+++ b/src/main/resources/config/fr.yml
@@ -22,7 +22,8 @@ BotToken: "BOTTOKEN"
 # pour laisser des messages: leave
 # pour les messages dynmap: dynmap
 # pour les messages de surveillance: watchdog
-# pour / discord broadcast: broadcasts (sauf si spécifié dans la commande)
+# pour /discord broadcast: broadcasts (sauf si spécifié dans la commande)
+# Lien vers le compte : link
 #
 # La première partie des paires de canaux n'est pas le nom du canal Discord!
 # Exécutez "/discord reload" après avoir modifié cette option pour appliquer
@@ -283,15 +284,14 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleToAddUserTo: le nom ou ID d'un rôle à mettre au joueur qui vient de lié son compte
 # MinecraftDiscordAccountLinkedSetDiscordNicknameAsInGameName: le nom discord du joueur doit-il être modifié par son nom Minecraft ?
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: permet d'envoyer un nouveau code au bot pour dissocier et relier le nouveau code
-# MinecraftDiscordAccountEnablePM: Permettre la liaison des comptes à l'aide de PM
-# MinecraftDiscordAccountChannels: le nom ou l'identifiant d'un canal discord pour lier les comptes
+# MinecraftDiscordAccountLinkedUsePM: Lier des comptes à l'aide de PMs
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-MinecraftDiscordAccountEnablePM: true
-MinecraftDiscordAccountChannels: []
+MinecraftDiscordAccountLinkedUsePM: true
+
 
 # Surveilleur de serveur
 #

--- a/src/main/resources/config/ja.yml
+++ b/src/main/resources/config/ja.yml
@@ -22,7 +22,8 @@ BotToken: "BOTTOKEN"
 # メッセージを残す場合: leave
 # dynmapメッセージの場合：dynmap
 # ウォッチドッグメッセージの場合: watchdog
-# / discordブロードキャストの場合: broadcasts （コマンドで指定されていない場合）
+# /discord broadcast 用の場合: broadcasts （コマンドで指定されていない場合）
+# アカウントリンク: link
 #
 # チャンネルペアの最初の部分はDiscordチャンネル名ではありません！
 # このオプションを適用するように変更した後、「/ discord reload」を実行します
@@ -287,15 +288,13 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 #
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: Discordユーザーがアカウントをリンクするときに追加するDiscordロール名またはID
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 新しいコードをボットに送信して新しいコードとのリンクを解除して再リンクすることを許可する
-# MinecraftDiscordAccountEnablePM: PMを使用してアカウントをリンクすることを許可
-# MinecraftDiscordAccountChannels: アカウントのリンクに使用できるチャンネル名またはIDのリスト
+# MinecraftDiscordAccountLinkedUsePM: PMを使用してアカウントをリンクする
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-MinecraftDiscordAccountEnablePM: true
-MinecraftDiscordAccountChannels: []
+MinecraftDiscordAccountLinkedUsePM: true
 
 # Server ウォッチドッグ
 #

--- a/src/main/resources/config/ja.yml
+++ b/src/main/resources/config/ja.yml
@@ -287,11 +287,15 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 #
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: Discordユーザーがアカウントをリンクするときに追加するDiscordロール名またはID
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 新しいコードをボットに送信して新しいコードとのリンクを解除して再リンクすることを許可する
+# MinecraftDiscordAccountEnablePM: PMを使用してアカウントをリンクすることを許可
+# MinecraftDiscordAccountChannels: アカウントのリンクに使用できるチャンネル名またはIDのリスト
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+MinecraftDiscordAccountEnablePM: true
+MinecraftDiscordAccountChannels: []
 
 # Server ウォッチドッグ
 #

--- a/src/main/resources/config/ja.yml
+++ b/src/main/resources/config/ja.yml
@@ -289,12 +289,14 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: Discordユーザーがアカウントをリンクするときに追加するDiscordロール名またはID
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 新しいコードをボットに送信して新しいコードとのリンクを解除して再リンクすることを許可する
 # MinecraftDiscordAccountLinkedUsePM: PMを使用してアカウントをリンクする
+# MinecraftDiscordAccountLinkedMessageDeleteSeconds: テキストチャンネルでリンクをした際のメッセージを削除するまでの時間（秒）。削除しない場合は0に設定します。
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 MinecraftDiscordAccountLinkedUsePM: true
+MinecraftDiscordAccountLinkedMessageDeleteSeconds: 0
 
 # Server ウォッチドッグ
 #

--- a/src/main/resources/config/ko.yml
+++ b/src/main/resources/config/ko.yml
@@ -23,6 +23,7 @@ BotToken: "BOTTOKEN"
 # dynmap 메시지: dynmap
 # watchdog 메시지: watchdog
 # /discord broadcast 명령어: broadcasts (명령어로 지정되지 않은 경우)
+# 계정 링크: link
 #
 # 채널 쌍의 첫 번째 부분은 디스코드 채널 이름이 아닙니다!
 # 이 옵션을 적용하도록 변경한 후 "/discord reload" 실행
@@ -285,15 +286,13 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 #
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: 연결된 사용자에 대해 설정할 역할 이름 또는 ID입니다.
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 봇에 새 코드를 보내어 새 코드와의 링크를 해제하고 다시 링크 할 수 있습니다.
-# MinecraftDiscordAccountEnablePM: PM을 사용하여 계정을 연결하도록 허용
-# MinecraftDiscordAccountChannels: 계정을 연결하는 데 사용할 수 있는 채널 이름 또는 ID 목록
+# MinecraftDiscordAccountLinkedUsePM: PM을 사용하여 계정 연결
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-MinecraftDiscordAccountEnablePM: true
-MinecraftDiscordAccountChannels: []
+MinecraftDiscordAccountLinkedUsePM: true
 
 # 서버 와치독(Watchdog)
 #

--- a/src/main/resources/config/ko.yml
+++ b/src/main/resources/config/ko.yml
@@ -287,12 +287,14 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: 연결된 사용자에 대해 설정할 역할 이름 또는 ID입니다.
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 봇에 새 코드를 보내어 새 코드와의 링크를 해제하고 다시 링크 할 수 있습니다.
 # MinecraftDiscordAccountLinkedUsePM: PM을 사용하여 계정 연결
+# MinecraftDiscordAccountLinkedMessageDeleteSeconds: 텍스트 채널로 링크를 했을 때의 메시지를 삭제하기까지의 시간(초). 삭제하지 않으려면 0으로 설정합니다.
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 MinecraftDiscordAccountLinkedUsePM: true
+MinecraftDiscordAccountLinkedMessageDeleteSeconds: 0
 
 # 서버 와치독(Watchdog)
 #

--- a/src/main/resources/config/ko.yml
+++ b/src/main/resources/config/ko.yml
@@ -285,11 +285,15 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 #
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: 연결된 사용자에 대해 설정할 역할 이름 또는 ID입니다.
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 봇에 새 코드를 보내어 새 코드와의 링크를 해제하고 다시 링크 할 수 있습니다.
+# MinecraftDiscordAccountEnablePM: PM을 사용하여 계정을 연결하도록 허용
+# MinecraftDiscordAccountChannels: 계정을 연결하는 데 사용할 수 있는 채널 이름 또는 ID 목록
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+MinecraftDiscordAccountEnablePM: true
+MinecraftDiscordAccountChannels: []
 
 # 서버 와치독(Watchdog)
 #

--- a/src/main/resources/config/nl.yml
+++ b/src/main/resources/config/nl.yml
@@ -286,11 +286,15 @@ DiscordCannedResponses: {"!ip": "serverip.me", "!site": "http://jesiteulr.nl"}
 #
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: De naam of id van de discord role als ze hun account gekoppeld hebben.
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: hiermee kan een nieuwe code naar de bot worden verzonden om te ontkoppelen en opnieuw te koppelen aan de nieuwe code
+# MinecraftDiscordAccountEnablePM: Koppeling van rekeningen via PM toestaan
+# MinecraftDiscordAccountChannels: de naam of het id van een discordkanaal om accounts te koppelen
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+MinecraftDiscordAccountEnablePM: true
+MinecraftDiscordAccountChannels: []
 
 # Server watchdog
 #

--- a/src/main/resources/config/nl.yml
+++ b/src/main/resources/config/nl.yml
@@ -288,12 +288,14 @@ DiscordCannedResponses: {"!ip": "serverip.me", "!site": "http://jesiteulr.nl"}
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: De naam of id van de discord role als ze hun account gekoppeld hebben.
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: hiermee kan een nieuwe code naar de bot worden verzonden om te ontkoppelen en opnieuw te koppelen aan de nieuwe code
 # MinecraftDiscordAccountLinkedUsePM: Koppelen van rekeningen via PM's
+# MinecraftDiscordAccountLinkedMessageDeleteSeconds: Tijd (in seconden) voor het wissen van het bericht bij het linken in een tekstkanaal. Stel in op 0 als u het bericht niet wilt verwijderen.
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 MinecraftDiscordAccountLinkedUsePM: true
+MinecraftDiscordAccountLinkedMessageDeleteSeconds: 0
 
 # Server watchdog
 #

--- a/src/main/resources/config/nl.yml
+++ b/src/main/resources/config/nl.yml
@@ -23,6 +23,7 @@ BotToken: "BOTTOKEN"
 # voor dynmap-berichten: dynmap
 # voor watchdog-berichten: watchdog
 # voor /discord broadcast: broadcasts (tenzij gespecificeerd in de opdracht)
+# Account link: link
 #
 # Het eerste deel van kanaalparen is niet de kanaalnaam van Discord!
 # Voer "/discord reload" uit nadat u deze optie hebt gewijzigd om toe te passen
@@ -286,15 +287,13 @@ DiscordCannedResponses: {"!ip": "serverip.me", "!site": "http://jesiteulr.nl"}
 #
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: De naam of id van de discord role als ze hun account gekoppeld hebben.
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: hiermee kan een nieuwe code naar de bot worden verzonden om te ontkoppelen en opnieuw te koppelen aan de nieuwe code
-# MinecraftDiscordAccountEnablePM: Koppeling van rekeningen via PM toestaan
-# MinecraftDiscordAccountChannels: de naam of het id van een discordkanaal om accounts te koppelen
+# MinecraftDiscordAccountLinkedUsePM: Koppelen van rekeningen via PM's
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-MinecraftDiscordAccountEnablePM: true
-MinecraftDiscordAccountChannels: []
+MinecraftDiscordAccountLinkedUsePM: true
 
 # Server watchdog
 #

--- a/src/main/resources/config/pl.yml
+++ b/src/main/resources/config/pl.yml
@@ -286,11 +286,15 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 #
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: nazwa lub ID roli niezgody, do której należy dodać użytkownika niezgody po połączeniu konta
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: umożliwia wysłanie nowego kodu do bota w celu odłączenia i ponownego połączenia z nowym kodem
+# MinecraftDiscordAccountEnablePM: Umożliwić łączenie kont za pomocą PM
+# MinecraftDiscordAccountChannels: nazwa lub id kanału discord do łączenia kont
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+MinecraftDiscordAccountEnablePM: true
+MinecraftDiscordAccountChannels: []
 
 # Watchdog serwera
 #

--- a/src/main/resources/config/pl.yml
+++ b/src/main/resources/config/pl.yml
@@ -23,6 +23,7 @@ BotToken: "BOTTOKEN"
 # dla wiadomości dynmap: dynmap
 # dla wiadomości watchdog: watchdog
 # for /discord broadcast: broadcasts (chyba że określono w poleceniu)
+# Account link: link
 #
 # Pierwsza część par kanałów to nie nazwa kanału Discord!
 # Uruchom "/discord reload" po zmianie tej opcji, aby zastosować
@@ -286,15 +287,13 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 #
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: nazwa lub ID roli niezgody, do której należy dodać użytkownika niezgody po połączeniu konta
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: umożliwia wysłanie nowego kodu do bota w celu odłączenia i ponownego połączenia z nowym kodem
-# MinecraftDiscordAccountEnablePM: Umożliwić łączenie kont za pomocą PM
-# MinecraftDiscordAccountChannels: nazwa lub id kanału discord do łączenia kont
+# MinecraftDiscordAccountLinkedUsePM: Ligação de contas utilizando PMs
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-MinecraftDiscordAccountEnablePM: true
-MinecraftDiscordAccountChannels: []
+MinecraftDiscordAccountLinkedUsePM: true
 
 # Watchdog serwera
 #

--- a/src/main/resources/config/pl.yml
+++ b/src/main/resources/config/pl.yml
@@ -288,12 +288,14 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: nazwa lub ID roli niezgody, do której należy dodać użytkownika niezgody po połączeniu konta
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: umożliwia wysłanie nowego kodu do bota w celu odłączenia i ponownego połączenia z nowym kodem
 # MinecraftDiscordAccountLinkedUsePM: Ligação de contas utilizando PMs
+# MinecraftDiscordAccountLinkedMessageDeleteSeconds: Czas (w sekundach) przed usunięciem wiadomości przy łączeniu w kanale tekstowym. Ustaw na 0, jeśli nie chcesz usuwać wiadomości.
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 MinecraftDiscordAccountLinkedUsePM: true
+MinecraftDiscordAccountLinkedMessageDeleteSeconds: 0
 
 # Watchdog serwera
 #

--- a/src/main/resources/config/ru.yml
+++ b/src/main/resources/config/ru.yml
@@ -286,11 +286,15 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 #
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: имя или ID Discord роли, в которую будут добавлены пользователи, после того как привяжут свои аккаунты
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: можно ли отправить новый код боту, чтобы перепривязать аккаунт
+# MinecraftDiscordAccountEnablePM: Разрешить связывание счетов с помощью PM
+# MinecraftDiscordAccountChannels: имя или id канала discord для связи аккаунтов
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+MinecraftDiscordAccountEnablePM: true
+MinecraftDiscordAccountChannels: []
 
 # Мониторинг сервера
 #

--- a/src/main/resources/config/ru.yml
+++ b/src/main/resources/config/ru.yml
@@ -23,6 +23,7 @@ BotToken: "BOTTOKEN"
 # для сообщений dynmap: dynmap
 # для сообщений сторожевого таймера: watchdog
 # для /discord broadcast: broadcasts (если не указано в команде)
+# Ссылка на аккаунт: link
 #
 # Первая часть пар каналов не является названием канала Discord!
 # Выполните "/discord reload" после изменения этого опции для применения
@@ -286,15 +287,13 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 #
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: имя или ID Discord роли, в которую будут добавлены пользователи, после того как привяжут свои аккаунты
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: можно ли отправить новый код боту, чтобы перепривязать аккаунт
-# MinecraftDiscordAccountEnablePM: Разрешить связывание счетов с помощью PM
-# MinecraftDiscordAccountChannels: имя или id канала discord для связи аккаунтов
+# MinecraftDiscordAccountLinkedUsePM: Связывание счетов с помощью PMs
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-MinecraftDiscordAccountEnablePM: true
-MinecraftDiscordAccountChannels: []
+MinecraftDiscordAccountLinkedUsePM: true
 
 # Мониторинг сервера
 #

--- a/src/main/resources/config/ru.yml
+++ b/src/main/resources/config/ru.yml
@@ -288,12 +288,14 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: имя или ID Discord роли, в которую будут добавлены пользователи, после того как привяжут свои аккаунты
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: можно ли отправить новый код боту, чтобы перепривязать аккаунт
 # MinecraftDiscordAccountLinkedUsePM: Связывание счетов с помощью PMs
+# MinecraftDiscordAccountLinkedMessageDeleteSeconds: Время (в секундах) до удаления сообщения при связывании в текстовом канале. Установите значение 0, если вы не хотите удалять сообщение.
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 MinecraftDiscordAccountLinkedUsePM: true
+MinecraftDiscordAccountLinkedMessageDeleteSeconds: 0
 
 # Мониторинг сервера
 #

--- a/src/main/resources/config/zh.yml
+++ b/src/main/resources/config/zh.yml
@@ -287,12 +287,14 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: 當使用者已連結帳號時將其加入該身分組
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 允许向机器人发送新代码以取消链接并与新代码重新链接
 # MinecraftDiscordAccountLinkedUsePM: 使用PM链接账户
+# MinecraftDiscordAccountLinkedMessageDeleteSeconds: 在文本通道中链接时，删除信息前的时间（以秒为单位）。 如果你不想删除信息，请设置为0。
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
 MinecraftDiscordAccountLinkedUsePM: true
+MinecraftDiscordAccountLinkedMessageDeleteSeconds: 0
 
 # 伺服器監視器
 #

--- a/src/main/resources/config/zh.yml
+++ b/src/main/resources/config/zh.yml
@@ -23,6 +23,7 @@ BotToken: "BOTTOKEN"
 # 用于dynmap消息: dynmap
 # 用于看门狗消息: watchdog
 # 用于/discord broadcast: broadcasts（除非在命令中指定）
+# 帐户链接: link
 #
 # "频道对的第一部分不是Discord频道名称！
 # 更改此选项并运行“/discord reload”以应用
@@ -285,15 +286,13 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 #
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: 當使用者已連結帳號時將其加入該身分組
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 允许向机器人发送新代码以取消链接并与新代码重新链接
-# MinecraftDiscordAccountEnablePM: 允许使用PM链接账户
-# MinecraftDiscordAccountChannels: 用于连接账户的迪斯科频道的名称或ID
+# MinecraftDiscordAccountLinkedUsePM: 使用PM链接账户
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
-MinecraftDiscordAccountEnablePM: true
-MinecraftDiscordAccountChannels: []
+MinecraftDiscordAccountLinkedUsePM: true
 
 # 伺服器監視器
 #

--- a/src/main/resources/config/zh.yml
+++ b/src/main/resources/config/zh.yml
@@ -285,11 +285,15 @@ DiscordCannedResponses: {"!ip": "yourserveripchange.me", "!site": "http://yoursi
 #
 # MinecraftDiscordAccountLinkedRoleNameToAddUserTo: 當使用者已連結帳號時將其加入該身分組
 # MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: 允许向机器人发送新代码以取消链接并与新代码重新链接
+# MinecraftDiscordAccountEnablePM: 允许使用PM链接账户
+# MinecraftDiscordAccountChannels: 用于连接账户的迪斯科频道的名称或ID
 #
 MinecraftDiscordAccountLinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountUnlinkedConsoleCommands: ["", "", ""]
 MinecraftDiscordAccountLinkedRoleNameToAddUserTo: "Linked"
 MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode: false
+MinecraftDiscordAccountEnablePM: true
+MinecraftDiscordAccountChannels: []
 
 # 伺服器監視器
 #


### PR DESCRIPTION
# Link accounts via guild text channel

Because the process of sending a PM to the Discord Bot to link accounts is complicated, I have added a way to link by sending a code to the text channel.

## How to enable the feature
1. See the `config.yml`
2. Add the channel id or name to `MinecraftDiscordAccountChannels`
3. Well done! You can type link code to the text channel

## Extra change
- Changed reply message to link code to use Discord's reply feature