### PR TITLE
PlaceholderAPI fix for attachments

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordChatListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordChatListener.java
@@ -332,6 +332,13 @@ public class DiscordChatListener extends ListenerAdapter {
 
         placedMessage = MessageUtil.translateLegacy(
                 replacePlaceholders(placedMessage, event, selectedRoles));
+
+        OfflinePlayer authorPlayer = null;
+        UUID authorLinkedUuid = DiscordSRV.getPlugin().getAccountLinkManager().getUuid(event.getAuthor().getId());
+        if (authorLinkedUuid != null) authorPlayer = Bukkit.getOfflinePlayer(authorLinkedUuid);
+
+        placedMessage = PlaceholderUtil.replacePlaceholders(placedMessage, authorPlayer);
+
         placedMessage = DiscordUtil.convertMentionsToNames(placedMessage);
         if (!MessageUtil.isLegacy(placedMessage)) {
             // A hack that'll hold over until rewrite


### PR DESCRIPTION
4 lines copied from another part of the same file

Looks like just an oversight.