### PR TITLE
Schedule slash commands to be updated later when plugins are ready

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -1056,7 +1056,9 @@ public class DiscordSRV extends JavaPlugin {
         reloadChannels();
         reloadRegexes();
         reloadRoleAliases();
-        api.updateSlashCommands();
+
+        // schedule slash commands to be updated later when plugins are ready
+        Bukkit.getScheduler().runTaskLaterAsynchronously(this, api::updateSlashCommands, 20);
 
         // warn if the console channel is connected to a chat channel
         if (getMainTextChannel() != null && getConsoleChannel() != null && getMainTextChannel().getId().equals(getConsoleChannel().getId())) DiscordSRV.warning(LangUtil.InternalMessage.CONSOLE_CHANNEL_ASSIGNED_TO_LINKED_CHANNEL);

--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -1057,8 +1057,8 @@ public class DiscordSRV extends JavaPlugin {
         reloadRegexes();
         reloadRoleAliases();
 
-        // schedule slash commands to be updated later when plugins are ready
-        Bukkit.getScheduler().runTaskLaterAsynchronously(this, api::updateSlashCommands, 20);
+        // schedule slash commands to be updated later when plugins are ready (once the server had started up completely)
+        Bukkit.getScheduler().runTaskLater(this, () -> Bukkit.getScheduler().runTaskAsynchronously(this, api::updateSlashCommands), 20);
 
         // warn if the console channel is connected to a chat channel
         if (getMainTextChannel() != null && getConsoleChannel() != null && getMainTextChannel().getId().equals(getConsoleChannel().getId())) DiscordSRV.warning(LangUtil.InternalMessage.CONSOLE_CHANNEL_ASSIGNED_TO_LINKED_CHANNEL);

--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -1058,7 +1058,7 @@ public class DiscordSRV extends JavaPlugin {
         reloadRoleAliases();
 
         // schedule slash commands to be updated later when plugins are ready (once the server had started up completely)
-        Bukkit.getScheduler().runTaskLater(this, () -> Bukkit.getScheduler().runTaskAsynchronously(this, api::updateSlashCommands), 20);
+        Bukkit.getScheduler().runTask(this, () -> Bukkit.getScheduler().runTaskAsynchronously(this, api::updateSlashCommands));
 
         // warn if the console channel is connected to a chat channel
         if (getMainTextChannel() != null && getConsoleChannel() != null && getMainTextChannel().getId().equals(getConsoleChannel().getId())) DiscordSRV.warning(LangUtil.InternalMessage.CONSOLE_CHANNEL_ASSIGNED_TO_LINKED_CHANNEL);


### PR DESCRIPTION
This change makes it so that plugins won't have to register `onLoad()` if they want to catch the initial update slash command call.