### PR TITLE
Patch slash command api bugs / improvements

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
+++ b/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
@@ -50,7 +50,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -248,8 +247,8 @@ public class ApiManager extends ListenerAdapter {
      * @param provider the command data provider
      */
     public void addSlashCommandProvider(@NonNull SlashCommandProvider provider) {
-        // Prevent double registration, if an instance is already a plugin instance
-        if (Arrays.stream(Bukkit.getPluginManager().getPlugins()).anyMatch(plugin -> plugin == provider)) return;
+        // Prevent double registration, if an instance is a plugin instance
+        if (provider instanceof Plugin) return;
 
         this.slashCommandProviders.add(provider);
     }

--- a/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
+++ b/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
@@ -247,9 +247,7 @@ public class ApiManager extends ListenerAdapter {
      * @param provider the command data provider
      */
     public void addSlashCommandProvider(@NonNull SlashCommandProvider provider) {
-        // Prevent double registration, if an instance is a plugin instance
-        if (provider instanceof Plugin) return;
-
+        if (provider instanceof Plugin) return; // plugins are always registered
         this.slashCommandProviders.add(provider);
     }
     /**

--- a/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
+++ b/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
@@ -269,22 +269,36 @@ public class ApiManager extends ListenerAdapter {
                 .findFirst().orElse(null);
         if (commandData == null) return;
 
+        for (Plugin plugin : Bukkit.getPluginManager().getPlugins()) {
+            if (plugin instanceof SlashCommandProvider) {
+                SlashCommandProvider provider = (SlashCommandProvider) plugin;
+                handleSlashCommandEvent(provider, commandData, event);
+            }
+        }
         for (SlashCommandProvider provider : slashCommandProviders) {
-            for (Method method : provider.getClass().getMethods()) {
-                for (SlashCommand slashCommand : method.getAnnotationsByType(SlashCommand.class)) {
-                    if (!GlobPattern.compile(slashCommand.path()).matches(event.getCommandPath())) continue;
-                    if (method.getParameters().length != 1 || !method.getParameters()[0].getType().equals(SlashCommandEvent.class)) continue;
+            handleSlashCommandEvent(provider, commandData, event);
+        }
 
-                    if (!slashCommand.deferReply()) {
-                        invokeMethod(method, provider, event);
-                        ackCheck(event, commandData.getPlugin());
-                    } else {
-                        event.deferReply(slashCommand.deferEphemeral())
-                                .queue(hook -> {
-                                    invokeMethod(method, provider, event);
-                                    ackCheck(event, commandData.getPlugin());
-                                });
-                    }
+        ackCheck(event, commandData.getPlugin());
+    }
+
+    /**
+     * Go through a {@link SlashCommandProvider} and invoke methods that listen to the provided slash command
+     * @param provider the {@link SlashCommandProvider} to be searched and potentially invoked
+     * @param commandData the {@link PluginSlashCommand} data associated with this {@link SlashCommandEvent}
+     * @param event the {@link SlashCommandEvent} to be handled
+     */
+    private void handleSlashCommandEvent(SlashCommandProvider provider, PluginSlashCommand commandData, SlashCommandEvent event) {
+        for (Method method : provider.getClass().getMethods()) {
+            for (SlashCommand slashCommand : method.getAnnotationsByType(SlashCommand.class)) {
+                if (!GlobPattern.compile(slashCommand.path()).matches(event.getCommandPath())) continue;
+                if (method.getParameters().length != 1 || !method.getParameters()[0].getType().equals(SlashCommandEvent.class)) continue;
+
+                if (!slashCommand.deferReply()) {
+                    invokeMethod(method, provider, event);
+                } else {
+                    event.deferReply(slashCommand.deferEphemeral())
+                            .queue(hook -> invokeMethod(method, provider, event));
                 }
             }
         }

--- a/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
+++ b/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
@@ -50,6 +50,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -247,6 +248,9 @@ public class ApiManager extends ListenerAdapter {
      * @param provider the command data provider
      */
     public void addSlashCommandProvider(@NonNull SlashCommandProvider provider) {
+        // Prevent double registration, if an instance is already a plugin instance
+        if (Arrays.stream(Bukkit.getPluginManager().getPlugins()).anyMatch(plugin -> plugin == provider)) return;
+
         this.slashCommandProviders.add(provider);
     }
     /**

--- a/src/main/java/github/scarsz/discordsrv/api/commands/PluginSlashCommand.java
+++ b/src/main/java/github/scarsz/discordsrv/api/commands/PluginSlashCommand.java
@@ -88,5 +88,24 @@ public class PluginSlashCommand {
         this.guilds.add(guildId);
         return this;
     }
+    /**
+     * Remove the given {@link Guild} from the list of guilds this command will be registered to,
+     * when none are provided the command will be registered to all guilds.
+     * @param guild the guild to be removed
+     * @return the {@link PluginSlashCommand} instance for chaining
+     */
+    public PluginSlashCommand removeGuildFilter(Guild guild) {
+        return removeGuildFilter(guild.getId());
+    }
+    /**
+     * Remove the given {@link Guild} id from the list of guilds this command will be registered to,
+     * when none are provided the command will be registered to all guilds.
+     * @param guildId the guild ID of the guild to be removed
+     * @return the {@link PluginSlashCommand} instance for chaining
+     */
+    public PluginSlashCommand removeGuildFilter(String guildId) {
+        this.guilds.remove(guildId);
+        return this;
+    }
 
 }

--- a/src/main/java/github/scarsz/discordsrv/api/commands/PluginSlashCommand.java
+++ b/src/main/java/github/scarsz/discordsrv/api/commands/PluginSlashCommand.java
@@ -47,7 +47,7 @@ public class PluginSlashCommand {
      * @param commandData the built command data
      */
     public PluginSlashCommand(Plugin plugin, CommandData commandData) {
-        this(plugin, commandData, (String) null);
+        this(plugin, commandData, (String[]) null);
     }
     /**
      * Construct data for a new plugin-originating slash command


### PR DESCRIPTION
Fixed and improved a few things for the slash command api
- `null` should be of type String[] in the constructor of `PluginSlashCommand`
- Prevent double `SlashCommandProvider` registration, if an instance is already a `Plugin` instance
- `SlashCommandEvent` is not called for plugin main class instances of `SlashCommandProvider`
- Only warn "slash command not acknowledged by a plugin" if none of **all** of its listeners responded to it, instead of once for each of them that doesn't
- No need to check acknowledgement if the slash command is deferred *(through the annotation)*, as according to JDA docs, deferring the reply is already a form of acknowledgement 
- Added *(space)* remove guild filter methods for `PluginSlashCommand` for chaining