### PR TITLE
Add triggering bukkit events to all GameEvents

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -1696,17 +1696,28 @@ public class DiscordSRV extends JavaPlugin {
         }
     }
 
+    @Deprecated
     public void processChatMessage(Player player, String message, String channel, boolean cancelled) {
+        this.processChatMessage(player, message, channel, cancelled, null);
+    }
+
+    public void processChatMessage(Player player, String message, String channel, boolean cancelled, org.bukkit.event.Event event) {
         this.processChatMessage(
                 player,
                 MessageUtil.toComponent(message, true),
                 channel,
-                cancelled
+                cancelled,
+                event
         );
     }
 
-    @SuppressWarnings("deprecation") // Display names are legacy, Spigot is supported
+    @Deprecated
     public void processChatMessage(Player player, Component message, String channel, boolean cancelled) {
+        this.processChatMessage(player, message, channel, cancelled, null);
+    }
+
+    @SuppressWarnings("deprecation") // Display names are legacy, Spigot is supported
+    public void processChatMessage(Player player, Component message, String channel, boolean cancelled, org.bukkit.event.Event event) {
         // log debug message to notify that a chat message was being processed
         debug(Debug.MINECRAFT_TO_DISCORD, "Chat message received, canceled: " + cancelled + ", channel: " + channel);
 
@@ -1755,7 +1766,7 @@ public class DiscordSRV extends JavaPlugin {
             return;
         }
 
-        GameChatMessagePreProcessEvent preEvent = api.callEvent(new GameChatMessagePreProcessEvent(channel, message, player));
+        GameChatMessagePreProcessEvent preEvent = api.callEvent(new GameChatMessagePreProcessEvent(channel, message, player, event));
         if (preEvent.isCancelled()) {
             debug(Debug.MINECRAFT_TO_DISCORD, "GameChatMessagePreProcessEvent was cancelled, message send aborted");
             return;
@@ -1812,7 +1823,7 @@ public class DiscordSRV extends JavaPlugin {
             discordMessageContent = discordMessageContent.replace("@", "@\u200B"); // zero-width space
         }
 
-        GameChatMessagePostProcessEvent postEvent = api.callEvent(new GameChatMessagePostProcessEvent(channel, discordMessage, player, preEvent.isCancelled()));
+        GameChatMessagePostProcessEvent postEvent = api.callEvent(new GameChatMessagePostProcessEvent(channel, discordMessage, player, preEvent.isCancelled(), event));
         if (postEvent.isCancelled()) {
             debug(Debug.MINECRAFT_TO_DISCORD, "GameChatMessagePostProcessEvent was cancelled, message send aborted");
             return;

--- a/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePostProcessEvent.java
@@ -34,12 +34,11 @@ import org.bukkit.event.Event;
  * <p>Called after DiscordSRV has processed a achievement/advancement message but before being sent to Discord.
  * Modification is allow and will effect the message sent to Discord.</p>
  */
-public class AchievementMessagePostProcessEvent extends GameEvent implements Cancellable {
+public class AchievementMessagePostProcessEvent extends GameEvent<Event> implements Cancellable {
 
     @Getter @Setter private boolean cancelled;
 
-    @Getter private String achievementName;
-    @Getter private Event triggeringBukkitEvent;
+    @Getter private final String achievementName;
     @Getter @Setter private String channel;
 
     @Getter @Setter private Message discordMessage;
@@ -48,11 +47,10 @@ public class AchievementMessagePostProcessEvent extends GameEvent implements Can
     @Getter @Setter private String webhookAvatarUrl;
 
     public AchievementMessagePostProcessEvent(String channel, Message discordMessage, Player player, String achievementName, Event triggeringBukkitEvent, boolean usingWebhooks, String webhookName, String webhookAvatarUrl, boolean cancelled) {
-        super(player);
+        super(player, triggeringBukkitEvent);
         this.channel = channel;
         this.discordMessage = discordMessage;
         this.achievementName = achievementName;
-        this.triggeringBukkitEvent = triggeringBukkitEvent;
         this.usingWebhooks = usingWebhooks;
         this.webhookName = webhookName;
         this.webhookAvatarUrl = webhookAvatarUrl;
@@ -61,7 +59,7 @@ public class AchievementMessagePostProcessEvent extends GameEvent implements Can
 
     @Deprecated
     public AchievementMessagePostProcessEvent(String channel, Message discordMessage, Player player, String achievementName, boolean usingWebhooks, String webhookName, String webhookAvatarUrl, boolean cancelled) {
-        super(player);
+        super(player, null);
         this.channel = channel;
         this.discordMessage = discordMessage;
         this.achievementName = achievementName;
@@ -73,7 +71,7 @@ public class AchievementMessagePostProcessEvent extends GameEvent implements Can
     
     @Deprecated
     public AchievementMessagePostProcessEvent(String channel, String processedMessage, Player player, String achievementName, boolean cancelled) {
-        super(player);
+        super(player, null);
         this.channel = channel;
         this.discordMessage = new MessageBuilder().setContent(processedMessage).build();
         this.achievementName = achievementName;

--- a/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePreProcessEvent.java
@@ -32,26 +32,24 @@ import org.bukkit.event.Event;
 /**
  * <p>Called before DiscordSRV has processed a achievement/advancement message, modifications may be overwritten by DiscordSRV's processing.</p>
  */
-public class AchievementMessagePreProcessEvent extends GameEvent implements Cancellable {
+public class AchievementMessagePreProcessEvent extends GameEvent<Event> implements Cancellable {
 
     @Getter @Setter private boolean cancelled;
 
     @Getter @Setter private String achievementName;
-    @Getter private Event triggeringBukkitEvent;
     @Getter @Setter private String channel;
     @Getter @Setter private MessageFormat messageFormat;
 
     public AchievementMessagePreProcessEvent(String channel, MessageFormat messageFormat, Player player, String achievementName, Event triggeringBukkitEvent) {
-        super(player);
+        super(player, triggeringBukkitEvent);
         this.channel = channel;
         this.messageFormat = messageFormat;
         this.achievementName = achievementName;
-        this.triggeringBukkitEvent = triggeringBukkitEvent;
     }
 
     @Deprecated
     public AchievementMessagePreProcessEvent(String channel, MessageFormat messageFormat, Player player, String achievementName) {
-        super(player);
+        super(player, null);
         this.channel = channel;
         this.messageFormat = messageFormat;
         this.achievementName = achievementName;
@@ -59,7 +57,7 @@ public class AchievementMessagePreProcessEvent extends GameEvent implements Canc
 
     @Deprecated
     public AchievementMessagePreProcessEvent(String channel, String message, Player player, String achievementName) {
-        super(player);
+        super(player, null);
         this.channel = channel;
         MessageFormat messageFormat = new MessageFormat();
         messageFormat.setContent(message);

--- a/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePostProcessEvent.java
@@ -34,12 +34,11 @@ import org.bukkit.event.entity.PlayerDeathEvent;
  * <p>Called after DiscordSRV has processed a death message but before being sent to Discord.
  * Modification is allow and will effect the message sent to Discord.</p>
  */
-public class DeathMessagePostProcessEvent extends GameEvent implements Cancellable {
+public class DeathMessagePostProcessEvent extends GameEvent<PlayerDeathEvent> implements Cancellable {
 
     @Getter @Setter private boolean cancelled;
 
-    @Getter private String deathMessage;
-    @Getter private PlayerDeathEvent triggeringBukkitEvent;
+    @Getter private final String deathMessage;
     @Getter @Setter private String channel;
 
     @Getter @Setter private Message discordMessage;
@@ -48,11 +47,10 @@ public class DeathMessagePostProcessEvent extends GameEvent implements Cancellab
     @Getter @Setter private String webhookAvatarUrl;
 
     public DeathMessagePostProcessEvent(String channel, Message discordMessage, Player player, String deathMessage, PlayerDeathEvent triggeringBukkitEvent, boolean usingWebhooks, String webhookName, String webhookAvatarUrl, boolean cancelled) {
-        super(player);
+        super(player, triggeringBukkitEvent);
         this.channel = channel;
         this.discordMessage = discordMessage;
         this.deathMessage = deathMessage;
-        this.triggeringBukkitEvent = triggeringBukkitEvent;
         this.usingWebhooks = usingWebhooks;
         this.webhookName = webhookName;
         this.webhookAvatarUrl = webhookAvatarUrl;
@@ -61,7 +59,7 @@ public class DeathMessagePostProcessEvent extends GameEvent implements Cancellab
 
     @Deprecated
     public DeathMessagePostProcessEvent(String channel, Message discordMessage, Player player, String deathMessage, boolean usingWebhooks, String webhookName, String webhookAvatarUrl, boolean cancelled) {
-        super(player);
+        super(player, null);
         this.channel = channel;
         this.discordMessage = discordMessage;
         this.deathMessage = deathMessage;
@@ -73,7 +71,7 @@ public class DeathMessagePostProcessEvent extends GameEvent implements Cancellab
 
     @Deprecated
     public DeathMessagePostProcessEvent(String channel, String processedMessage, Player player, String deathMessage, boolean cancelled) {
-        super(player);
+        super(player, null);
         this.channel = channel;
         this.discordMessage = new MessageBuilder().setContent(processedMessage).build();
         this.deathMessage = deathMessage;

--- a/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePreProcessEvent.java
@@ -32,26 +32,24 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 /**
  * <p>Called before DiscordSRV has processed a death message, modifications may be overwritten by DiscordSRV's processing.</p>
  */
-public class DeathMessagePreProcessEvent extends GameEvent implements Cancellable {
+public class DeathMessagePreProcessEvent extends GameEvent<PlayerDeathEvent> implements Cancellable {
 
     @Getter @Setter private boolean cancelled;
 
     @Getter @Setter private String deathMessage;
-    @Getter private PlayerDeathEvent triggeringBukkitEvent;
     @Getter @Setter private String channel;
     @Getter @Setter private MessageFormat messageFormat;
 
     public DeathMessagePreProcessEvent(String channel, MessageFormat messageFormat, Player player, String deathMessage, PlayerDeathEvent triggeringBukkitEvent) {
-        super(player);
+        super(player, triggeringBukkitEvent);
         this.channel = channel;
         this.messageFormat = messageFormat;
         this.deathMessage = deathMessage;
-        this.triggeringBukkitEvent = triggeringBukkitEvent;
     }
 
     @Deprecated
     public DeathMessagePreProcessEvent(String channel, MessageFormat messageFormat, Player player, String deathMessage) {
-        super(player);
+        super(player, null);
         this.channel = channel;
         this.messageFormat = messageFormat;
         this.deathMessage = deathMessage;
@@ -59,7 +57,7 @@ public class DeathMessagePreProcessEvent extends GameEvent implements Cancellabl
 
     @Deprecated
     public DeathMessagePreProcessEvent(String channel, String message, Player player, String deathMessage) {
-        super(player);
+        super(player, null);
         this.channel = channel;
         MessageFormat messageFormat = new MessageFormat();
         messageFormat.setContent(message);

--- a/src/main/java/github/scarsz/discordsrv/api/events/GameChatMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/GameChatMessagePostProcessEvent.java
@@ -26,6 +26,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
 
 /**
  * <p>Called after DiscordSRV has processed a Minecraft chat message but before being sent to Discord.
@@ -33,18 +34,23 @@ import org.bukkit.event.Cancellable;
  * 
  * <p>If a messages is coming from VentureChat over Bungee then {@link VentureChatMessagePostProcessEvent} would be called instead, due to the lack of the Player object</p>
  */
-public class GameChatMessagePostProcessEvent extends GameEvent implements Cancellable {
+public class GameChatMessagePostProcessEvent extends GameEvent<Event> implements Cancellable {
 
     @Getter @Setter private boolean cancelled;
 
     @Getter @Setter private String channel;
     @Getter @Setter private String processedMessage;
 
-    public GameChatMessagePostProcessEvent(String channel, String processedMessage, Player player, boolean cancelled) {
-        super(player);
+    public GameChatMessagePostProcessEvent(String channel, String processedMessage, Player player, boolean cancelled, Event event) {
+        super(player, event);
         this.channel = channel;
         this.processedMessage = processedMessage;
         setCancelled(cancelled);
+    }
+
+    @Deprecated
+    public GameChatMessagePostProcessEvent(String channel, String processedMessage, Player player, boolean cancelled) {
+        this(channel, processedMessage, player, cancelled, null);
     }
 
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/GameChatMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/GameChatMessagePreProcessEvent.java
@@ -28,6 +28,7 @@ import lombok.Setter;
 import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
 
 /**
  * <p>Called before DiscordSRV has processed a Minecraft chat message, modifications may be overwritten by DiscordSRV's processing.</p>
@@ -38,17 +39,22 @@ import org.bukkit.event.Cancellable;
  * 
  * <p>If a messages is coming from VentureChat over Bungee then {@link VentureChatMessagePreProcessEvent} would be called instead, due to the lack of the Player object</p>
  */
-public class GameChatMessagePreProcessEvent extends GameEvent implements Cancellable {
+public class GameChatMessagePreProcessEvent extends GameEvent<Event> implements Cancellable {
 
     @Getter @Setter private boolean cancelled;
 
     @Getter @Setter private String channel;
     @Getter @Setter private Component messageComponent;
 
-    public GameChatMessagePreProcessEvent(String channel, Component message, Player player) {
-        super(player);
+    public GameChatMessagePreProcessEvent(String channel, Component message, Player player, Event event) {
+        super(player, event);
         this.channel = channel;
         this.messageComponent = message;
+    }
+
+    @Deprecated
+    public GameChatMessagePreProcessEvent(String channel, Component message, Player player) {
+        this(channel, message, player, null);
     }
 
     @Deprecated

--- a/src/main/java/github/scarsz/discordsrv/api/events/GameEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/GameEvent.java
@@ -25,12 +25,14 @@ package github.scarsz.discordsrv.api.events;
 import lombok.Getter;
 import org.bukkit.entity.Player;
 
-abstract class GameEvent extends Event {
+abstract class GameEvent<T extends org.bukkit.event.Event> extends Event {
 
     @Getter final private Player player;
+    @Getter final private T triggeringBukkitEvent;
 
-    GameEvent(Player player) {
+    GameEvent(Player player, T triggeringBukkitEvent) {
         this.player = player;
+        this.triggeringBukkitEvent = triggeringBukkitEvent;
     }
 
 }

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/ChattyChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/ChattyChatHook.java
@@ -45,7 +45,7 @@ public class ChattyChatHook implements ChatHook {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onChattyMessage(ChattyMessageEvent event) {
-        DiscordSRV.getPlugin().processChatMessage(event.getPlayer(), event.getMessage(), event.getChat().getName(), false);
+        DiscordSRV.getPlugin().processChatMessage(event.getPlayer(), event.getMessage(), event.getChat().getName(), false, event);
     }
 
     @Override

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/FancyChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/FancyChatHook.java
@@ -50,7 +50,7 @@ public class FancyChatHook implements ChatHook {
         Player sender = null;
         if (event.getSender() instanceof Player) sender = (Player) event.getSender();
 
-        DiscordSRV.getPlugin().processChatMessage(sender, event.getMessage(), event.getChannel().getName(), false);
+        DiscordSRV.getPlugin().processChatMessage(sender, event.getMessage(), event.getChannel().getName(), false, event);
     }
 
     @Override

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/HerochatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/HerochatHook.java
@@ -48,7 +48,7 @@ public class HerochatHook implements ChatHook {
         // make sure message isn't just blank
         if (StringUtils.isBlank(event.getMessage())) return;
 
-        DiscordSRV.getPlugin().processChatMessage(event.getSender().getPlayer(), event.getMessage(), event.getChannel().getName(), event.getResult() != Chatter.Result.ALLOWED);
+        DiscordSRV.getPlugin().processChatMessage(event.getSender().getPlayer(), event.getMessage(), event.getChannel().getName(), event.getResult() != Chatter.Result.ALLOWED, event);
     }
 
     @Override

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/LegendChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/LegendChatHook.java
@@ -43,7 +43,7 @@ public class LegendChatHook implements ChatHook {
         // make sure message isn't just blank
         if (StringUtils.isBlank(event.getMessage())) return;
 
-        DiscordSRV.getPlugin().processChatMessage(event.getSender().getPlayer(), event.getMessage(), event.getChannel().getName(), event.isCancelled());
+        DiscordSRV.getPlugin().processChatMessage(event.getSender().getPlayer(), event.getMessage(), event.getChannel().getName(), event.isCancelled(), event);
     }
 
     @Override

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/LunaChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/LunaChatHook.java
@@ -52,7 +52,7 @@ public class LunaChatHook implements ChatHook {
         // get sender player
         Player player = (event.getMember() != null && event.getMember() instanceof ChannelMemberPlayer) ? ((ChannelMemberPlayer) event.getMember()).getPlayer() : null;
 
-        DiscordSRV.getPlugin().processChatMessage(player, event.getNgMaskedMessage(), event.getChannel().getName(), false);
+        DiscordSRV.getPlugin().processChatMessage(player, event.getNgMaskedMessage(), event.getChannel().getName(), false, event);
     }
 
     @Override

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/TownyChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/TownyChatHook.java
@@ -91,7 +91,7 @@ public class TownyChatHook implements ChatHook {
             return;
         }
 
-        DiscordSRV.getPlugin().processChatMessage(event.getPlayer(), event.getMessage(), event.getChannel().getName(), event.isCancelled());
+        DiscordSRV.getPlugin().processChatMessage(event.getPlayer(), event.getMessage(), event.getChannel().getName(), event.isCancelled(), event);
     }
 
     @Override

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/VentureChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/VentureChatHook.java
@@ -89,7 +89,7 @@ public class VentureChatHook implements ChatHook {
             Player player = chatPlayer.getPlayer();
             if (player != null) {
                 // these events are never cancelled
-                DiscordSRV.getPlugin().processChatMessage(player, message, chatChannel.getName(), false);
+                DiscordSRV.getPlugin().processChatMessage(player, message, chatChannel.getName(), false, event);
                 return;
             }
         }

--- a/src/main/java/github/scarsz/discordsrv/listeners/ModernPlayerChatListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/ModernPlayerChatListener.java
@@ -81,7 +81,8 @@ public class ModernPlayerChatListener implements Listener {
                     event.getPlayer(),
                     GsonComponentSerializer.gson().deserialize(json),
                     DiscordSRV.getPlugin().getOptionalChannel("global"),
-                    event.isCancelled()
+                    event.isCancelled(),
+                    event
             );
         });
     }

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerChatListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerChatListener.java
@@ -44,7 +44,8 @@ public class PlayerChatListener implements Listener {
                         event.getPlayer(),
                         event.getMessage(),
                         DiscordSRV.getPlugin().getOptionalChannel("global"),
-                        event.isCancelled()
+                        event.isCancelled(),
+                        event
                 )
         );
     }


### PR DESCRIPTION
Instead of individual game events (advancement, death etc,) containing the triggering bukkit event, we'll have all of them also do that.
The extra information in those triggering bukkit events will be helpful to devs using the api.