### PR TITLE
Add typing indicators

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/ChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/ChatHook.java
@@ -25,6 +25,8 @@ package github.scarsz.discordsrv.hooks.chat;
 import github.scarsz.discordsrv.hooks.PluginHook;
 import github.scarsz.discordsrv.util.MessageUtil;
 import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Nullable;
 
 public interface ChatHook extends PluginHook {
 
@@ -35,6 +37,10 @@ public interface ChatHook extends PluginHook {
 
     default void broadcastMessageToChannel(String channel, Component message) {
         broadcastMessageToChannel(channel, MessageUtil.toLegacy(message));
+    }
+
+    default @Nullable String getPrimaryChannelOfPlayer(Player player) {
+        return null;
     }
 
 }

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/FancyChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/FancyChatHook.java
@@ -25,6 +25,7 @@ package github.scarsz.discordsrv.hooks.chat;
 import br.com.finalcraft.fancychat.api.FancyChatApi;
 import br.com.finalcraft.fancychat.api.FancyChatSendChannelMessageEvent;
 import br.com.finalcraft.fancychat.config.fancychat.FancyChannel;
+import br.com.finalcraft.fancychat.util.MuteUtil;
 import github.scarsz.discordsrv.DiscordSRV;
 import github.scarsz.discordsrv.util.LangUtil;
 import github.scarsz.discordsrv.util.MessageUtil;
@@ -36,6 +37,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
 
 public class FancyChatHook implements ChatHook {
 
@@ -68,6 +70,19 @@ public class FancyChatHook implements ChatHook {
         String translatedMessage = MessageUtil.translateLegacy(plainMessage);
         FancyChatApi.sendMessage(translatedMessage, fancyChannel);
         PlayerUtil.notifyPlayersOfMentions(player -> fancyChannel.getPlayersOnThisChannel().contains(player), legacy);
+    }
+
+    @Override
+    public @Nullable String getPrimaryChannelOfPlayer(Player player) {
+        if (MuteUtil.isMuted(player)) {
+            return null;
+        }
+
+        FancyChannel channel = FancyChatApi.getPlayerChannel(player);
+        if (channel == null) {
+            return null;
+        }
+        return channel.getName();
     }
 
     @Override

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/HerochatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/HerochatHook.java
@@ -34,9 +34,11 @@ import github.scarsz.discordsrv.util.PlayerUtil;
 import github.scarsz.discordsrv.util.PluginUtil;
 import net.kyori.adventure.text.Component;
 import org.apache.commons.lang3.StringUtils;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -72,6 +74,20 @@ public class HerochatHook implements ChatHook {
                                 .collect(Collectors.toList())
                                 .contains(player),
                 legacy);
+    }
+
+    @Override
+    public @Nullable String getPrimaryChannelOfPlayer(Player player) {
+        Chatter chatter = Herochat.getChatterManager().getChatter(player);
+        if (chatter == null || chatter.isMuted()) {
+            return null;
+        }
+
+        Channel channel = chatter.getActiveChannel();
+        if (channel == null || channel.isMuted() || channel.isMuted(player.getName())) {
+            return null;
+        }
+        return channel.getName();
     }
 
     private static Channel getChannelByCaseInsensitiveName(String name) {

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/LegendChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/LegendChatHook.java
@@ -25,6 +25,7 @@ package github.scarsz.discordsrv.hooks.chat;
 import br.com.devpaulo.legendchat.api.Legendchat;
 import br.com.devpaulo.legendchat.api.events.ChatMessageEvent;
 import br.com.devpaulo.legendchat.channels.types.Channel;
+import br.com.devpaulo.legendchat.players.PlayerManager;
 import github.scarsz.discordsrv.DiscordSRV;
 import github.scarsz.discordsrv.util.LangUtil;
 import github.scarsz.discordsrv.util.MessageUtil;
@@ -32,9 +33,11 @@ import github.scarsz.discordsrv.util.PlayerUtil;
 import github.scarsz.discordsrv.util.PluginUtil;
 import net.kyori.adventure.text.Component;
 import org.apache.commons.lang3.StringUtils;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
 
 public class LegendChatHook implements ChatHook {
 
@@ -61,6 +64,20 @@ public class LegendChatHook implements ChatHook {
         String translatedMessage = MessageUtil.translateLegacy(plainMessage);
         chatChannel.sendMessage(translatedMessage);
         PlayerUtil.notifyPlayersOfMentions(player -> chatChannel.getPlayersWhoCanSeeChannel().contains(player), legacy);
+    }
+
+    @Override
+    public @Nullable String getPrimaryChannelOfPlayer(Player player) {
+        PlayerManager playerManager = Legendchat.getPlayerManager();
+        if (playerManager.isPlayerHiddenFromRecipients(player)) {
+            return null;
+        }
+
+        Channel channel = playerManager.getPlayerFocusedChannel(player);
+        if (channel == null) {
+            return null;
+        }
+        return channel.getName();
     }
 
     private static Channel getChannelByCaseInsensitiveName(String name) {

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/LunaChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/LunaChatHook.java
@@ -22,9 +22,11 @@
 
 package github.scarsz.discordsrv.hooks.chat;
 
+import com.github.ucchyocean.lc3.LunaChatAPI;
 import com.github.ucchyocean.lc3.LunaChatBukkit;
 import com.github.ucchyocean.lc3.bukkit.event.LunaChatBukkitChannelChatEvent;
 import com.github.ucchyocean.lc3.channel.Channel;
+import com.github.ucchyocean.lc3.member.ChannelMember;
 import com.github.ucchyocean.lc3.member.ChannelMemberBukkit;
 import com.github.ucchyocean.lc3.member.ChannelMemberPlayer;
 import github.scarsz.discordsrv.Debug;
@@ -39,6 +41,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.stream.Collectors;
 
@@ -79,6 +82,21 @@ public class LunaChatHook implements ChatHook {
                                 .collect(Collectors.toList())
                                 .contains(player),
                 legacy);
+    }
+
+    @Override
+    public @Nullable String getPrimaryChannelOfPlayer(Player player) {
+        LunaChatAPI api = LunaChatBukkit.getInstance().getLunaChatAPI();
+        Channel channel = api.getDefaultChannel(player.getName());
+        if (channel == null) {
+            return null;
+        }
+
+        ChannelMember member = ChannelMember.getChannelMember(player);
+        if (channel.getMuted().contains(member)) {
+            return null;
+        }
+        return channel.getName();
     }
 
     @Override

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/VentureChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/VentureChatHook.java
@@ -29,6 +29,7 @@ import github.scarsz.discordsrv.api.events.VentureChatMessagePostProcessEvent;
 import github.scarsz.discordsrv.api.events.VentureChatMessagePreProcessEvent;
 import github.scarsz.discordsrv.util.*;
 import mineverse.Aust1n46.chat.MineverseChat;
+import mineverse.Aust1n46.chat.api.MineverseChatAPI;
 import mineverse.Aust1n46.chat.api.MineverseChatPlayer;
 import mineverse.Aust1n46.chat.api.events.VentureChatEvent;
 import mineverse.Aust1n46.chat.channel.ChatChannel;
@@ -45,6 +46,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.List;
@@ -271,6 +273,26 @@ public class VentureChatHook implements ChatHook {
                     message
             );
         }
+    }
+
+    @Override
+    public @Nullable String getPrimaryChannelOfPlayer(Player player) {
+        MineverseChatPlayer chatPlayer = MineverseChatAPI.getOnlineMineverseChatPlayer(player);
+        if (chatPlayer == null) {
+            return null;
+        }
+
+        ChatChannel channel;
+        if (chatPlayer.isQuickChat()) {
+            channel = chatPlayer.getQuickChannel();
+        } else {
+            channel = chatPlayer.getCurrentChannel();
+        }
+
+        if (channel == null || chatPlayer.isMuted(channel.getName())) {
+            return null;
+        }
+        return channel.getName();
     }
 
     @Override

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerChatPreviewListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerChatPreviewListener.java
@@ -1,0 +1,105 @@
+/*-
+ * LICENSE
+ * DiscordSRV
+ * -------------
+ * Copyright (C) 2016 - 2022 Austin "Scarsz" Shapiro
+ * -------------
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * END
+ */
+
+package github.scarsz.discordsrv.listeners;
+
+import github.scarsz.discordsrv.DiscordSRV;
+import github.scarsz.discordsrv.hooks.chat.ChatHook;
+import github.scarsz.discordsrv.util.DiscordUtil;
+import github.scarsz.discordsrv.util.MessageUtil;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.plugin.RegisteredListener;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Optional;
+
+public class PlayerChatPreviewListener {
+
+    @SuppressWarnings("deprecation")
+    public PlayerChatPreviewListener() {
+        try {
+            Class<?> eventClass = Class.forName("org.bukkit.event.player.AsyncPlayerChatPreviewEvent");
+
+            // AsyncPlayerChatPreviewEvent is still considered a "draft API" and may receive future changes that
+            // break backward compatibility, so we should check to make sure it still extends AsyncPlayerChatEvent
+            if (!AsyncPlayerChatEvent.class.isAssignableFrom(eventClass)) {
+                DiscordSRV.error("AsyncPlayerChatPreviewEvent doesn't extend AsyncPlayerChatEvent, "
+                        + "likely due to a newer server version; typing indicators will not function");
+                return;
+            }
+
+            RegisteredListener registeredListener = new RegisteredListener(
+                    new Listener() {},
+                    (listener, event) -> onAsyncPlayerChatPreview((AsyncPlayerChatEvent) event),
+                    EventPriority.MONITOR,
+                    DiscordSRV.getPlugin(),
+                    false
+            );
+
+            HandlerList handlerList = (HandlerList) eventClass.getMethod("getHandlerList").invoke(null);
+            handlerList.register(registeredListener);
+        } catch (ClassNotFoundException e) {
+            // The server version is <1.19.1
+        } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
+            DiscordSRV.error("Failed to get the handler list for AsyncPlayerChatPreviewEvent, "
+                    + "typing indicators will not function");
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private void onAsyncPlayerChatPreview(AsyncPlayerChatEvent event) {
+        Player player = event.getPlayer();
+        Component message = MessageUtil.toComponent(event.getMessage(), true);
+        if (DiscordSRV.getPlugin().skipProcessingChatMessage(player, message, event.isCancelled(), false)) {
+            return;
+        }
+
+        Optional<ChatHook> chatHook = DiscordSRV.getPlugin()
+                .getPluginHooks()
+                .stream()
+                .filter(hook -> hook instanceof ChatHook)
+                .map(hook -> (ChatHook) hook)
+                .findAny();
+
+        TextChannel channel;
+        if (chatHook.isPresent()) {
+            String channelName = chatHook.get().getPrimaryChannelOfPlayer(player);
+            if (channelName == null) {
+                return;
+            }
+            channel = DiscordSRV.getPlugin().getDestinationTextChannelForGameChannelName(channelName);
+        } else {
+            channel = DiscordSRV.getPlugin().getOptionalTextChannel("global");
+        }
+
+        if (channel != null) {
+            DiscordUtil.updateTypingIndicator(channel);
+        }
+    }
+
+}

--- a/src/main/java/github/scarsz/discordsrv/util/DiscordUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/DiscordUtil.java
@@ -895,13 +895,4 @@ public class DiscordUtil {
         lastTypingIndicatorTimes.put(channel.getId(), currentTime);
         channel.sendTyping().queue();
     }
-
-    /**
-     * Get the map containing the times a typing indicator was last sent for each channel
-     * @return The map containing the times - in nanoseconds since the Unix epoch - a typing indicator was last sent for
-     * each channel
-     */
-    public static Map<String, Long> getLastTypingIndicatorTimes() {
-        return lastTypingIndicatorTimes;
-    }
 }

--- a/src/main/resources/config/de.yml
+++ b/src/main/resources/config/de.yml
@@ -158,6 +158,7 @@ StatusUpdateRateInMinutes: 2
 # DiscordChatChannelRolesSelectionAsWhitelist: wenn die folgende Liste als Whitelist (true) oder als Blacklist (false) behandelt werden soll
 # DiscordChatChannelRolesSelection: Liste der Rollen, die aus allen Rollen eines Benutzers herausgefiltert werden sollen
 # DiscordChatChannelRoleAliases: Liste der Rollen-Aliase (alternative Namen für Rollen, die in Minecraft-Nachrichten verwendet werden sollen)
+# DiscordChatChannelTypingIndicators: ob der Bot auf Discord als "tippend" erscheinen soll, während Minecraft-Spieler tippen (erfordert 1.19.1 und "previews-chat" aktiviert in server.properties)
 #
 DiscordChatChannelDiscordToMinecraft: true
 DiscordChatChannelMinecraftToDiscord: true
@@ -179,6 +180,7 @@ DiscordChatChannelBlockedRolesIds: ["000000000000000000", "000000000000000000", 
 DiscordChatChannelRolesSelectionAsWhitelist: false
 DiscordChatChannelRolesSelection: ["Don't show me!", "Misc role"]
 DiscordChatChannelRoleAliases: {"Developer": "Dev"}
+DiscordChatChannelTypingIndicators: false
 
 # Konsolenkanal betreffende Einstellungen
 # Der Konsolenkanal verbindet die Minecraft-Konsole mit einem Discord-Kanal. Somit lassen sich über diesen Kanal in

--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -158,6 +158,7 @@ StatusUpdateRateInMinutes: 2
 # DiscordChatChannelRolesSelectionAsWhitelist: if the following list should be treated as a whitelist (true) or a blacklist (false)
 # DiscordChatChannelRolesSelection: list of roles that should be filtered from all of a user's roles
 # DiscordChatChannelRoleAliases: list of role aliases (alternate names for roles to use in Minecraft messages)
+# DiscordChatChannelTypingIndicators: whether the bot should appear as "typing" on Discord while Minecraft players are typing (requires 1.19.1 and "previews-chat" enabled in server.properties)
 #
 DiscordChatChannelDiscordToMinecraft: true
 DiscordChatChannelMinecraftToDiscord: true
@@ -179,6 +180,7 @@ DiscordChatChannelBlockedRolesIds: ["000000000000000000", "000000000000000000", 
 DiscordChatChannelRolesSelectionAsWhitelist: false
 DiscordChatChannelRolesSelection: ["Don't show me!", "Misc role"]
 DiscordChatChannelRoleAliases: {"Developer": "Dev"}
+DiscordChatChannelTypingIndicators: false
 
 # Console channel information
 # The console channel is the text channel that receives messages which are then run as server commands

--- a/src/main/resources/config/es.yml
+++ b/src/main/resources/config/es.yml
@@ -158,6 +158,7 @@ StatusUpdateRateInMinutes: 2
 # DiscordChatChannelRolesSelectionAsWhitelist: si la siguiente lista se debe tratar como una lista blanca (verdadera) o una lista negra (falsa)
 # DiscordChatChannelRolesSelection: lista de roles que se deben filtrar de todos los roles de un usuario
 # DiscordChatChannelRoleAliases: lista de alias de roles (nombres alternativos de roles para usar en mensajes de Minecraft)
+# DiscordChatChannelTypingIndicators: si el bot debería aparecer como "escribiendo" en Discord mientras los jugadores de Minecraft están escribiendo (requiere 1.19.1 y "previews-chat" habilitado en server.properties)
 #
 DiscordChatChannelDiscordToMinecraft: true
 DiscordChatChannelMinecraftToDiscord: true
@@ -179,6 +180,7 @@ DiscordChatChannelBlockedRolesIds: ["000000000000000000", "000000000000000000", 
 DiscordChatChannelRolesSelectionAsWhitelist: false
 DiscordChatChannelRolesSelection: ["Don't show me!", "Misc role"]
 DiscordChatChannelRoleAliases: {"Developer": "Dev"}
+DiscordChatChannelTypingIndicators: false
 
 # Información del canal de la consola
 # El canal de la consola es el canal de texto que recibe mensajes que luego se ejecutan como comandos del servidor

--- a/src/main/resources/config/et.yml
+++ b/src/main/resources/config/et.yml
@@ -158,6 +158,7 @@ StatusUpdateRateInMinutes: 2
 # DiscordChatChannelRolesSelectionAsWhitelist: if the following list should be treated as a whitelist (true) or a blacklist (false)
 # DiscordChatChannelRolesSelection: list of roles that should be filtered from all of a user's roles
 # DiscordChatChannelRoleAliases: list of role aliases (alternate names for roles to use in Minecraft messages)
+# DiscordChatChannelTypingIndicators: kas bot peaks ilmuma Discordis "trükkivana", kui Minecrafti mängijad kirjutavad (nõuab versiooni 1.19.1 ja serveris server.properties on lubatud "previews-chat")
 #
 DiscordChatChannelDiscordToMinecraft: true
 DiscordChatChannelMinecraftToDiscord: true
@@ -179,6 +180,7 @@ DiscordChatChannelBlockedRolesIds: ["000000000000000000", "000000000000000000", 
 DiscordChatChannelRolesSelectionAsWhitelist: false
 DiscordChatChannelRolesSelection: ["Ära näita mind!", "Muu roll"]
 DiscordChatChannelRoleAliases: {"Arendaja": "Dev"}
+DiscordChatChannelTypingIndicators: false
 
 # Console channel information
 # The console channel is the text channel that receives messages which are then run as server commands

--- a/src/main/resources/config/fr.yml
+++ b/src/main/resources/config/fr.yml
@@ -157,6 +157,7 @@ StatusUpdateRateInMinutes: 2
 # DiscordChatChannelRolesSelectionAsWhitelist: si la liste suivante doit être traitée comme une liste blanche (true) ou une liste noire (false)
 # DiscordChatChannelRolesSelection: la liste des rôles devant être filtrés de tous les rôles d'un utilisateur
 # DiscordChatChannelRoleAliases: liste des alias de rôle (noms alternatifs des rôles à utiliser dans les messages Minecraft)
+# DiscordChatChannelTypingIndicators: si le bot doit apparaître comme "tapant" sur Discord pendant que les joueurs de Minecraft tapent (nécessite 1.19.1 et "previews-chat" activé dans server.properties)
 #
 DiscordChatChannelDiscordToMinecraft: true
 DiscordChatChannelMinecraftToDiscord: true
@@ -178,6 +179,7 @@ DiscordChatChannelBlockedRolesIds: ["000000000000000000", "000000000000000000", 
 DiscordChatChannelRolesSelectionAsWhitelist: false
 DiscordChatChannelRolesSelection: ["Don't show me!", "Misc role"]
 DiscordChatChannelRoleAliases: {"Developer": "Dev"}
+DiscordChatChannelTypingIndicators: false
 
 # Channel console
 # Le channel console est un channel qui reçoit des messages de la console.

--- a/src/main/resources/config/ja.yml
+++ b/src/main/resources/config/ja.yml
@@ -158,6 +158,7 @@ StatusUpdateRateInMinutes: 2
 # DiscordChatChannelRolesSelectionAsWhitelist:次のリストをホワイトリスト（true）またはブラックリスト（false）として扱う場合
 # DiscordChatChannelRolesSelection:すべてのユーザーの役割から除外する必要がある役割のリスト
 # DiscordChatChannelRoleAliases: ロールエイリアスのリスト（Minecraftメッセージで使用するロールの代替名）
+# DiscordChatChannelTypingIndicators: Minecraft プレイヤーが入力している間、ボットが Discord で「入力中」として表示されるかどうか (1.19.1 および server.properties で有効化された「previews-chat」が必要)
 #
 DiscordChatChannelDiscordToMinecraft: true
 DiscordChatChannelMinecraftToDiscord: true
@@ -179,6 +180,7 @@ DiscordChatChannelBlockedRolesIds: ["000000000000000000", "000000000000000000", 
 DiscordChatChannelRolesSelectionAsWhitelist: false
 DiscordChatChannelRolesSelection: ["Don't show me!", "Misc role"]
 DiscordChatChannelRoleAliases: {"Developer": "Dev"}
+DiscordChatChannelTypingIndicators: false
 
 # コンソールチャンネル情報
 # コンソールチャンネルは、DiscordのテキストチャンネルとMinecraftのサーバーコンソールを紐づけたチャンネルです。

--- a/src/main/resources/config/ko.yml
+++ b/src/main/resources/config/ko.yml
@@ -159,6 +159,7 @@ StatusUpdateRateInMinutes: 2
 # DiscordChatChannelRolesSelectionAsWhitelist: 필터링할 역할 처리 설정; true로 설정하면 "필터링할 역할 목록"을 허용 목록으로 설정하고, false로 설정하면 "필터링할 역할 목록"을 차단 목록으로 설정합니다.
 # DiscordChatChannelRolesSelection: 필터링할 역할 목록
 # DiscordChatChannelRoleAliases: 마인크래프트 메시지에서 사용할 역할 별명
+# DiscordChatChannelTypingIndicators: Minecraft 플레이어가 입력하는 동안 봇이 Discord에서 "입력 중"으로 나타나야 하는지 여부(1.19.1 및 server.properties에서 "previews-chat" 활성화 필요)
 #
 DiscordChatChannelDiscordToMinecraft: true
 DiscordChatChannelMinecraftToDiscord: true
@@ -180,6 +181,7 @@ DiscordChatChannelBlockedRolesIds: ["000000000000000000", "000000000000000000", 
 DiscordChatChannelRolesSelectionAsWhitelist: false
 DiscordChatChannelRolesSelection: ["Don't show me!", "Misc role"]
 DiscordChatChannelRoleAliases: {"Developer": "Dev"}
+DiscordChatChannelTypingIndicators: false
 
 # 콘솔 채널 설정
 # 콘솔 채널은 서버 콘솔의 메시지를 디스코드로 받아오고 명령어를 콘솔로 전송해 실행하는 채널입니다.

--- a/src/main/resources/config/nl.yml
+++ b/src/main/resources/config/nl.yml
@@ -158,6 +158,7 @@ StatusUpdateRateInMinutes: 2
 # DiscordChatChannelRolesSelectionAsWhitelist: als de volgende lijst moet worden behandeld als een witte lijst (waar) of een zwarte lijst (false)
 # DiscordChatChannelRolesSelection: lijst met 'roles' die moeten worden gefilterd uit alle rollen van een gebruiker
 # DiscordChatChannelRoleAliases: lijst met rolaliassen (alternatieve namen voor rollen om te gebruiken in Minecraft-berichten)
+# DiscordChatChannelTypingIndicators: of de bot moet verschijnen als "typend" op Discord terwijl Minecraft-spelers aan het typen zijn (vereist 1.19.1 en "previews-chat" ingeschakeld in server.properties)
 #
 DiscordChatChannelDiscordToMinecraft: true
 DiscordChatChannelMinecraftToDiscord: true
@@ -179,6 +180,7 @@ DiscordChatChannelBlockedRolesIds: ["000000000000000000", "000000000000000000", 
 DiscordChatChannelRolesSelectionAsWhitelist: false
 DiscordChatChannelRolesSelection: ["Don't show me!", "Misc role"]
 DiscordChatChannelRoleAliases: {"Developer": "Dev"}
+DiscordChatChannelTypingIndicators: false
 
 # Console kanaal informatie
 # Het console kanaal is het text kanaal dat berichten ontvangt die ook in de console te zien zijn.

--- a/src/main/resources/config/pl.yml
+++ b/src/main/resources/config/pl.yml
@@ -158,6 +158,7 @@ StatusUpdateRateInMinutes: 2
 # DiscordChatChannelRolesSelectionAsWhitelist: czy poniższa lista powinna być traktowana jako biała lista (prawda) czy czarna lista (fałsz)
 # DiscordChatChannelRolesSelection: lista ról, które powinny zostać odfiltrowane ze wszystkich ról użytkownika
 # DiscordChatChannelRoleAliases: lista aliasów ról (alternatywne nazwy ról do użycia w wiadomościach Minecraft)
+# DiscordChatChannelTypingIndicators: czy bot powinien pojawiać się jako "piszący" na Discordzie podczas pisania przez graczy Minecrafta (wymaga włączonego 1.19.1 i "previews-chat" w server.properties)
 #
 DiscordChatChannelDiscordToMinecraft: true
 DiscordChatChannelMinecraftToDiscord: true
@@ -179,6 +180,7 @@ DiscordChatChannelBlockedRolesIds: ["000000000000000000", "000000000000000000", 
 DiscordChatChannelRolesSelectionAsWhitelist: false
 DiscordChatChannelRolesSelection: ["Don't show me!", "Misc role"]
 DiscordChatChannelRoleAliases: {"Developer": "Dev"}
+DiscordChatChannelTypingIndicators: false
 
 # Informacje o kanale konsoli
 # Kanał konsoli to kanał tekstowy, który odbiera komunikaty, które są następnie uruchamiane jako polecenia serwera

--- a/src/main/resources/config/ru.yml
+++ b/src/main/resources/config/ru.yml
@@ -158,6 +158,7 @@ StatusUpdateRateInMinutes: 2
 # DiscordChatChannelRolesSelectionAsWhitelist: если следующий список следует рассматривать как белый список (true) или черный список (false)
 # DiscordChatChannelRolesSelection: список ролей, которые должны быть отфильтрованы по всем ролям пользователя.
 # DiscordChatChannelRoleAliases: список псевдонимов ролей (альтернативные имена для ролей для использования в сообщениях Minecraft)
+# DiscordChatChannelTypingIndicators: должен ли бот отображаться как «печатающий» в Discord, пока игроки Minecraft печатают (требуется 1.19.1 и «previews-chat», включенный в server.properties)
 #
 DiscordChatChannelDiscordToMinecraft: true
 DiscordChatChannelMinecraftToDiscord: true
@@ -179,6 +180,7 @@ DiscordChatChannelBlockedRolesIds: ["000000000000000000", "000000000000000000", 
 DiscordChatChannelRolesSelectionAsWhitelist: false
 DiscordChatChannelRolesSelection: ["Don't show me!", "Misc role"]
 DiscordChatChannelRoleAliases: {"Developer": "Dev"}
+DiscordChatChannelTypingIndicators: false
 
 # Настройка чата консоли
 # Канал или чат консоли - это текстовый канал, который интерпретирует все отслылаемые из Discord сообщения как команды консоли,

--- a/src/main/resources/config/zh.yml
+++ b/src/main/resources/config/zh.yml
@@ -157,6 +157,7 @@ StatusUpdateRateInMinutes: 2
 # DiscordChatChannelRolesSelectionAsWhitelist: 將後項名單中的用戶組視為白名單(true)或黑名單(false)
 # DiscordChatChannelRolesSelection: 此項設定的用戶組將依前項設定之規則處理
 # DiscordChatChannelRoleAliases: 角色别名列表（在Minecraft消息中使用的角色的备用名称）
+# DiscordChatChannelTypingIndicators: 當 Minecraft 玩家正在打字時，機器人是否應該在 Discord 上顯示為“正在打字”（需要 1.19.1 和 server.properties 中啟用的“previews-chat”）
 #
 DiscordChatChannelDiscordToMinecraft: true
 DiscordChatChannelMinecraftToDiscord: true
@@ -178,6 +179,7 @@ DiscordChatChannelBlockedRolesIds: ["000000000000000000", "000000000000000000", 
 DiscordChatChannelRolesSelectionAsWhitelist: false
 DiscordChatChannelRolesSelection: ["Don't show me!", "Misc role"]
 DiscordChatChannelRoleAliases: {"Developer": "Dev"}
+DiscordChatChannelTypingIndicators: false
 
 # 控制台頻道資訊
 # 此文字頻道所接收的訊息等同於控制台指令


### PR DESCRIPTION
This adds an optional feature that makes the bot start "typing" in Discord while players are typing in Minecraft, as described in #1412. It does this by taking advantage of the new [`AsyncPlayerChatPreviewEvent`](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/player/AsyncPlayerChatPreviewEvent.html) that was added in Spigot 1.19.1.

It adds a config option, `DiscordChatChannelTypingIndicators`, which is disabled by default and does nothing on versions prior to 1.19.1 (except sent a warning message to the console). The `previews-chat` option also needs to be enabled in server.properties or a warning message will be sent to the console.

If a chat hook is enabled, typing indicators will be correctly sent for the channel the player is currently talking in, also taking into account player/channel mutes. I tested this with all of the supported chat plugins on 1.19.2. If no chat hook is enabled, typing indicators will be sent for the global channel.

Typing indicators are sent as infrequently as possible to maximize performance: if the bot isn't already typing in a channel, it'll start typing immediately, otherwise it'll make sure at least 5 seconds have passed before sending another indicator. Overall, it only takes a couple milliseconds to process each chat preview event even with chat hooks.

Closes #1412.

https://user-images.githubusercontent.com/64972126/195221730-69139306-7212-4499-9437-5fd7175507fc.mp4