### PR TITLE
Fire an event before responding to player list commands

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordChatChannelListCommandMessageEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordChatChannelListCommandMessageEvent.java
@@ -50,12 +50,13 @@ public class DiscordChatChannelListCommandMessageEvent extends Event {
     @Getter @Setter private String playerListMessage;
     @Getter @Setter private int expiration;
 
-    public DiscordChatChannelListCommandMessageEvent(TextChannel channel, Guild guild, String message, GuildMessageReceivedEvent triggeringJDAEvent, String playerListMessage, Result result) {
+    public DiscordChatChannelListCommandMessageEvent(TextChannel channel, Guild guild, String message, GuildMessageReceivedEvent triggeringJDAEvent, String playerListMessage, int expiration, Result result) {
         this.channel = channel;
         this.guild = guild;
         this.message = message;
         this.triggeringJDAEvent = triggeringJDAEvent;
         this.playerListMessage = playerListMessage;
+        this.expiration = expiration;
         this.result = result;
     }
 
@@ -72,7 +73,7 @@ public class DiscordChatChannelListCommandMessageEvent extends Event {
 
         /**
          * <p>Cancel the event, treat message as regular discord message for further processing.</p>
-         * <p>(For example, be boardcasted in game)</p>
+         * <p>(For example, be broadcasted in game)</p>
          */
         TREAT_AS_REGULAR_MESSAGE;
 

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordChatChannelListCommandMessageEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordChatChannelListCommandMessageEvent.java
@@ -1,0 +1,81 @@
+/*-
+ * LICENSE
+ * DiscordSRV
+ * -------------
+ * Copyright (C) 2016 - 2021 Austin "Scarsz" Shapiro
+ * -------------
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * END
+ */
+
+package github.scarsz.discordsrv.api.events;
+
+import lombok.Getter;
+import lombok.Setter;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
+
+/**
+ * <p>Called before a playerlist command message response is sent to {@link TextChannel} by the bot</p>
+ *
+ * <p>To stop the command response from expiring, set it to 0 with {@link #setExpiration(int)}</p>
+ * <p>You can modify the result of this event with {@link #setResult(Result)}</p>
+ *
+ * @see Result#SEND_RESPONSE
+ * @see Result#NO_ACTION
+ * @see Result#TREAT_AS_REGULAR_MESSAGE
+ */
+public class DiscordChatChannelListCommandMessageEvent extends Event {
+
+    @Getter @Setter private Result result;
+
+    @Getter private final TextChannel channel;
+    @Getter private final Guild guild;
+    @Getter private final String message;
+    @Getter private final GuildMessageReceivedEvent triggeringJDAEvent;
+
+    @Getter @Setter private String playerListMessage;
+    @Getter @Setter private int expiration;
+
+    public DiscordChatChannelListCommandMessageEvent(TextChannel channel, Guild guild, String message, GuildMessageReceivedEvent triggeringJDAEvent, String playerListMessage, Result result) {
+        this.channel = channel;
+        this.guild = guild;
+        this.message = message;
+        this.triggeringJDAEvent = triggeringJDAEvent;
+        this.playerListMessage = playerListMessage;
+        this.result = result;
+    }
+
+    public enum Result {
+        /**
+         * <p>Send the player list response like normal.</p>
+         */
+        SEND_RESPONSE,
+
+        /**
+         * <p>Cancel the event, do not perform any action afterwards.</p>
+         */
+        NO_ACTION,
+
+        /**
+         * <p>Cancel the event, treat message as regular discord message for further processing.</p>
+         * <p>(For example, be boardcasted in game)</p>
+         */
+        TREAT_AS_REGULAR_MESSAGE;
+
+    }
+
+}

--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordChatListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordChatListener.java
@@ -408,11 +408,11 @@ public class DiscordChatListener extends ListenerAdapter {
         if (!StringUtils.trimToEmpty(message).equalsIgnoreCase(DiscordSRV.config().getString("DiscordChatChannelListCommandMessage"))) return false;
 
         int expiration = DiscordSRV.config().getInt("DiscordChatChannelListCommandExpiration") * 1000;
-        String playerListMessage = "";
+        String playerListMessage;
         if (PlayerUtil.getOnlinePlayers(true).size() == 0) {
             playerListMessage = PlaceholderUtil.replacePlaceholdersToDiscord(LangUtil.Message.PLAYER_LIST_COMMAND_NO_PLAYERS.toString());
         } else {
-            playerListMessage += LangUtil.Message.PLAYER_LIST_COMMAND.toString().replace("%playercount%", PlayerUtil.getOnlinePlayers(true).size() + "/" + Bukkit.getMaxPlayers());
+            playerListMessage = LangUtil.Message.PLAYER_LIST_COMMAND.toString().replace("%playercount%", PlayerUtil.getOnlinePlayers(true).size() + "/" + Bukkit.getMaxPlayers());
             playerListMessage = PlaceholderUtil.replacePlaceholdersToDiscord(playerListMessage);
             playerListMessage += "\n```\n";
 
@@ -448,7 +448,7 @@ public class DiscordChatListener extends ListenerAdapter {
         }
 
         DiscordChatChannelListCommandMessageEvent listCommandMessageEvent = DiscordSRV.api.callEvent(
-                new DiscordChatChannelListCommandMessageEvent(event.getChannel(), event.getGuild(), message, event, playerListMessage, DiscordChatChannelListCommandMessageEvent.Result.SEND_RESPONSE));
+                new DiscordChatChannelListCommandMessageEvent(event.getChannel(), event.getGuild(), message, event, playerListMessage, expiration, DiscordChatChannelListCommandMessageEvent.Result.SEND_RESPONSE));
         switch (listCommandMessageEvent.getResult()) {
             case SEND_RESPONSE:
                 DiscordUtil.sendMessage(event.getChannel(), listCommandMessageEvent.getPlayerListMessage(), listCommandMessageEvent.getExpiration());

--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordChatListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordChatListener.java
@@ -407,10 +407,11 @@ public class DiscordChatListener extends ListenerAdapter {
         if (!DiscordSRV.config().getBoolean("DiscordChatChannelListCommandEnabled")) return false;
         if (!StringUtils.trimToEmpty(message).equalsIgnoreCase(DiscordSRV.config().getString("DiscordChatChannelListCommandMessage"))) return false;
 
+        int expiration = DiscordSRV.config().getInt("DiscordChatChannelListCommandExpiration") * 1000;
+        String playerListMessage = "";
         if (PlayerUtil.getOnlinePlayers(true).size() == 0) {
-            DiscordUtil.sendMessage(event.getChannel(), PlaceholderUtil.replacePlaceholdersToDiscord(LangUtil.Message.PLAYER_LIST_COMMAND_NO_PLAYERS.toString()), DiscordSRV.config().getInt("DiscordChatChannelListCommandExpiration") * 1000);
+            playerListMessage = PlaceholderUtil.replacePlaceholdersToDiscord(LangUtil.Message.PLAYER_LIST_COMMAND_NO_PLAYERS.toString());
         } else {
-            String playerListMessage = "";
             playerListMessage += LangUtil.Message.PLAYER_LIST_COMMAND.toString().replace("%playercount%", PlayerUtil.getOnlinePlayers(true).size() + "/" + Bukkit.getMaxPlayers());
             playerListMessage = PlaceholderUtil.replacePlaceholdersToDiscord(playerListMessage);
             playerListMessage += "\n```\n";
@@ -444,17 +445,29 @@ public class DiscordChatListener extends ListenerAdapter {
 
             if (playerListMessage.length() > 1996) playerListMessage = playerListMessage.substring(0, 1993) + "...";
             playerListMessage += "\n```";
-            DiscordUtil.sendMessage(event.getChannel(), playerListMessage, DiscordSRV.config().getInt("DiscordChatChannelListCommandExpiration") * 1000);
         }
 
-        // expire message after specified time
-        if (DiscordSRV.config().getInt("DiscordChatChannelListCommandExpiration") > 0 && DiscordSRV.config().getBoolean("DiscordChatChannelListCommandExpirationDeleteRequest")) {
-            new Thread(() -> {
-                try {
-                    Thread.sleep(DiscordSRV.config().getInt("DiscordChatChannelListCommandExpiration") * 1000L);
-                } catch (InterruptedException ignored) {}
-                DiscordUtil.deleteMessage(event.getMessage());
-            }).start();
+        DiscordChatChannelListCommandMessageEvent listCommandMessageEvent = DiscordSRV.api.callEvent(
+                new DiscordChatChannelListCommandMessageEvent(event.getChannel(), event.getGuild(), message, event, playerListMessage, DiscordChatChannelListCommandMessageEvent.Result.SEND_RESPONSE));
+        switch (listCommandMessageEvent.getResult()) {
+            case SEND_RESPONSE:
+                DiscordUtil.sendMessage(event.getChannel(), listCommandMessageEvent.getPlayerListMessage(), listCommandMessageEvent.getExpiration());
+
+                // expire message after specified time
+                if (listCommandMessageEvent.getExpiration() > 0 && DiscordSRV.config().getBoolean("DiscordChatChannelListCommandExpirationDeleteRequest")) {
+                    new Thread(() -> {
+                        try {
+                            Thread.sleep(listCommandMessageEvent.getExpiration());
+                        } catch (InterruptedException ignored) {
+                        }
+                        DiscordUtil.deleteMessage(event.getMessage());
+                    }).start();
+                }
+                return true;
+            case NO_ACTION:
+                return true;
+            case TREAT_AS_REGULAR_MESSAGE:
+                return false;
         }
         return true;
     }

--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordChatListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordChatListener.java
@@ -39,7 +39,6 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.format.TextColor;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -51,6 +50,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
@@ -455,13 +455,7 @@ public class DiscordChatListener extends ListenerAdapter {
 
                 // expire message after specified time
                 if (listCommandMessageEvent.getExpiration() > 0 && DiscordSRV.config().getBoolean("DiscordChatChannelListCommandExpirationDeleteRequest")) {
-                    new Thread(() -> {
-                        try {
-                            Thread.sleep(listCommandMessageEvent.getExpiration());
-                        } catch (InterruptedException ignored) {
-                        }
-                        DiscordUtil.deleteMessage(event.getMessage());
-                    }).start();
+                    event.getMessage().delete().queueAfter(listCommandMessageEvent.getExpiration(), TimeUnit.MILLISECONDS);
                 }
                 return true;
             case NO_ACTION:


### PR DESCRIPTION
Added new `DiscordChatChannelListCommandMessageEvent`, this event is fired before responding to player list commands by discordsrv, allowing plugins to modify the response.