### PR TITLE
Slash Command Priorities

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
+++ b/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
@@ -217,7 +217,10 @@ public class ApiManager extends ListenerAdapter {
         int finalConflictingCommands = conflictingCommands;
         RestAction.allOf(guildCommandUpdateActions).queue(all -> {
             int successful = all.stream().filter(Objects::nonNull).mapToInt(List::size).sum();
-            DiscordSRV.info("Successfully registered " + successful + " slash commands (" + finalConflictingCommands + " conflicted) for " + conflictResolvedCommands.values().stream().map(PluginSlashCommand::getPlugin).distinct().count() + " plugins in " + all.stream().filter(Objects::nonNull).count() + "/" + DiscordSRV.getPlugin().getJda().getGuilds().size() + " guilds (" + finalCancelledGuilds + " cancelled)");
+            long pluginCount = conflictResolvedCommands.values().stream().map(PluginSlashCommand::getPlugin).distinct().count();
+            long registeredGuilds = all.stream().filter(Objects::nonNull).count();
+            int totalGuilds = DiscordSRV.getPlugin().getJda().getGuilds().size();
+            DiscordSRV.info("Successfully registered " + successful + " slash commands (" + finalConflictingCommands + " conflicted) for " + pluginCount + " plugins in " + registeredGuilds + "/" + totalGuilds + " guilds (" + finalCancelledGuilds + " cancelled)");
 
             if (errors.isEmpty()) return;
 

--- a/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
+++ b/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
@@ -184,7 +184,7 @@ public class ApiManager extends ListenerAdapter {
             PluginSlashCommand conflictingCommand = conflictResolvedCommands.putIfAbsent(name, pluginSlashCommand);
             if (conflictingCommand == null) continue;
             conflictingCommands++;
-            if (pluginSlashCommand.getPriority().ordinal() > conflictingCommand.getPriority().ordinal())
+            if (pluginSlashCommand.getPriority().ordinal() < conflictingCommand.getPriority().ordinal())
                 conflictResolvedCommands.put(name, pluginSlashCommand);
         }
 

--- a/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
+++ b/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
@@ -313,6 +313,7 @@ public class ApiManager extends ListenerAdapter {
         for (Method method : provider.getClass().getMethods()) {
             for (SlashCommand slashCommand : method.getAnnotationsByType(SlashCommand.class)) {
                 if (slashCommand.priority() != priority) continue;
+                if (!slashCommand.ignoreAcknowledged() && event.isAcknowledged()) continue;
                 if (!GlobPattern.compile(slashCommand.path()).matches(event.getCommandPath())) continue;
                 if (method.getParameters().length != 1 || !method.getParameters()[0].getType().equals(SlashCommandEvent.class)) continue;
 

--- a/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
+++ b/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
@@ -184,7 +184,7 @@ public class ApiManager extends ListenerAdapter {
             PluginSlashCommand conflictingCommand = conflictResolvedCommands.putIfAbsent(name, pluginSlashCommand);
             if (conflictingCommand == null) continue;
             conflictingCommands++;
-            if (pluginSlashCommand.getPriority().getSlot() > conflictingCommand.getPriority().getSlot())
+            if (pluginSlashCommand.getPriority().ordinal() > conflictingCommand.getPriority().ordinal())
                 conflictResolvedCommands.put(name, pluginSlashCommand);
         }
 

--- a/src/main/java/github/scarsz/discordsrv/api/commands/PluginSlashCommand.java
+++ b/src/main/java/github/scarsz/discordsrv/api/commands/PluginSlashCommand.java
@@ -23,6 +23,7 @@
 package github.scarsz.discordsrv.api.commands;
 
 import lombok.Value;
+import lombok.experimental.NonFinal;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 import org.bukkit.plugin.Plugin;
@@ -40,6 +41,7 @@ public class PluginSlashCommand {
     Plugin plugin;
     CommandData commandData;
     Set<String> guilds = new HashSet<>();
+    @NonFinal SlashCommandPriority priority;
 
     /**
      * Construct data for a new plugin-originating slash command
@@ -47,7 +49,16 @@ public class PluginSlashCommand {
      * @param commandData the built command data
      */
     public PluginSlashCommand(Plugin plugin, CommandData commandData) {
-        this(plugin, commandData, (String[]) null);
+        this(plugin, commandData, SlashCommandPriority.NORMAL);
+    }
+    /**
+     * Construct data for a new plugin-originating slash command
+     * @param plugin the owning plugin
+     * @param commandData the built command data
+     * @param priority the priority of this slash command
+     */
+    public PluginSlashCommand(Plugin plugin, CommandData commandData, SlashCommandPriority priority) {
+        this(plugin, commandData, priority, (String[]) null);
     }
     /**
      * Construct data for a new plugin-originating slash command
@@ -56,11 +67,21 @@ public class PluginSlashCommand {
      * @param guildIds the applicable guild IDs for this command. if not provided, command will be applicable to all guilds
      */
     public PluginSlashCommand(Plugin plugin, CommandData commandData, String... guildIds) {
+        this(plugin, commandData, SlashCommandPriority.NORMAL, guildIds);
+    }
+    /**
+     * Construct data for a new plugin-originating slash command
+     * @param plugin the owning plugin
+     * @param commandData the built command data
+     * @param priority the priority of this slash command
+     * @param guildIds the applicable guild IDs for this command. if not provided, command will be applicable to all guilds
+     */
+    public PluginSlashCommand(Plugin plugin, CommandData commandData, SlashCommandPriority priority, String... guildIds) {
         this.plugin = plugin;
         this.commandData = commandData;
+        this.priority = priority;
         if (guildIds != null) Collections.addAll(guilds, guildIds);
     }
-
     /**
      * Whether this plugin command is applicable to the given guild
      * @param guild the guild to check for
@@ -105,6 +126,15 @@ public class PluginSlashCommand {
      */
     public PluginSlashCommand removeGuildFilter(String guildId) {
         this.guilds.remove(guildId);
+        return this;
+    }
+    /**
+     * Set the priority of this slash command when handling registration conflicts
+     * @param priority the priority of this slash command
+     * @return the {@link PluginSlashCommand} instance for chaining
+     */
+    public PluginSlashCommand priority(SlashCommandPriority priority) {
+        this.priority = priority;
         return this;
     }
 

--- a/src/main/java/github/scarsz/discordsrv/api/commands/PluginSlashCommand.java
+++ b/src/main/java/github/scarsz/discordsrv/api/commands/PluginSlashCommand.java
@@ -133,7 +133,7 @@ public class PluginSlashCommand {
      * @param priority the priority of this slash command
      * @return the {@link PluginSlashCommand} instance for chaining
      */
-    public PluginSlashCommand priority(SlashCommandPriority priority) {
+    public PluginSlashCommand setPriority(SlashCommandPriority priority) {
         this.priority = priority;
         return this;
     }

--- a/src/main/java/github/scarsz/discordsrv/api/commands/SlashCommand.java
+++ b/src/main/java/github/scarsz/discordsrv/api/commands/SlashCommand.java
@@ -57,7 +57,8 @@ public @interface SlashCommand {
     String path();
 
     /**
-     * The priority of this slash command handler. Multiple slash commands handlers with the same priority will be fired haphazardly.
+     * The priority of this slash command handler. Multiple slash commands handlers with the same priority will be fired
+     * in an undefined order.
      * @return the priority of the slash command handler method
      */
     SlashCommandPriority priority() default SlashCommandPriority.NORMAL;

--- a/src/main/java/github/scarsz/discordsrv/api/commands/SlashCommand.java
+++ b/src/main/java/github/scarsz/discordsrv/api/commands/SlashCommand.java
@@ -60,7 +60,7 @@ public @interface SlashCommand {
      * The priority of this slash command handler. Multiple slash commands handlers with the same priority will be fired haphazardly.
      * @return the priority of the slash command handler method
      */
-    SlashCommandPriority priority();
+    SlashCommandPriority priority() default SlashCommandPriority.NORMAL;
 
     /**
      * Tells DiscordSRV to automatically acknowledge the command & defer replying for you.

--- a/src/main/java/github/scarsz/discordsrv/api/commands/SlashCommand.java
+++ b/src/main/java/github/scarsz/discordsrv/api/commands/SlashCommand.java
@@ -79,4 +79,10 @@ public @interface SlashCommand {
      */
     boolean deferEphemeral() default false;
 
+    /**
+     * @return whether DiscordSRV should still invoke this slash command handler if the event had already been
+     * acknowledged in a prior handler.
+     */
+    boolean ignoreAcknowledged() default false;
+
 }

--- a/src/main/java/github/scarsz/discordsrv/api/commands/SlashCommand.java
+++ b/src/main/java/github/scarsz/discordsrv/api/commands/SlashCommand.java
@@ -57,6 +57,12 @@ public @interface SlashCommand {
     String path();
 
     /**
+     * The priority of this slash command handler. Multiple slash commands handlers with the same priority will be fired haphazardly.
+     * @return the priority of the slash command handler method
+     */
+    SlashCommandPriority priority();
+
+    /**
      * Tells DiscordSRV to automatically acknowledge the command & defer replying for you.
      * Reply deferring is required when your command might take longer than 3 seconds to execute.
      * If the reply is deferred, you have up to 15 minutes for your command to respond.

--- a/src/main/java/github/scarsz/discordsrv/api/commands/SlashCommand.java
+++ b/src/main/java/github/scarsz/discordsrv/api/commands/SlashCommand.java
@@ -74,6 +74,7 @@ public @interface SlashCommand {
      * @return whether DiscordSRV should automatically defer the interaction's reply when routing the event to your handler
      */
     boolean deferReply() default false;
+
     /**
      * @return whether events that are automatically deferred with {@link SlashCommand#deferReply()} will be ephemeral;
      * ephemeral replies are only shown temporarily to the user that executed the command.

--- a/src/main/java/github/scarsz/discordsrv/api/commands/SlashCommandPriority.java
+++ b/src/main/java/github/scarsz/discordsrv/api/commands/SlashCommandPriority.java
@@ -22,8 +22,6 @@
 
 package github.scarsz.discordsrv.api.commands;
 
-import lombok.Getter;
-
 /**
  * <p>Used to indicate the registration priority of slash commands and the invocation order of slash command handlers</p>
  * <p>Defaults to {@link #NORMAL} in {@link PluginSlashCommand} where it's not specifically set</p>

--- a/src/main/java/github/scarsz/discordsrv/api/commands/SlashCommandPriority.java
+++ b/src/main/java/github/scarsz/discordsrv/api/commands/SlashCommandPriority.java
@@ -1,0 +1,62 @@
+/*-
+ * LICENSE
+ * DiscordSRV
+ * -------------
+ * Copyright (C) 2016 - 2021 Austin "Scarsz" Shapiro
+ * -------------
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * END
+ */
+
+package github.scarsz.discordsrv.api.commands;
+
+import lombok.Getter;
+
+/**
+ * <p>Used to indicate the registration priority of slash commands and the invocation order of slash command handlers</p>
+ * <p>Defaults to {@link #NORMAL} in {@link SlashCommand} annotations where it's not specifically set</p>
+ * <p>Defaults to {@link #NORMAL} in {@link PluginSlashCommand} where it's not specifically set</p>
+ */
+public enum SlashCommandPriority {
+
+    /**
+     * Slash command should be prioritized before every other
+     */
+    FIRST(0),
+    /**
+     * Slash command is important to not be overridden by others
+     */
+    EARLY(1),
+    /**
+     * Slash command is neither important nor unimportant, and may be prioritized
+     * normally
+     */
+    NORMAL(2),
+    /**
+     * Slash command is not important and may be overridden by others
+     */
+    LATE(3),
+    /**
+     * Slash command should be overridden by any other if other plugin so chooses
+     */
+    LAST(4);
+
+    @Getter private final int slot;
+
+    SlashCommandPriority(int slot) {
+        this.slot = slot;
+    }
+
+}

--- a/src/main/java/github/scarsz/discordsrv/api/commands/SlashCommandPriority.java
+++ b/src/main/java/github/scarsz/discordsrv/api/commands/SlashCommandPriority.java
@@ -35,32 +35,26 @@ public enum SlashCommandPriority {
      * <p>When in {@link PluginSlashCommand} - Slash command should always be prioritized before every other</p>
      * <p>When in {@link SlashCommand} - Slash command handler should always be fired first, taking precedent over others</p>
      */
-    FIRST(0),
+    FIRST,
     /**
      * <p>When in {@link PluginSlashCommand} - Slash command is important and should not be overridden by others</p>
      * <p>When in {@link SlashCommand} - Slash command handler is important and should not be overtaken by others</p>
      */
-    EARLY(1),
+    EARLY,
     /**
      * <p>When in {@link PluginSlashCommand} - Slash command is neither important nor unimportant, and may be prioritized normally</p>
      * <p>When in {@link SlashCommand} - Slash command handler is neither important nor unimportant, and may be prioritized normally</p>
      */
-    NORMAL(2),
+    NORMAL,
     /**
      * <p>When in {@link PluginSlashCommand} - Slash command is not important and may be overridden by others</p>
      * <p>When in {@link SlashCommand} - Slash command handler is not important and may give way to other handlers who wishes to overtake</p>
      */
-    LATE(3),
+    LATE,
     /**
      * <p>When in {@link PluginSlashCommand} - Slash command should be overridden by any other if other conflicting commands exist</p>
      * <p>When in {@link SlashCommand} - Slash command handler should always be overtaken if any other handlers wishes to </p>
      */
-    LAST(4);
-
-    @Getter private final int slot;
-
-    SlashCommandPriority(int slot) {
-        this.slot = slot;
-    }
+    LAST;
 
 }

--- a/src/main/java/github/scarsz/discordsrv/api/commands/SlashCommandPriority.java
+++ b/src/main/java/github/scarsz/discordsrv/api/commands/SlashCommandPriority.java
@@ -26,30 +26,34 @@ import lombok.Getter;
 
 /**
  * <p>Used to indicate the registration priority of slash commands and the invocation order of slash command handlers</p>
- * <p>Defaults to {@link #NORMAL} in {@link SlashCommand} annotations where it's not specifically set</p>
  * <p>Defaults to {@link #NORMAL} in {@link PluginSlashCommand} where it's not specifically set</p>
+ * <p>Defaults to {@link #NORMAL} in {@link SlashCommand} annotations where it's not specifically set</p>
  */
 public enum SlashCommandPriority {
 
     /**
-     * Slash command should be prioritized before every other
+     * <p>When in {@link PluginSlashCommand} - Slash command should always be prioritized before every other</p>
+     * <p>When in {@link SlashCommand} - Slash command handler should always be fired first, taking precedent over others</p>
      */
     FIRST(0),
     /**
-     * Slash command is important to not be overridden by others
+     * <p>When in {@link PluginSlashCommand} - Slash command is important and should not be overridden by others</p>
+     * <p>When in {@link SlashCommand} - Slash command handler is important and should not be overtaken by others</p>
      */
     EARLY(1),
     /**
-     * Slash command is neither important nor unimportant, and may be prioritized
-     * normally
+     * <p>When in {@link PluginSlashCommand} - Slash command is neither important nor unimportant, and may be prioritized normally</p>
+     * <p>When in {@link SlashCommand} - Slash command handler is neither important nor unimportant, and may be prioritized normally</p>
      */
     NORMAL(2),
     /**
-     * Slash command is not important and may be overridden by others
+     * <p>When in {@link PluginSlashCommand} - Slash command is not important and may be overridden by others</p>
+     * <p>When in {@link SlashCommand} - Slash command handler is not important and may give way to other handlers who wishes to overtake</p>
      */
     LATE(3),
     /**
-     * Slash command should be overridden by any other if other plugin so chooses
+     * <p>When in {@link PluginSlashCommand} - Slash command should be overridden by any other if other conflicting commands exist</p>
+     * <p>When in {@link SlashCommand} - Slash command handler should always be overtaken if any other handlers wishes to </p>
      */
     LAST(4);
 


### PR DESCRIPTION
This PR introduces slash command priorities both during command registration and command handling. 
It opens the door to converting DiscordSRV's built-in text commands into slash commands while allowing other plugins to override them.

Tho there are a few questions
- Is this a good way to approach this problem?
- If so, should `SlashCommandPriority` in `SlashCommand` annotations and `PluginSlashCommand` fields use separated enums?