### PR TITLE
Slightly tweaking slash commands logging

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
+++ b/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
@@ -211,6 +211,8 @@ public class ApiManager extends ListenerAdapter {
             int totalGuilds = DiscordSRV.getPlugin().getJda().getGuilds().size();
             if (successful > 0) {
                 DiscordSRV.info("Successfully registered " + successful + " slash commands (" + finalConflictingCommands + " conflicted) for " + pluginCount + " plugins in " + registeredGuilds + "/" + totalGuilds + " guilds (" + finalCancelledGuilds + " cancelled)");
+            } else {
+                DiscordSRV.info("Cleared all pre-existing slash commands in " + registeredGuilds + "/" + totalGuilds + " guilds (" + finalCancelledGuilds + " cancelled)");
             }
 
             if (errors.isEmpty()) return;

--- a/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
+++ b/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
@@ -209,7 +209,7 @@ public class ApiManager extends ListenerAdapter {
             long pluginCount = conflictResolvedCommands.values().stream().map(PluginSlashCommand::getPlugin).distinct().count();
             long registeredGuilds = all.stream().filter(Objects::nonNull).count();
             int totalGuilds = DiscordSRV.getPlugin().getJda().getGuilds().size();
-            if (finalConflictingCommands > 0) {
+            if (successful > 0) {
                 DiscordSRV.info("Successfully registered " + successful + " slash commands (" + finalConflictingCommands + " conflicted) for " + pluginCount + " plugins in " + registeredGuilds + "/" + totalGuilds + " guilds (" + finalCancelledGuilds + " cancelled)");
             }
 


### PR DESCRIPTION
- Use the `successful` variable to decide whether any commands are registered, instead of whether any commands conflicted with each other (`finalConflictingCommands`)
- Logs that all existing commands are cleared if no commands are registered