### PR TITLE
Add mention placeholder to account linking message

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/objects/managers/link/FileAccountLinkManager.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/managers/link/FileAccountLinkManager.java
@@ -130,6 +130,9 @@ public class FileAccountLinkManager extends AbstractAccountLinkManager {
         synchronized (linkedAccounts) {
             contains = linkedAccounts.containsKey(discordId);
         }
+
+        String mention = DiscordUtil.getUserById(discordId).getAsMention();
+
         if (contains) {
             if (DiscordSRV.config().getBoolean("MinecraftDiscordAccountLinkedAllowRelinkBySendingANewCode")) {
                 unlink(discordId);
@@ -141,7 +144,8 @@ public class FileAccountLinkManager extends AbstractAccountLinkManager {
                 OfflinePlayer offlinePlayer = DiscordSRV.getPlugin().getServer().getOfflinePlayer(uuid);
                 return LangUtil.Message.ALREADY_LINKED.toString()
                         .replace("%username%", PrettyUtil.beautifyUsername(offlinePlayer, "<Unknown>", false))
-                        .replace("%uuid%", uuid.toString());
+                        .replace("%uuid%", uuid.toString())
+                        .replace("%mention%", mention);
             }
         }
 
@@ -163,12 +167,16 @@ public class FileAccountLinkManager extends AbstractAccountLinkManager {
             return LangUtil.Message.DISCORD_ACCOUNT_LINKED.toString()
                     .replace("%name%", PrettyUtil.beautifyUsername(player, "<Unknown>", false))
                     .replace("%displayname%", PrettyUtil.beautifyNickname(player, "<Unknown>", false))
-                    .replace("%uuid%", getUuid(discordId).toString());
+                    .replace("%uuid%", getUuid(discordId).toString())
+                    .replace("%mention%", mention);
         }
 
-        return linkCode.length() == 4
+        String reply = linkCode.length() == 4
                 ? LangUtil.Message.UNKNOWN_CODE.toString()
                 : LangUtil.Message.INVALID_CODE.toString();
+        return reply
+                .replace("%code%", linkCode)
+                .replace("%mention%", mention);
     }
 
     @Override

--- a/src/main/java/github/scarsz/discordsrv/objects/managers/link/JdbcAccountLinkManager.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/managers/link/JdbcAccountLinkManager.java
@@ -30,6 +30,7 @@ import github.scarsz.discordsrv.objects.ExpiringDualHashBidiMap;
 import github.scarsz.discordsrv.util.DiscordUtil;
 import github.scarsz.discordsrv.util.LangUtil;
 import github.scarsz.discordsrv.util.MessageUtil;
+import github.scarsz.discordsrv.util.PrettyUtil;
 import github.scarsz.discordsrv.util.SQLUtil;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -350,6 +351,9 @@ public class JdbcAccountLinkManager extends AbstractAccountLinkManager {
     @Override
     public String process(String code, String discordId) {
         ensureOffThread(false);
+
+        String mention = DiscordUtil.getUserById(discordId).getAsMention();
+
         UUID existingUuid = getUuid(discordId);
         boolean alreadyLinked = existingUuid != null;
         if (alreadyLinked) {
@@ -359,7 +363,8 @@ public class JdbcAccountLinkManager extends AbstractAccountLinkManager {
                 OfflinePlayer offlinePlayer = DiscordSRV.getPlugin().getServer().getOfflinePlayer(existingUuid);
                 return LangUtil.Message.ALREADY_LINKED.toString()
                         .replace("%username%", String.valueOf(offlinePlayer.getName()))
-                        .replace("%uuid%", offlinePlayer.getUniqueId().toString());
+                        .replace("%uuid%", offlinePlayer.getUniqueId().toString())
+                        .replace("%mention%", mention);
             }
         }
 
@@ -386,13 +391,18 @@ public class JdbcAccountLinkManager extends AbstractAccountLinkManager {
             }
 
             return LangUtil.Message.DISCORD_ACCOUNT_LINKED.toString()
-                    .replace("%name%", player.getName() != null ? player.getName() : "<Unknown>")
-                    .replace("%uuid%", uuid.toString());
+                    .replace("%name%", PrettyUtil.beautifyUsername(player, "<Unknown>", false))
+                    .replace("%displayname%", PrettyUtil.beautifyNickname(player, "<Unknown>", false))
+                    .replace("%uuid%", uuid.toString())
+                    .replace("%mention%", mention);
         }
 
-        return code.length() == 4
+        String reply = code.length() == 4
                 ? LangUtil.Message.UNKNOWN_CODE.toString()
                 : LangUtil.Message.INVALID_CODE.toString();
+        return reply
+                .replace("%code%", code)
+                .replace("%mention%", mention);
     }
 
     @Override

--- a/src/main/resources/messages/de.yml
+++ b/src/main/resources/messages/de.yml
@@ -414,11 +414,15 @@ ServerWatchdogMessage: "<t:%timestamp%:R> %guildowner%, der Server hat in %timeo
 # Verfügbare Platzhalter:
 # CodeGenerated:                %code%:         der generierte Code für den Spieler, um seine Accounts zu verbinden
 #                               %botname%:      der Name des Bots in Discord
+# UnknownCode/InvalidCode:      %code%:         der generierte Code für den Spieler, um seine Accounts zu verbinden
+#                               %mention%:      die Erwähnung des Discord-Kontos
 # DiscordAccountLinked:         %name%:         der Name des Minecraft-Spielers, dessen Discord-Account verbunden wurde
 #                               %displayname%:  der Anzeigename des Minecraft-Players, mit dem das Discord-Konto des Benutzers verknüpft war
 #                               %uuid%:         die UUID des Minecraft-Spielers, dessen Discord-Account verbunden wurde
+#                               %mention%:      Erwähnungen an Discord-Konten
 # DiscordAccountAlreadyLinked:  %uuid%:         die Minecraft-UUID des verknüpften Minecraft-Kontos des Benutzers
 #                               %username%:     der Minecraft-Benutzername des verknüpften Minecraft-Kontos des Benutzers
+#                               %mention%:      Erwähnungen an Discord-Konten
 # DiscordLinkedAccountRequired  %message%:      die Nachricht, die der Benutzer nicht senden konnte, weil sie nicht verknüpft waren
 # MinecraftAccountLinked:       %id%:           die Discord-ID des Discord-Nutzers, dessen Minecraft-Account verbunden wurde
 #                               %username%:     der Discord-Name des Discord-Nutzers, dessen Minecraft-Account verbunden wurde

--- a/src/main/resources/messages/en.yml
+++ b/src/main/resources/messages/en.yml
@@ -409,11 +409,15 @@ ServerWatchdogMessage: "<t:%timestamp%:R> %guildowner%, the server hasn't ticked
 # Available placeholders:
 # CodeGenerated:                %code%:         the code generated for the player to link their account with
 #                               %botname%:      the name of the bot on Discord
+# UnknownCode/InvalidCode:      %code%:         the code generated for the player to link their account with
+#                               %mention%:      the mention to Discord account
 # DiscordAccountLinked:         %name%:         the name of the Minecraft player that the user's Discord account was linked to
 #                               %displayname%:  the display name of the Minecraft player that the user's Discord account was linked to
 #                               %uuid%:         the uuid of the Minecraft player that the user's Discord account was linked to
+#                               %mention%:      the mention to Discord account
 # DiscordAccountAlreadyLinked:  %uuid%:         the Minecraft uuid of the user's linked Minecraft account
 #                               %username%:     the Minecraft username of the user's linked Minecraft account
+#                               %mention%:      the mention to Discord account
 # DiscordLinkedAccountRequired  %message%:      the message the user was not able to send because they were not linked
 # MinecraftAccountLinked:       %id%:           the discord id of the Discord user that the user's Minecraft account was linked to
 #                               %username%:     the discord name of the Discord user that the user's Minecraft account was linked to

--- a/src/main/resources/messages/es.yml
+++ b/src/main/resources/messages/es.yml
@@ -407,11 +407,15 @@ ServerWatchdogMessage: "<t:%timestamp%:R> %guildowner%, el servidor no ha respon
 # Variables disponibles:
 # CodeGenerated:                %code%:         el código generado para que el jugador vincule su cuenta
 #                               %botname%:      el nombre del bot en Discord
+# UnknownCode/InvalidCode:      %code%:         el código generado para que el jugador vincule su cuenta
+#                               %mention%:      la mención a la cuenta de Discordia
 # DiscordAccountLinked:         %name%:         el nombre del jugador de Minecraft al que estaba vinculada la cuenta de Discord
 #                               %displayname%:  el nombre para mostrar del reproductor de Minecraft al que se vinculó la cuenta Discord del usuario
 #                               %uuid%:         uuid del jugador de Minecraft al que estaba vinculada la cuenta de Discord
+#                               %mention%:      la mención a la cuenta de Discordia
 # DiscordAccountAlreadyLinked:  %uuid%:         el uuid de Minecraft de la cuenta de Minecraft vinculada del usuario
 #                               %username%:     el nombre de usuario de Minecraft de la cuenta de Minecraft vinculada del usuario
+#                               %mention%:      la mención a la cuenta de Discordia
 # DiscordLinkedAccountRequired  %message%:      el mensaje que el usuario no pudo enviar porque no estaba vinculado
 # MinecraftAccountLinked:       %id%:           el ID de Discord del usuario al que estaba vinculada la cuenta de Minecraft
 #                               %username%:     el nombre de Discord del usuario al que estaba vinculada la cuenta de Minecraft

--- a/src/main/resources/messages/et.yml
+++ b/src/main/resources/messages/et.yml
@@ -409,11 +409,15 @@ ServerWatchdogMessage: "<t:%timestamp%:R> %guildowner%, server ei ole %timeout% 
 # Available placeholders:
 # CodeGenerated:                %code%:         the code generated for the player to link their account with
 #                               %botname%:      the name of the bot on Discord
+# UnknownCode/InvalidCode:      %code%:         the code generated for the player to link their account with
+#                               %mention%:      märkus Discord kontole
 # DiscordAccountLinked:         %name%:         the name of the Minecraft player that the user's Discord account was linked to
 #                               %displayname%:  the display name of the Minecraft player that the user's Discord account was linked to
 #                               %uuid%:         the uuid of the Minecraft player that the user's Discord account was linked to
+#                               %mention%:      märkus Discord kontole
 # DiscordAccountAlreadyLinked:  %uuid%:         the Minecraft uuid of the user's linked Minecraft account
 #                               %username%:     the Minecraft username of the user's linked Minecraft account
+#                               %mention%:      märkus Discord kontole
 # DiscordLinkedAccountRequired  %message%:      the message the user was not able to send because they were not linked
 # MinecraftAccountLinked:       %id%:           the discord id of the Discord user that the user's Minecraft account was linked to
 #                               %username%:     the discord name of the Discord user that the user's Minecraft account was linked to

--- a/src/main/resources/messages/fr.yml
+++ b/src/main/resources/messages/fr.yml
@@ -408,11 +408,15 @@ ServerWatchdogMessage: "<t:%timestamp%:R> %guildowner%, le serveur n'a pas répo
 # Placeholders disponibles :
 # CodeGenerated:                %code%:         code généré pour les joueurs voulant lier leur compte
 #                               %botname%:      nom du bot sur Discord
+# UnknownCode/InvalidCode:      %code%:         code généré pour les joueurs voulant lier leur compte
+#                               %mention%:      la mention au compte Discord
 # DiscordAccountLinked:         %name%:         le nom du joueur de Minecraft sur lequel le compte Discord est lié
 #                               %displayname%:  le nom d'affichage du lecteur Minecraft auquel le compte Discord de l'utilisateur était lié
 #                               %uuid%:         l'UUID du joueur de Minecraft sur lequel le compte Discord est lié
+#                               %mention%:      la mention au compte Discord
 # DiscordAccountAlreadyLinked:  %uuid%:         le uuid Minecraft du compte Minecraft lié de l'utilisateur
 #                               %username%:     le nom d'utilisateur Minecraft du compte Minecraft lié de l'utilisateur
+#                               %mention%:      la mention au compte Discord
 # DiscordLinkedAccountRequired  %message%:      le message que l'utilisateur n'a pas pu envoyer car il n'était pas lié
 # MinecraftAccountLinked:       %id%:           l'ID Discord de l'utilisateur auquel le compte Minecraft est lié
 #                               %username%:     le nom Discord de l'utilisateur auquel le compte Minecraft est lié

--- a/src/main/resources/messages/ja.yml
+++ b/src/main/resources/messages/ja.yml
@@ -410,11 +410,15 @@ ServerWatchdogMessage: "<t:%timestamp%:R> %guildowner%、サーバーが%timeout
 # 使用できるキーワード:
 # CodeGenerated:                %code%:         プレーヤーとアカウントをリンクするために生成されたコード
 #                               %botname%:      Discordボットの名前
+# UnknownCode/InvalidCode:      %code%:         プレーヤーとアカウントをリンクするために生成されたコード
+#                               %mention%:      Discordアカウントへのメンション
 # DiscordAccountLinked:         %name%:         Discordアカウントとリンクされた、Minecraftプレイヤーのプレイヤー名
 #                               %displayname%:  ユーザーのDiscordアカウントとMinecraftプレーヤーの表示名がリンクされていた
 #                               %uuid%:         Discordアカウントとリンクされた、MinecraftプレイヤーのUUID
+#                               %mention%:      Discordアカウントへのメンション
 # DiscordAccountAlreadyLinked:  %uuid%:         ユーザーのリンクされたMinecraftアカウントのMinecraftuuid
 #                               %username%:     ユーザーのリンクされたMinecraftアカウントのMinecraftユーザー名
+#                               %mention%:      Discordアカウントへのメンション
 # DiscordLinkedAccountRequired  %message%:      リンクされていないためにユーザーが送信できなかったメッセージ
 # MinecraftAccountLinked:       %id%:           Minecraftアカウントとリンクされた、DiscordユーザーのID
 #                               %username%:     Minecraftアカウントとリンクされた、Discordユーザーの名前

--- a/src/main/resources/messages/ko.yml
+++ b/src/main/resources/messages/ko.yml
@@ -410,11 +410,15 @@ ServerWatchdogMessage: "<t:%timestamp%:R> %guildowner%, 서버가 %timeout%초 �
 # 사용 가능한 변수:
 # CodeGenerated:                %code%:         DiscordSRV가 계정 인증을 위해 임의로 발급한 코드입니다.
 #                               %botname%:      디스코드 상의 봇의 이름입니다.
+# UnknownCode/InvalidCode:      %code%:         DiscordSRV가 계정 인증을 위해 임의로 발급한 코드입니다.
+#                               %mention%:      Discord 계정에 대한 언급
 # DiscordAccountLinked:         %name%:         연동할 마인크래프트 플레이어 이름입니다.
 #                               %displayname%:  사용자의 디스코드 계정이 연결된 Minecraft 플레이어의 표시 이름입니다.
 #                               %uuid%:         연동할 마인크래프트 계정의 UUID입니다.
+#                               %mention%:      Discord 계정에 대한 언급
 # DiscordAccountAlreadyLinked:  %uuid%:         연동할 마인크래프트 계정의 UUID입니다.
 #                               %username%:     연결된 마인크래프트 계정의 이름입니다.
+#                               %mention%:      Discord 계정에 대한 언급
 # DiscordLinkedAccountRequired  %message%:      계정 연결이 필수인 경우 계정이 연결되지 않아 메시지를 보내지 못할때 전송되는 안내 메시지입니다.
 # MinecraftAccountLinked:       %id%:           연동할 플레이어의 디스코드 ID입니다.
 #                               %username%:     연동할 플레이어의 디스코드 사용자 이름입니다.

--- a/src/main/resources/messages/nl.yml
+++ b/src/main/resources/messages/nl.yml
@@ -410,11 +410,15 @@ ServerWatchdogMessage: "<t:%timestamp%:R> %guildowner%, de server heeft niet ger
 # Beschikbare 'placeholders':
 # CodeGenerated:                %code%:         De code dat gegenereerd wordt voor de speler om zijn account te koppelen.
 #                               %botname%:      De naam van de bot in Discord.
+# UnknownCode/InvalidCode:      %code%:         De code dat gegenereerd wordt voor de speler om zijn account te koppelen.
+#                               %mention%:      de vermelding op Discord account
 # DiscordAccountLinked:         %name%:         De naam van de Minecraft speler waarvan het Discord account gekoppeld is.
 #                               %displayname%:  de weergavenaam van de Minecraft-speler waaraan het Discord-account van de gebruiker was gekoppeld
 #                               %uuid%:         het uuid van de Minecraft speler waarvan het Discord account gekoppeld is.
+#                               %mention%:      de vermelding op Discord account
 # DiscordAccountAlreadyLinked:  %uuid%:         de Minecraft-uuid van het gekoppelde Minecraft-account van de gebruiker
 #                               %username%:     de Minecraft-gebruikersnaam van het gekoppelde Minecraft-account van de gebruiker
+#                               %mention%:      de vermelding op Discord account
 # DiscordLinkedAccountRequired  %message%:      het bericht dat de gebruiker niet kon verzenden omdat ze niet waren gekoppeld
 # MinecraftAccountLinked:       %id%:           Het Discord ID van de Discord gebruiker waarvan het Minecraft account gekoppeld is.
 #                               %username%:     Het Discord naam van de Discord gebruiker waarvan het Minecraft account gekoppeld is.

--- a/src/main/resources/messages/pl.yml
+++ b/src/main/resources/messages/pl.yml
@@ -408,11 +408,15 @@ ServerWatchdogMessage: "<t:%timestamp%:R> %guildowner%, serwer nie odpowiedział
 # Dostępne symbole zastępcze:
 # CodeGenerated:                %code%:         kod wygenerowany dla gracza, z którym ma połączyć swoje konto
 #                               %botname%:      nazwa bota na Discordzie
+# UnknownCode/InvalidCode:      %code%:         kod wygenerowany dla gracza, z którym ma połączyć swoje konto
+#                               %mention%:      wzmianka na koncie Discord
 # DiscordAccountLinked:         %name%:         nazwa gracza Minecraft, z którym było połączone konto Discord użytkownika
 #                               %displayname%:  nazwa wyświetlana odtwarzacza Minecraft, z którym było połączone konto użytkownika Discord
 #                               %uuid%:         identyfikator użytkownika odtwarzacza Minecraft, z którym było połączone konto Discord użytkownika
+#                               %mention%:      wzmianka na koncie Discord
 # DiscordAccountAlreadyLinked:  %uuid%:         identyfikator użytkownika Minecraft połączonego konta Minecraft użytkownika
 #                               %username%:     nazwa użytkownika Minecraft połączonego konta Minecraft użytkownika
+#                               %mention%:      wzmianka na koncie Discord
 # DiscordLinkedAccountRequired  %message%:      wiadomość, której użytkownik nie mógł wysłać, ponieważ nie był połączony
 # MinecraftAccountLinked:       %id%:           identyfikator niezgody użytkownika Discord, z którym było połączone konto Minecraft użytkownika
 #                               %username%:     nazwa niezgody użytkownika Discord, z którym było połączone konto Minecraft użytkownika

--- a/src/main/resources/messages/ru.yml
+++ b/src/main/resources/messages/ru.yml
@@ -410,11 +410,15 @@ ServerWatchdogMessage: "<t:%timestamp%:R> %guildowner%, сервер не отв
 # Доступные шаблоны:
 # CodeGenerated:                %code%:         одноразовый код, сгенерированный для пользователя, для привязки аккаунта
 #                               %botname%:      имя бота Discord
+# UnknownCode/InvalidCode:      %code%:         одноразовый код, сгенерированный для пользователя, для привязки аккаунта
+#                               %mention%:      упоминание учетной записи Discord
 # DiscordAccountLinked:         %name%:         имя игрока Minecraft, с которым связан аккаунт Discord
 #                               %displayname%:  отображаемое имя игрока Minecraft, с которым связан аккаунт Discord
 #                               %uuid%:         uuid игрока Minecraft, с которым связан аккаунт Discord
+#                               %mention%:      упоминание учетной записи Discord
 # DiscordAccountAlreadyLinked:  %uuid%:         uuid Minecraft связанной учетной записи Minecraft пользователя
 #                               %username%:     имя пользователя Minecraft связанной учетной записи Minecraft пользователя
+#                               %mention%:      упоминание учетной записи Discord
 # DiscordLinkedAccountRequired  %message%:      сообщение, которое пользователь не смог отправить, потому что они не были связаны
 # MinecraftAccountLinked:       %id%:           идентификатор пользователя Discord, с которым была связана учетная запись Minecraft
 #                               %username%:     имя пользователя Discord, с которым была связана учетная запись Minecraft

--- a/src/main/resources/messages/zh.yml
+++ b/src/main/resources/messages/zh.yml
@@ -408,11 +408,15 @@ ServerWatchdogMessage: "<t:%timestamp%:R> %guildowner%, 服務器在 %timeout% �
 # 可用的變數:
 # CodeGenerated:                %code%:         生成給玩家的驗證碼
 #                               %botname%:      Discord bot的名稱
+# UnknownCode/InvalidCode:      %code%:         生成給玩家的驗證碼
+#                               %mention%:      提到了Discord账户
 # DiscordAccountLinked:         %name%:         已連結至Discord的Minecraft玩家名稱
 #                               %displayname%:  用户的Discord帐户已链接到Minecraft播放器的显示名称
 #                               %uuid%:         已連結至Discord的Minecraft玩家UUID
+#                               %mention%:      提到了Discord账户
 # DiscordAccountAlreadyLinked:  %uuid%:         用户关联的Minecraft帐户的Minecraft uuid
 #                               %username%:     用户链接的Minecraft帐户的Minecraft用户名
+#                               %mention%:      提到了Discord账户
 # DiscordLinkedAccountRequired  %message%:      the message the user was not able to send because they were not linked
 # MinecraftAccountLinked:       %id%:           Minecraft玩家已連結的Discord ID
 #                               %username%:     Minecraft玩家已連結的Discord名稱


### PR DESCRIPTION
# Add mention placeholder to account linking message

I want to add a Discord's Mention to account linking message.
Because I want to have a log of who linked to Minecraft account, even if the original message is deleted.

This feature will be useful when PR #1433 allows account linking in the guild channel.

![You can add mention](https://user-images.githubusercontent.com/16362824/187211107-bb337a6a-2fb4-4769-90df-6f8cefad8461.png)
