### PR TITLE
Patch slash command api bugs

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/api/commands/PluginSlashCommand.java
+++ b/src/main/java/github/scarsz/discordsrv/api/commands/PluginSlashCommand.java
@@ -88,5 +88,24 @@ public class PluginSlashCommand {
         this.guilds.add(guildId);
         return this;
     }
+    /**
+     * Remove the given {@link Guild} from the list of guilds this command will be registered to,
+     * when none are provided the command will be registered to all guilds.
+     * @param guild the guild to be removed
+     * @return the {@link PluginSlashCommand} instance for chaining
+     */
+    public PluginSlashCommand removeGuildFilter(Guild guild) {
+        return removeGuildFilter(guild.getId());
+    }
+    /**
+     * Remove the given {@link Guild} id from the list of guilds this command will be registered to,
+     * when none are provided the command will be registered to all guilds.
+     * @param guildId the guild ID of the guild to be removed
+     * @return the {@link PluginSlashCommand} instance for chaining
+     */
+    public PluginSlashCommand removeGuildFilter(String guildId) {
+        this.guilds.remove(guildId);
+        return this;
+    }
 
 }

--- a/src/main/java/github/scarsz/discordsrv/api/commands/PluginSlashCommand.java
+++ b/src/main/java/github/scarsz/discordsrv/api/commands/PluginSlashCommand.java
@@ -47,7 +47,7 @@ public class PluginSlashCommand {
      * @param commandData the built command data
      */
     public PluginSlashCommand(Plugin plugin, CommandData commandData) {
-        this(plugin, commandData, (String) null);
+        this(plugin, commandData, (String[]) null);
     }
     /**
      * Construct data for a new plugin-originating slash command


### PR DESCRIPTION
Fixed and improved a few things for the slash command api
- `null` should be of type String[] in the constructor of `PluginSlashCommand`
- Prevent double `SlashCommandProvider` registration, if an instance is already a plugin main class instance
- `SlashCommandEvent` is not called for plugin main class instances of `SlashCommandProvider`s
- Only warn a slash command is not acknowledged by a plugin if none of its listeners responded to it, instead of once for each of them that doesn't
- Remove guild filter methods for `PluginSlashCommand` for chaining