### PR TITLE
Add PlaceholderAPI support to account linking code messages

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/commands/CommandLink.java
+++ b/src/main/java/github/scarsz/discordsrv/commands/CommandLink.java
@@ -28,6 +28,7 @@ import github.scarsz.discordsrv.util.DiscordUtil;
 import github.scarsz.discordsrv.util.GamePermissionUtil;
 import github.scarsz.discordsrv.util.LangUtil;
 import github.scarsz.discordsrv.util.MessageUtil;
+import github.scarsz.discordsrv.util.PlaceholderUtil;
 import net.dv8tion.jda.api.entities.User;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
@@ -124,11 +125,14 @@ public class CommandLink {
         } else {
             String code = manager.generateCode(player.getUniqueId());
 
-            Component component = LegacyComponentSerializer.builder().character('&').extractUrls().build().deserialize(
-                    LangUtil.Message.CODE_GENERATED.toString()
-                            .replace("%code%", code)
-                            .replace("%botname%", DiscordSRV.getPlugin().getMainGuild().getSelfMember().getEffectiveName())
-            );
+            // load message text
+            String message = LangUtil.Message.CODE_GENERATED.toString()
+                    .replace("%code%", code)
+                    .replace("%botname%", DiscordSRV.getPlugin().getMainGuild().getSelfMember().getEffectiveName());
+            // replace additional placeholders (PlaceholderAPI)
+            message = PlaceholderUtil.replacePlaceholders(message, Bukkit.getOfflinePlayer(player.getUniqueId()));
+            // build message component
+            Component component = LegacyComponentSerializer.builder().character('&').extractUrls().build().deserialize(message);
 
             String clickToCopyCode = LangUtil.Message.CLICK_TO_COPY_CODE.toString();
             if (StringUtils.isNotBlank(clickToCopyCode)) {

--- a/src/main/java/github/scarsz/discordsrv/objects/managers/CommandManager.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/managers/CommandManager.java
@@ -27,8 +27,11 @@ import github.scarsz.discordsrv.commands.*;
 import github.scarsz.discordsrv.util.GamePermissionUtil;
 import github.scarsz.discordsrv.util.LangUtil;
 import github.scarsz.discordsrv.util.MessageUtil;
+import github.scarsz.discordsrv.util.PlaceholderUtil;
 import lombok.Getter;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -82,7 +85,8 @@ public class CommandManager {
 
     public boolean handle(CommandSender sender, String command, String[] args) {
         if (command == null) {
-            String message = LangUtil.Message.DISCORD_COMMAND.toString()
+            OfflinePlayer offlinePlayer = sender instanceof Player ? Bukkit.getOfflinePlayer(((Player)sender).getUniqueId()) : null;
+            String message = PlaceholderUtil.replacePlaceholders(LangUtil.Message.DISCORD_COMMAND.toString(), offlinePlayer)
                     .replace("{INVITE}", DiscordSRV.config().getString("DiscordInviteLink"));
             for (String line : message.split("\n")) MessageUtil.sendMessage(sender, line);
             return true;


### PR DESCRIPTION
As requested by François#7192 in support ticket 11134, adds support for PlaceholderAPI usage in DiscordCommandFormat message.