### PR TITLE
Added GuildSlashCommandUpdateEvent

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
+++ b/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
@@ -30,6 +30,7 @@ import github.scarsz.discordsrv.api.commands.PluginSlashCommand;
 import github.scarsz.discordsrv.api.commands.SlashCommand;
 import github.scarsz.discordsrv.api.commands.SlashCommandProvider;
 import github.scarsz.discordsrv.api.events.Event;
+import github.scarsz.discordsrv.api.events.GuildSlashCommandUpdateEvent;
 import github.scarsz.discordsrv.util.LangUtil;
 import lombok.NonNull;
 import net.dv8tion.jda.api.entities.Guild;
@@ -37,6 +38,7 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.interactions.commands.Command;
+import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.requests.RestAction;
@@ -48,7 +50,12 @@ import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.stream.Collectors;
@@ -174,22 +181,23 @@ public class ApiManager extends ListenerAdapter {
         Set<RestAction<List<Command>>> guildCommandUpdateActions = new HashSet<>();
         Set<CommandRegistrationError> errors = Collections.synchronizedSet(new HashSet<>());
         for (Guild guild : DiscordSRV.getPlugin().getJda().getGuilds()) {
-            guildCommandUpdateActions.add(
-                    guild.updateCommands()
-                            .addCommands(commands.stream()
-                                    .filter(command -> command.isApplicable(guild))
-                                    .map(PluginSlashCommand::getCommandData)
-                                    .collect(Collectors.toSet())
-                            )
-                            .onErrorMap(throwable -> {
-                                errors.add(new CommandRegistrationError(guild, throwable));
-                                return null;
-                            })
-            );
+            Set<CommandData> commandSet = commands.stream()
+                    .filter(command -> command.isApplicable(guild))
+                    .map(PluginSlashCommand::getCommandData)
+                    .collect(Collectors.toSet());
+            GuildSlashCommandUpdateEvent event = DiscordSRV.api.callEvent(new GuildSlashCommandUpdateEvent(guild, commandSet));
+            if (!event.isCancelled()) {
+                guildCommandUpdateActions.add(
+                    guild.updateCommands().addCommands(commandSet).onErrorMap(throwable -> {
+                        errors.add(new CommandRegistrationError(guild, throwable));
+                        return null;
+                    })
+                );
+            }
         }
         RestAction.allOf(guildCommandUpdateActions).queue(all -> {
             int successful = all.stream().filter(Objects::nonNull).mapToInt(List::size).sum();
-            DiscordSRV.info("Successfully registered " + successful + " slash commands for " + commands.stream().map(PluginSlashCommand::getPlugin).distinct().count() + " plugins in " + successful + "/" + DiscordSRV.getPlugin().getJda().getGuilds().size() + " guilds");
+            DiscordSRV.info("Successfully registered " + successful + " slash commands for " + commands.stream().map(PluginSlashCommand::getPlugin).distinct().count() + " plugins in " + all.stream().filter(Objects::nonNull).count() + "/" + DiscordSRV.getPlugin().getJda().getGuilds().size() + " guilds");
 
             if (errors.isEmpty()) return;
 

--- a/src/main/java/github/scarsz/discordsrv/api/events/GuildSlashCommandUpdateEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/GuildSlashCommandUpdateEvent.java
@@ -1,0 +1,53 @@
+/*-
+ * LICENSE
+ * DiscordSRV
+ * -------------
+ * Copyright (C) 2016 - 2021 Austin "Scarsz" Shapiro
+ * -------------
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * END
+ */
+
+package github.scarsz.discordsrv.api.events;
+
+import github.scarsz.discordsrv.api.Cancellable;
+import lombok.Getter;
+import lombok.Setter;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.interactions.commands.build.CommandData;
+
+import java.util.Set;
+
+/**
+ * <p>Called before slash commands updates are sent to discord, when
+ * {@link github.scarsz.discordsrv.api.ApiManager#updateSlashCommands()} is called, once for each {@link Guild}</p>
+ *
+ * <p>You could change what commands are included by modifying the list of slash commands with
+ * {@link #getCommands()} or use {@link #setCancelled(boolean)} to prevent all slash commands from
+ * registering to this {@link Guild} altogether</p>
+ */
+public class GuildSlashCommandUpdateEvent extends Event implements Cancellable {
+
+    @Getter @Setter private boolean cancelled;
+
+    @Getter private final Guild guild;
+    @Getter private final Set<CommandData> commands;
+
+    public GuildSlashCommandUpdateEvent(Guild guild, Set<CommandData> commands) {
+        this.guild = guild;
+        this.commands = commands;
+    }
+
+}

--- a/src/main/java/github/scarsz/discordsrv/api/events/GuildSlashCommandUpdateEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/GuildSlashCommandUpdateEvent.java
@@ -31,12 +31,14 @@ import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 import java.util.Set;
 
 /**
- * <p>Called before slash commands updates are sent to discord, when
- * {@link github.scarsz.discordsrv.api.ApiManager#updateSlashCommands()} is called, once for each {@link Guild}</p>
+ * <p>Called before slash command updates are sent to discord when
+ * {@link github.scarsz.discordsrv.api.ApiManager#updateSlashCommands()} is called.
+ * This event is called once for each {@link Guild}</p>
  *
- * <p>You could change what commands are included by modifying the list of slash commands with
+ * <p>You could change what commands are included by modifying the {@link Set} of slash commands with
  * {@link #getCommands()} or use {@link #setCancelled(boolean)} to prevent all slash commands from
- * registering to this {@link Guild} altogether</p>
+ * registering to this {@link Guild} altogether. Cancelling also leave slash commands originally registered in a
+ * {@link Guild} untouched.</p>
  */
 public class GuildSlashCommandUpdateEvent extends Event implements Cancellable {
 


### PR DESCRIPTION
This PR adds the ability to modify the list of commands given to the `CommandListUpdateAction` when slash commands are updated. 

This allows for, for example, an addon trying to block a command from another, the ability to include commands not handled through the slash command API, or simply monitor what commands are being registered.

Cancelling this event can also allow a guild's slash commands to be left untouched by discordsrv.

Similar to what you would do in `PlayerCommandPreprocessEvent` or the exact purpose of `PlayerCommandSendEvent`