### PR TITLE
Update LunaChat Hook

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -23,6 +23,7 @@
 package github.scarsz.discordsrv;
 
 import alexh.weak.Dynamic;
+import com.github.ucchyocean.lc3.bukkit.event.LunaChatBukkitPostJapanizeEvent;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.gson.Gson;
@@ -1790,16 +1791,32 @@ public class DiscordSRV extends JavaPlugin {
         String username = player.getName();
         if (!reserializer) username = DiscordUtil.escapeMarkdown(username);
 
-        String discordMessage = (hasGoodGroup
-                ? LangUtil.Message.CHAT_TO_DISCORD.toString()
-                : LangUtil.Message.CHAT_TO_DISCORD_NO_PRIMARY_GROUP.toString())
-                .replaceAll("%time%|%date%", TimeUtil.timeStamp())
-                .replace("%channelname%", channel != null ? channel.substring(0, 1).toUpperCase() + channel.substring(1) : "")
-                .replace("%primarygroup%", userPrimaryGroup)
-                .replace("%username%", username)
-                .replace("%usernamenoescapes%", MessageUtil.strip(player.getName()))
-                .replace("%world%", player.getWorld().getName())
-                .replace("%worldalias%", MessageUtil.strip(MultiverseCoreHook.getWorldAlias(player.getWorld().getName())));
+        String discordMessage = "";
+
+        // Use a different format if the message is a LunaChat converted message
+        if (PluginUtil.pluginHookIsEnabled("LunaChat") && event.getClass().equals(LunaChatBukkitPostJapanizeEvent.class)) {
+            discordMessage = (hasGoodGroup
+                    ? LangUtil.Message.LUNACHAT_CONVERTED_TO_DISCORD.toString()
+                    : LangUtil.Message.LUNACHAT_CONVERTED_TO_DISCORD_NO_PRIMARY_GROUP.toString())
+                    .replaceAll("%time%|%date%", TimeUtil.timeStamp())
+                    .replace("%channelname%", channel != null ? channel.substring(0, 1).toUpperCase() + channel.substring(1) : "")
+                    .replace("%primarygroup%", userPrimaryGroup)
+                    .replace("%username%", username)
+                    .replace("%usernamenoescapes%", MessageUtil.strip(player.getName()))
+                    .replace("%world%", player.getWorld().getName())
+                    .replace("%worldalias%", MessageUtil.strip(MultiverseCoreHook.getWorldAlias(player.getWorld().getName())));
+        } else {
+            discordMessage = (hasGoodGroup
+                    ? LangUtil.Message.CHAT_TO_DISCORD.toString()
+                    : LangUtil.Message.CHAT_TO_DISCORD_NO_PRIMARY_GROUP.toString())
+                    .replaceAll("%time%|%date%", TimeUtil.timeStamp())
+                    .replace("%channelname%", channel != null ? channel.substring(0, 1).toUpperCase() + channel.substring(1) : "")
+                    .replace("%primarygroup%", userPrimaryGroup)
+                    .replace("%username%", username)
+                    .replace("%usernamenoescapes%", MessageUtil.strip(player.getName()))
+                    .replace("%world%", player.getWorld().getName())
+                    .replace("%worldalias%", MessageUtil.strip(MultiverseCoreHook.getWorldAlias(player.getWorld().getName())));
+        }
         discordMessage = PlaceholderUtil.replacePlaceholdersToDiscord(discordMessage, player);
 
         String displayName = MessageUtil.strip(player.getDisplayName());

--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -1797,26 +1797,20 @@ public class DiscordSRV extends JavaPlugin {
         if (PluginUtil.pluginHookIsEnabled("LunaChat") && event.getClass().equals(LunaChatBukkitPostJapanizeEvent.class)) {
             discordMessage = (hasGoodGroup
                     ? LangUtil.Message.LUNACHAT_CONVERTED_TO_DISCORD.toString()
-                    : LangUtil.Message.LUNACHAT_CONVERTED_TO_DISCORD_NO_PRIMARY_GROUP.toString())
-                    .replaceAll("%time%|%date%", TimeUtil.timeStamp())
-                    .replace("%channelname%", channel != null ? channel.substring(0, 1).toUpperCase() + channel.substring(1) : "")
-                    .replace("%primarygroup%", userPrimaryGroup)
-                    .replace("%username%", username)
-                    .replace("%usernamenoescapes%", MessageUtil.strip(player.getName()))
-                    .replace("%world%", player.getWorld().getName())
-                    .replace("%worldalias%", MessageUtil.strip(MultiverseCoreHook.getWorldAlias(player.getWorld().getName())));
+                    : LangUtil.Message.LUNACHAT_CONVERTED_TO_DISCORD_NO_PRIMARY_GROUP.toString());
         } else {
             discordMessage = (hasGoodGroup
                     ? LangUtil.Message.CHAT_TO_DISCORD.toString()
-                    : LangUtil.Message.CHAT_TO_DISCORD_NO_PRIMARY_GROUP.toString())
-                    .replaceAll("%time%|%date%", TimeUtil.timeStamp())
-                    .replace("%channelname%", channel != null ? channel.substring(0, 1).toUpperCase() + channel.substring(1) : "")
-                    .replace("%primarygroup%", userPrimaryGroup)
-                    .replace("%username%", username)
-                    .replace("%usernamenoescapes%", MessageUtil.strip(player.getName()))
-                    .replace("%world%", player.getWorld().getName())
-                    .replace("%worldalias%", MessageUtil.strip(MultiverseCoreHook.getWorldAlias(player.getWorld().getName())));
+                    : LangUtil.Message.CHAT_TO_DISCORD_NO_PRIMARY_GROUP.toString());
         }
+        discordMessage = discordMessage
+                .replaceAll("%time%|%date%", TimeUtil.timeStamp())
+                .replace("%channelname%", channel != null ? channel.substring(0, 1).toUpperCase() + channel.substring(1) : "")
+                .replace("%primarygroup%", userPrimaryGroup)
+                .replace("%username%", username)
+                .replace("%usernamenoescapes%", MessageUtil.strip(player.getName()))
+                .replace("%world%", player.getWorld().getName())
+                .replace("%worldalias%", MessageUtil.strip(MultiverseCoreHook.getWorldAlias(player.getWorld().getName())));
         discordMessage = PlaceholderUtil.replacePlaceholdersToDiscord(discordMessage, player);
 
         String displayName = MessageUtil.strip(player.getDisplayName());
@@ -1828,18 +1822,14 @@ public class DiscordSRV extends JavaPlugin {
             discordMessageContent = MessageUtil.strip(MessageUtil.toLegacy(message));
         }
 
+        discordMessage = discordMessage
+                .replace("%displayname%", displayName)
+                .replace("%displaynamenoescapes%", MessageUtil.strip(player.getDisplayName()))
+                .replace("%message%", discordMessageContent);
         // Convert %original% if the message is a LunaChat converted message
         if (PluginUtil.pluginHookIsEnabled("LunaChat") && event.getClass().equals(LunaChatBukkitPostJapanizeEvent.class)) {
             discordMessage = discordMessage
-                    .replace("%displayname%", displayName)
-                    .replace("%displaynamenoescapes%", MessageUtil.strip(player.getDisplayName()))
-                    .replace("%message%", discordMessageContent)
                     .replace("%original%", ((LunaChatBukkitPostJapanizeEvent) event).getOriginal());
-        } else {
-            discordMessage = discordMessage
-                    .replace("%displayname%", displayName)
-                    .replace("%displaynamenoescapes%", MessageUtil.strip(player.getDisplayName()))
-                    .replace("%message%", discordMessageContent);
         }
 
         discordMessage = processRegex(discordMessage);

--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -1828,10 +1828,19 @@ public class DiscordSRV extends JavaPlugin {
             discordMessageContent = MessageUtil.strip(MessageUtil.toLegacy(message));
         }
 
-        discordMessage = discordMessage
-                .replace("%displayname%", displayName)
-                .replace("%displaynamenoescapes%", MessageUtil.strip(player.getDisplayName()))
-                .replace("%message%", discordMessageContent);
+        // Convert %original% if the message is a LunaChat converted message
+        if (PluginUtil.pluginHookIsEnabled("LunaChat") && event.getClass().equals(LunaChatBukkitPostJapanizeEvent.class)) {
+            discordMessage = discordMessage
+                    .replace("%displayname%", displayName)
+                    .replace("%displaynamenoescapes%", MessageUtil.strip(player.getDisplayName()))
+                    .replace("%message%", discordMessageContent)
+                    .replace("%original%", ((LunaChatBukkitPostJapanizeEvent) event).getOriginal());
+        } else {
+            discordMessage = discordMessage
+                    .replace("%displayname%", displayName)
+                    .replace("%displaynamenoescapes%", MessageUtil.strip(player.getDisplayName()))
+                    .replace("%message%", discordMessageContent);
+        }
 
         discordMessage = processRegex(discordMessage);
         if (discordMessage == null) return;

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/LunaChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/LunaChatHook.java
@@ -24,6 +24,7 @@ package github.scarsz.discordsrv.hooks.chat;
 
 import com.github.ucchyocean.lc3.LunaChatBukkit;
 import com.github.ucchyocean.lc3.bukkit.event.LunaChatBukkitChannelChatEvent;
+import com.github.ucchyocean.lc3.bukkit.event.LunaChatBukkitPostJapanizeEvent;
 import com.github.ucchyocean.lc3.channel.Channel;
 import com.github.ucchyocean.lc3.member.ChannelMemberBukkit;
 import com.github.ucchyocean.lc3.member.ChannelMemberPlayer;
@@ -53,6 +54,17 @@ public class LunaChatHook implements ChatHook {
         Player player = (event.getMember() != null && event.getMember() instanceof ChannelMemberPlayer) ? ((ChannelMemberPlayer) event.getMember()).getPlayer() : null;
 
         DiscordSRV.getPlugin().processChatMessage(player, event.getNgMaskedMessage(), event.getChannel().getName(), false, event);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onMessageConverted(LunaChatBukkitPostJapanizeEvent event) {
+        // make sure message isn't just blank
+        if (StringUtils.isBlank(event.getJapanized())) return;
+
+        // get sender player
+        Player player = (event.getMember() != null && event.getMember() instanceof ChannelMemberPlayer) ? ((ChannelMemberPlayer) event.getMember()).getPlayer() : null;
+
+        DiscordSRV.getPlugin().processChatMessage(player, event.getJapanized(), event.getChannel().getName(), false, event);
     }
 
     @Override

--- a/src/main/java/github/scarsz/discordsrv/util/LangUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/LangUtil.java
@@ -703,6 +703,8 @@ public class LangUtil {
         CHAT_CHANNEL_TOPIC_AT_SERVER_SHUTDOWN("ChannelTopicUpdaterChatChannelTopicAtServerShutdownFormat", false),
         CHAT_TO_DISCORD("MinecraftChatToDiscordMessageFormat", false),
         CHAT_TO_DISCORD_NO_PRIMARY_GROUP("MinecraftChatToDiscordMessageFormatNoPrimaryGroup", false),
+        LUNACHAT_CONVERTED_TO_DISCORD("LunaChatConvertedMessageFormat", false),
+        LUNACHAT_CONVERTED_TO_DISCORD_NO_PRIMARY_GROUP("LunaChatConvertedMessageFormatNoPrimaryGroup", false),
         CHAT_TO_MINECRAFT("DiscordToMinecraftChatMessageFormat", true),
         CHAT_TO_MINECRAFT_ALL_ROLES_SEPARATOR("DiscordToMinecraftAllRolesSeparator", true),
         CHAT_TO_MINECRAFT_NO_ROLE("DiscordToMinecraftChatMessageFormatNoRole", true),

--- a/src/main/resources/messages/de.yml
+++ b/src/main/resources/messages/de.yml
@@ -101,6 +101,37 @@ MinecraftChatToDiscordMessageFormatNoPrimaryGroup: "%displayname% » %message%"
 #
 ChatChannelHookMessageFormat: "%channelcolor%[%channelnickname%]&r %message%"
 
+# LunaChat converted message
+# LunaChatConvertedMessageFormat: the format used when sending LunaChat converted messages to Discord
+# LunaChatConvertedMessageFormatNoPrimaryGroup: used in place of LunaChatConvertedMessageFormat
+#                                               when no primary group for the player was found
+# Available placeholders:
+# %username%:     raw player username
+#                  example: jeb_
+# %displayname%:  display name from things like nicknames
+#                  example: BigBossManJeb
+# %usernamenoescapes%:     raw player username without escaping discord format (for use in inline code & code block markdown)
+#                  example: jeb_
+# %displaynamenoescapes%:  display name from things like nicknames without escaping discord format (for use in inline code & code block markdown)
+#                  example: BigBossManJeb
+# %original%:     original message content
+#                  例: konnnitiha
+# %message%:      converted message content
+#                  例: こんにちは
+# %primarygroup%: the name of the user's primary group
+# %world%:        name of world player is in
+#                  example: world
+# %worldalias%:   alias of world player is in via Multiverse-Core
+#                  example: Mainland
+# %date%:         current date & time
+#                  example: Sun Jan 1 15:30:45 PDT 2017
+# %channelname%:  the name of the channel that the message was sent in, if the message was sent in a channel at all
+#                  example: Global
+# PlaceholderAPI placeholders are also supported
+
+LunaChatConvertedMessageFormat: "`[JP] %message%`"
+LunaChatConvertedMessageFormatNoPrimaryGroup: "`[JP] %message%`"
+
 # Dynmap-Nachrichten
 #
 # DynmapNameFormat: das Format für den Benutzernamen der an Dynmap gesendeten Nachricht (dies kann abhängig von den Dynmap-Einstellungen ausgeblendet sein)

--- a/src/main/resources/messages/en.yml
+++ b/src/main/resources/messages/en.yml
@@ -97,6 +97,37 @@ MinecraftChatToDiscordMessageFormatNoPrimaryGroup: "%displayname% » %message%"
 #
 ChatChannelHookMessageFormat: "%channelcolor%[%channelnickname%]&r %message%"
 
+# LunaChat converted message
+# LunaChatConvertedMessageFormat: the format used when sending LunaChat converted messages to Discord
+# LunaChatConvertedMessageFormatNoPrimaryGroup: used in place of LunaChatConvertedMessageFormat
+#                                               when no primary group for the player was found
+# Available placeholders:
+# %username%:     raw player username
+#                  example: jeb_
+# %displayname%:  display name from things like nicknames
+#                  example: BigBossManJeb
+# %usernamenoescapes%:     raw player username without escaping discord format (for use in inline code & code block markdown)
+#                  example: jeb_
+# %displaynamenoescapes%:  display name from things like nicknames without escaping discord format (for use in inline code & code block markdown)
+#                  example: BigBossManJeb
+# %original%:     original message content
+#                  例: konnnitiha
+# %message%:      converted message content
+#                  例: こんにちは
+# %primarygroup%: the name of the user's primary group
+# %world%:        name of world player is in
+#                  example: world
+# %worldalias%:   alias of world player is in via Multiverse-Core
+#                  example: Mainland
+# %date%:         current date & time
+#                  example: Sun Jan 1 15:30:45 PDT 2017
+# %channelname%:  the name of the channel that the message was sent in, if the message was sent in a channel at all
+#                  example: Global
+# PlaceholderAPI placeholders are also supported
+
+LunaChatConvertedMessageFormat: "`[JP] %message%`"
+LunaChatConvertedMessageFormatNoPrimaryGroup: "`[JP] %message%`"
+
 # Dynmap messages
 #
 # DynmapNameFormat: the format for the username part of the message sent to Dynmap (this may be hidden depending on dynmap settings)

--- a/src/main/resources/messages/es.yml
+++ b/src/main/resources/messages/es.yml
@@ -97,6 +97,37 @@ MinecraftChatToDiscordMessageFormatNoPrimaryGroup: "%displayname% » %message%"
 #
 ChatChannelHookMessageFormat: "%channelcolor%[%channelnickname%]&r %message%"
 
+# LunaChat converted message
+# LunaChatConvertedMessageFormat: the format used when sending LunaChat converted messages to Discord
+# LunaChatConvertedMessageFormatNoPrimaryGroup: used in place of LunaChatConvertedMessageFormat
+#                                               when no primary group for the player was found
+# Available placeholders:
+# %username%:     raw player username
+#                  example: jeb_
+# %displayname%:  display name from things like nicknames
+#                  example: BigBossManJeb
+# %usernamenoescapes%:     raw player username without escaping discord format (for use in inline code & code block markdown)
+#                  example: jeb_
+# %displaynamenoescapes%:  display name from things like nicknames without escaping discord format (for use in inline code & code block markdown)
+#                  example: BigBossManJeb
+# %original%:     original message content
+#                  例: konnnitiha
+# %message%:      converted message content
+#                  例: こんにちは
+# %primarygroup%: the name of the user's primary group
+# %world%:        name of world player is in
+#                  example: world
+# %worldalias%:   alias of world player is in via Multiverse-Core
+#                  example: Mainland
+# %date%:         current date & time
+#                  example: Sun Jan 1 15:30:45 PDT 2017
+# %channelname%:  the name of the channel that the message was sent in, if the message was sent in a channel at all
+#                  example: Global
+# PlaceholderAPI placeholders are also supported
+
+LunaChatConvertedMessageFormat: "`[JP] %message%`"
+LunaChatConvertedMessageFormatNoPrimaryGroup: "`[JP] %message%`"
+
 # Mensajes Dynmap
 #
 # DynmapNameFormat: el formato para la parte del nombre de usuario del mensaje enviado a Dynmap (esto puede estar oculto dependiendo de la configuración de dynmap)

--- a/src/main/resources/messages/et.yml
+++ b/src/main/resources/messages/et.yml
@@ -97,6 +97,37 @@ MinecraftChatToDiscordMessageFormatNoPrimaryGroup: "%displayname% » %message%"
 #
 ChatChannelHookMessageFormat: "%channelcolor%[%channelnickname%]&r %message%"
 
+# LunaChat converted message
+# LunaChatConvertedMessageFormat: the format used when sending LunaChat converted messages to Discord
+# LunaChatConvertedMessageFormatNoPrimaryGroup: used in place of LunaChatConvertedMessageFormat
+#                                               when no primary group for the player was found
+# Available placeholders:
+# %username%:     raw player username
+#                  example: jeb_
+# %displayname%:  display name from things like nicknames
+#                  example: BigBossManJeb
+# %usernamenoescapes%:     raw player username without escaping discord format (for use in inline code & code block markdown)
+#                  example: jeb_
+# %displaynamenoescapes%:  display name from things like nicknames without escaping discord format (for use in inline code & code block markdown)
+#                  example: BigBossManJeb
+# %original%:     original message content
+#                  例: konnnitiha
+# %message%:      converted message content
+#                  例: こんにちは
+# %primarygroup%: the name of the user's primary group
+# %world%:        name of world player is in
+#                  example: world
+# %worldalias%:   alias of world player is in via Multiverse-Core
+#                  example: Mainland
+# %date%:         current date & time
+#                  example: Sun Jan 1 15:30:45 PDT 2017
+# %channelname%:  the name of the channel that the message was sent in, if the message was sent in a channel at all
+#                  example: Global
+# PlaceholderAPI placeholders are also supported
+
+LunaChatConvertedMessageFormat: "`[JP] %message%`"
+LunaChatConvertedMessageFormatNoPrimaryGroup: "`[JP] %message%`"
+
 # Dynmap messages
 #
 # DynmapNameFormat: the format for the username part of the message sent to Dynmap (this may be hidden depending on dynmap settings)

--- a/src/main/resources/messages/fr.yml
+++ b/src/main/resources/messages/fr.yml
@@ -95,6 +95,37 @@ MinecraftChatToDiscordMessageFormatNoPrimaryGroup: "%displayname% » %message%"
 #
 ChatChannelHookMessageFormat: "%channelcolor%[%channelnickname%]&r %message%"
 
+# LunaChat converted message
+# LunaChatConvertedMessageFormat: the format used when sending LunaChat converted messages to Discord
+# LunaChatConvertedMessageFormatNoPrimaryGroup: used in place of LunaChatConvertedMessageFormat
+#                                               when no primary group for the player was found
+# Available placeholders:
+# %username%:     raw player username
+#                  example: jeb_
+# %displayname%:  display name from things like nicknames
+#                  example: BigBossManJeb
+# %usernamenoescapes%:     raw player username without escaping discord format (for use in inline code & code block markdown)
+#                  example: jeb_
+# %displaynamenoescapes%:  display name from things like nicknames without escaping discord format (for use in inline code & code block markdown)
+#                  example: BigBossManJeb
+# %original%:     original message content
+#                  例: konnnitiha
+# %message%:      converted message content
+#                  例: こんにちは
+# %primarygroup%: the name of the user's primary group
+# %world%:        name of world player is in
+#                  example: world
+# %worldalias%:   alias of world player is in via Multiverse-Core
+#                  example: Mainland
+# %date%:         current date & time
+#                  example: Sun Jan 1 15:30:45 PDT 2017
+# %channelname%:  the name of the channel that the message was sent in, if the message was sent in a channel at all
+#                  example: Global
+# PlaceholderAPI placeholders are also supported
+
+LunaChatConvertedMessageFormat: "`[JP] %message%`"
+LunaChatConvertedMessageFormatNoPrimaryGroup: "`[JP] %message%`"
+
 # Messages Dynmap
 #
 # DynmapNameFormat: le format de la partie nom d'utilisateur du message envoyé à Dynmap (cela peut être masqué en fonction des paramètres de dynmap)

--- a/src/main/resources/messages/ja.yml
+++ b/src/main/resources/messages/ja.yml
@@ -97,6 +97,37 @@ MinecraftChatToDiscordMessageFormatNoPrimaryGroup: "%displayname% » %message%"
 #
 ChatChannelHookMessageFormat: "%channelcolor%[%channelnickname%]&r %message%"
 
+# LunaChatの変換メッセージ
+# LunaChatConvertedMessageFormat: LunaChatの変換メッセージをDiscordに送る時に適用されるフォーマット
+# LunaChatConvertedMessageFormatNoPrimaryGroup: プレイヤーのプライマリグループが見つからなかった場合に
+#                                                    LunaChatConvertedMessageFormatの代わりに使用されるフォーマット
+# 使用できるキーワード:
+# %username%:     プレイヤー名
+#                  例: jeb_
+# %displayname%:  プレイヤーの表示名
+#                  例: BigBossManJeb
+# %usernamenoescapes%:     不和の形式をエスケープしなプレイヤー名（インラインコードとコードブロックマークダウンで使用）
+#                  example: jeb_
+# %displaynamenoescapes%:  不和の形式をエスケープしなプレイヤーの表示名（インラインコードとコードブロックマークダウンで使用）
+#                  example: BigBossManJeb
+# %original%:     変換前のメッセージ内容
+#                  例: konnnitiha
+# %message%:      変換後のメッセージ内容
+#                  例: こんにちは
+# %primarygroup%: プレイヤーのプライマリグループ名
+# %world%:        プレイヤーが発言した時に居たワールド名
+#                  例: world
+# %worldalias%:   プレイヤーが発言した時に居たワールドの、Multiverse-Coreに設定されているエイリアス名
+#                  例: Mainland
+# %date%:         現在の日付と時間
+#                  例: Sun Jan 1 15:30:45 PDT 2017
+# %channelname%:  メッセージがチャットチャネルから送信されている場合、メッセージが送信されたチャネルの名前。
+#                  例: Global
+# PlaceholderAPIプレースホルダもサポートされています
+
+LunaChatConvertedMessageFormat: "`[JP] %message%`"
+LunaChatConvertedMessageFormatNoPrimaryGroup: "`[JP] %message%`"
+
 # Dynmapメッセージ
 #
 # DynmapNameFormat: Dynmapに送信されるメッセージのユーザー名部分の形式（これは、dynmap設定によっては非表示になる場合があります）

--- a/src/main/resources/messages/ja.yml
+++ b/src/main/resources/messages/ja.yml
@@ -9,7 +9,7 @@
 # DiscordToMinecraftChatMessageFormat_mychannel: "[&bDiscord From MyChannel &r| %toprolecolor%%toprole%&r] %name% » %message%"
 # DiscordToMinecraftChatMessageFormatNoRole_mychannel: "[&bDiscord From MyChannel&r] %name% » %message%"
 #
-# 使用できるキーワード:
+# 使用できるプレースホルダー:
 # %allroles%:       発言した人が持っている全てのロール。DiscordToMinecraftAllRolesSeparatorで指定される記号で繋げられて表示されます
 #                    例: Owner | Developer | Boss man
 # %message%:        メッセージ内容
@@ -56,25 +56,25 @@ DiscordToMinecraftMessageReplyFormat: " (に返信する %name%)"
 # MinecraftChatToDiscordMessageFormatNoPrimaryGroup: プレイヤーのプライマリグループが見つからなかった場合に
 #                                                    MinecraftChatToDiscordMessageFormatの代わりに使用されるフォーマット
 #
-# 使用できるキーワード:
+# 使用できるプレースホルダー:
 # %username%:     プレイヤー名
 #                  例: jeb_
 # %displayname%:  プレイヤーの表示名
 #                  例: BigBossManJeb
-# %usernamenoescapes%:     不和の形式をエスケープしなプレイヤー名（インラインコードとコードブロックマークダウンで使用）
+# %usernamenoescapes%:     Discordの形式で変換しない元のプレイヤーユーザー名（インラインコードおよびコードブロックマークダウンで使用）
 #                  example: jeb_
-# %displaynamenoescapes%:  不和の形式をエスケープしなプレイヤーの表示名（インラインコードとコードブロックマークダウンで使用）
+# %displaynamenoescapes%:  Discordの形式で変換しないニックネームのようなプレイヤーの表示名（インラインコードおよびコードブロックマークダウンで使用）
 #                  example: BigBossManJeb
 # %message%:      メッセージ内容
 #                  例: Hello!
 # %primarygroup%: プレイヤーのプライマリグループ名
-# %world%:        プレイヤーが発言した時に居たワールド名
+# %world%:        プレイヤーが発言した時のワールド名
 #                  例: world
-# %worldalias%:   プレイヤーが発言した時に居たワールドの、Multiverse-Coreに設定されているエイリアス名
+# %worldalias%:   プレイヤーが発言した時のワールドのMultiverse-Coreに設定されているエイリアス名
 #                  例: Mainland
 # %date%:         現在の日付と時間
 #                  例: Sun Jan 1 15:30:45 PDT 2017
-# %channelname%:  メッセージがチャットチャネルから送信されている場合、メッセージが送信されたチャネルの名前。
+# %channelname%:  メッセージがチャットチャネルから送信されている場合のチャネル名
 #                  例: Global
 # PlaceholderAPIプレースホルダもサポートされています
 #
@@ -85,12 +85,12 @@ MinecraftChatToDiscordMessageFormatNoPrimaryGroup: "%displayname% » %message%"
 # これは、サポートされているチャットチャンネルプラグインがフックされている場合にのみ使用される特別なメッセージです。
 # ゲーム内のメッセージに、チャンネル固有の情報を付与することができます。
 #
-# 使用できるキーワード:
+# 使用できるプレースホルダー:
 # %channelcolor%:    チャンネルに設定されているカラーコード
 #                     例: &4
-# %channelname%:     チャンネル名。通常は、サーバーの内部IDになります
+# %channelname%:     チャンネル名。通常は、サーバーの内部ID
 #                     例: staff
-# %channelnickname%: チャンネルのニックネーム。通常は、プレイヤーが表示名として見ることができる名前になります
+# %channelnickname%: チャンネルのニックネーム。通常は、プレイヤーが表示名として見ることができる名前です
 #                     例: Staff
 # %message%:         DiscordToMinecraftChatMessageFormat / DiscordToMinecraftChatMessageFormatNoRole が適用された結果のメッセージ内容。
 #                     例: jeb_ > サーバーからこんにちは！
@@ -101,27 +101,27 @@ ChatChannelHookMessageFormat: "%channelcolor%[%channelnickname%]&r %message%"
 # LunaChatConvertedMessageFormat: LunaChatの変換メッセージをDiscordに送る時に適用されるフォーマット
 # LunaChatConvertedMessageFormatNoPrimaryGroup: プレイヤーのプライマリグループが見つからなかった場合に
 #                                                    LunaChatConvertedMessageFormatの代わりに使用されるフォーマット
-# 使用できるキーワード:
+# 使用できるプレースホルダー:
 # %username%:     プレイヤー名
 #                  例: jeb_
 # %displayname%:  プレイヤーの表示名
 #                  例: BigBossManJeb
-# %usernamenoescapes%:     不和の形式をエスケープしなプレイヤー名（インラインコードとコードブロックマークダウンで使用）
+# %usernamenoescapes%:     Discordの形式で変換しない元のプレイヤーユーザー名（インラインコードおよびコードブロックマークダウンで使用）
 #                  example: jeb_
-# %displaynamenoescapes%:  不和の形式をエスケープしなプレイヤーの表示名（インラインコードとコードブロックマークダウンで使用）
+# %displaynamenoescapes%:  Discordの形式で変換しないニックネームのようなプレイヤーの表示名（インラインコードおよびコードブロックマークダウンで使用）
 #                  example: BigBossManJeb
 # %original%:     変換前のメッセージ内容
 #                  例: konnnitiha
 # %message%:      変換後のメッセージ内容
 #                  例: こんにちは
 # %primarygroup%: プレイヤーのプライマリグループ名
-# %world%:        プレイヤーが発言した時に居たワールド名
+# %world%:        プレイヤーが発言した時のワールド名
 #                  例: world
-# %worldalias%:   プレイヤーが発言した時に居たワールドの、Multiverse-Coreに設定されているエイリアス名
+# %worldalias%:   プレイヤーが発言した時のワールドのMultiverse-Coreに設定されているエイリアス名
 #                  例: Mainland
 # %date%:         現在の日付と時間
 #                  例: Sun Jan 1 15:30:45 PDT 2017
-# %channelname%:  メッセージがチャットチャネルから送信されている場合、メッセージが送信されたチャネルの名前。
+# %channelname%:  メッセージがチャットチャネルから送信されている場合のチャネル名
 #                  例: Global
 # PlaceholderAPIプレースホルダもサポートされています
 
@@ -130,15 +130,15 @@ LunaChatConvertedMessageFormatNoPrimaryGroup: "`[JP] %message%`"
 
 # Dynmapメッセージ
 #
-# DynmapNameFormat: Dynmapに送信されるメッセージのユーザー名部分の形式（これは、dynmap設定によっては非表示になる場合があります）
-# DynmapChatFormat: Dynmapに送信されるメッセージのメッセージ部分のフォーマット
+# DynmapNameFormat: Dynmapに送信されるメッセージのユーザー名の形式（これは、dynmap設定によっては非表示になる場合があります）
+# DynmapChatFormat: Dynmapに送信されるメッセージのメッセージのフォーマット
 #
-# 使用できるキーワード:
-# Discordと同じ-> Minecraftプレースホルダー
+# 使用できるプレースホルダー:
+# Minecraft -> Discord と同じ
 #
 # DynmapDiscordFormat: Discordに送られるDynmapメッセージのフォーマット
 #
-# 使用できるキーワード:
+# 使用できるプレースホルダー:
 # %message%:  メッセージ内容
 #              例: Hello!
 # %name%:     Dynmap Webチャットで送信されたメッセージのユーザー名（空白にすることもできます）
@@ -150,10 +150,10 @@ DynmapChatFormat: "%message%"
 DynmapDiscordFormat: "[Dynmap] %name% » %message%"
 
 # Discord コンソールチャンネルメッセージ設定
-# コンソールチャンネルが有効なら、コンソールからコンソールチャンネルに送信される時に適用されるフォーマット設定です。
+# コンソールチャンネル有効時に、コンソールからコンソールチャンネルに送信される時のフォーマット
 #
-# 使用できるキーワード:
-# {level}:    メッセージの重要度レベル
+# 使用できるプレースホルダー:
+# {level}:    重要度レベル
 #              例: INFO, WARN, ERROR
 # {name}:     ロガー名
 #              例: Server
@@ -161,8 +161,8 @@ DynmapDiscordFormat: "[Dynmap] %name% » %message%"
 #              例: Sun 15:30:45
 # PlaceholderAPIプレースホルダもサポートされています
 #
-# DiscordConsoleChannelPrefix: 行の前に追加するプレフィックス。
-# DiscordConsoleChannelSuffix: 行の後に追加するサフィックス。
+# DiscordConsoleChannelPrefix: 行の前に追加する接頭辞。
+# DiscordConsoleChannelSuffix: 行の後に追加する接尾辞。
 #
 DiscordConsoleChannelTimestampFormat: "EEE HH:mm:ss"
 DiscordConsoleChannelPrefix: "[{date} {level}{name}] "
@@ -171,9 +171,9 @@ DiscordConsoleChannelPadding: 0
 
 # Discordチャットチャンネル !c コマンドエラーメッセージ
 # コマンド自体を実行する際のエラーではなく、プレーヤーがコマンドを実行するためのアクセス許可でエラーが発生した場合に使用されます
-# これはPMとしてユーザーに送信されます
+# これはプライベートメッセージとしてユーザーに送信されます
 #
-# 使用できるキーワード:
+# 使用できるプレースホルダー:
 # %user%:  コマンドを実行しようとしたユーザーの名前
 #           例: Notch
 # %error%: エラーの理由
@@ -187,7 +187,7 @@ DiscordChatChannelConsoleCommandNotifyErrorsFormat: "**%user%** さんが実行�
 # DiscordChatChannelListCommandFormatOnlinePlayers: リストの先頭に表示されるメッセージ
 # DiscordChatChannelListCommandFormatNoOnlinePlayers: オンラインのプレイヤーが誰もいないときに使用されるメッセージ
 # DiscordChatChannelListCommandPlayerFormat: 各プレーヤーがリストに表示される方法の形式
-#   使用できるキーワード:
+#   使用できるプレースホルダー:
 #   %username%:     プレイヤー名
 #   %displayname%:  プレイヤーの表示名
 #   %primarygroup%: プレイヤーのプライマリグループ名
@@ -204,16 +204,16 @@ DiscordChatChannelListCommandAllPlayersSeparator: ", "
 # Minecraft -> Discord 通知メッセージ
 #
 #
-# 情報を埋め込む:
+# 埋め込みメッセージの情報:
 # Color:      16進数の色コードを受け入れます (例 "#ffffff") またはRGB整数 (例 0)
-# Fields:     フォーマットは "題名;値;inline" (例 "誰が参加しましたか？;%displayname%;true") または"Blank"で空白のフィールドを追加します
-# Timestamp:  メッセージが送信された時間を使用するか、特定の時間のエポックタイムスタンプを使用するには、trueに設定します (https://www.epochconverter.com/)
+# Fields:     フォーマットは "title;value;inline" (例 "誰が参加しましたか？;%displayname%;true") または "blank" で空のフィールドを追加します
+# Timestamp:  メッセージの送信時刻を使用するか、特定の時刻のエポックタイムスタンプを使用する場合は、trueを設定してください (https://www.epochconverter.com/)
 #
 # PlayerJoin/PlayerFirstJoin/PlayerLeave/PlayerDeath/PlayerAchievementで使用可能なプレースホルダー:
 # %displayname%:         プレイヤーの表示名
 # %username%:            プレイヤー名
-# %displaynamenoescapes%:  不和の形式をエスケープしなプレイヤーの表示名（インラインコードとコードブロックマークダウンで使用）
-# %usernamenoescapes%:     不和の形式をエスケープしなプレイヤー名（インラインコードとコードブロックマークダウンで使用）
+# %displaynamenoescapes%:  Discordの形式で変換しない元のプレイヤーユーザー名（インラインコードおよびコードブロックマークダウンで使用）
+# %usernamenoescapes%:     Discordの形式で変換しないニックネームのようなプレイヤーの表示名（インラインコードおよびコードブロックマークダウンで使用）
 # %date%:                現在の日付と時間
 # %embedavatarurl%:      ユーザーのアバター
 # %botavatarurl%:        ボットのアバター
@@ -221,7 +221,7 @@ DiscordChatChannelListCommandAllPlayersSeparator: ", "
 # PlaceholderAPIプレースホルダもサポートされています
 #
 # PlayerJoinで使用可能なプレースホルダー:
-# %message%:        ゲーム内で見られるメッセージに参加
+# %message%:        ゲーム内で見られる参加メッセージ
 #
 MinecraftPlayerJoinMessage:
   Enabled: true
@@ -309,7 +309,7 @@ MinecraftPlayerLeaveMessage:
 #
 # PlayerDeathで使用可能なプレースホルダー:
 # %deathmessage%: 死亡メッセージ
-# %world%:        プレイヤーが死亡したワールドの名前
+# %world%:        プレイヤーが死亡したワールド名
 #
 MinecraftPlayerDeathMessage:
   Enabled: true
@@ -339,7 +339,7 @@ MinecraftPlayerDeathMessage:
 #
 # PlayerAchievementメッセージで使用可能なプレースホルダー：
 # %achievement%: メッセージ内容
-# %world%:       実績を得たときにいたワールドの名前
+# %world%:       実績を得たときのワールド名
 #
 MinecraftPlayerAchievementMessage:
   Enabled: true
@@ -368,12 +368,12 @@ MinecraftPlayerAchievementMessage:
     Timestamp: false
 
 # チャンネルトピックメッセージ
-# チャットチャンネルやコンソールチャンネルのトピックをサーバー情報で自動的に更新することに関連する設定です
+# チャットチャンネルやコンソールチャンネルのトピックをサーバー情報で自動的に更新する際の設定です
 #
 # ChannelTopicUpdater______ChannelTopicFormat: チャンネルのトピックにX秒ごとに設定するメッセージ
 # ChannelTopicUpdater______ChannelTopicAtShutdownFormat: サーバーがシャットダウンしたときにチャネルのトピックに設定するメッセージ
 #
-# 使用できるキーワード:
+# 使用できるプレースホルダー:
 # %playercount%:   現在のプレイヤー数
 # %playermax%:     最大プレイヤー数
 # %date%:          現在の日時
@@ -428,24 +428,24 @@ DiscordChatChannelServerShutdownMessage: ":octagonal_sign: **サーバーが停�
 # ServerWatchdogMessage: メインのチャットチャンネルに送信されるメッセージ。
 #                        "<@USERID>" を使うと、指定したユーザーIDにメンションを送ることができます。例 "<@12345678901234567890>"
 #                        "<@&ROLEID>" を使うと、指定したロールIDにメンションを送ることができます。例 "<@&12345678901234567890>"; ロールIDは、DiscordSRVが起動するときのコンソールログメッセージにも表示しているので、参考にしてください。
-#                        "%guildowner%" を使うと、サーバーオーバーにメンションを送りことができます。
+#                        "%guildowner%" を使うと、サーバーオーナーにメンションを送ることができます。
 #                        "%date%" を使うと、メッセージに時刻を表示することができます。
 #                        "%timeout%" を使用して、ServerWatchdogTimeout をプレースホルダーとして使用できます
-#                        不和のタイムスタンプ形式で使用するために "%timestamp%" プレースホルダーを使用できます
+#                        Discordのタイムスタンプ形式で使用するために "%timestamp%" プレースホルダーを使用できます
 #
 ServerWatchdogMessage: "<t:%timestamp%:R> %guildowner%、サーバーが%timeout%秒以内に応答しませんでした！ :fire::bangbang:"
 
 # アカウントリンクメッセージ
 # アカウントをリンクしたときに使われるメッセージです
 #
-# 使用できるキーワード:
+# 使用できるプレースホルダー:
 # CodeGenerated:                %code%:         プレーヤーとアカウントをリンクするために生成されたコード
 #                               %botname%:      Discordボットの名前
 # UnknownCode/InvalidCode:      %code%:         プレーヤーとアカウントをリンクするために生成されたコード
 #                               %mention%:      Discordアカウントへのメンション
 # DiscordAccountLinked:         %name%:         Discordアカウントとリンクされた、Minecraftプレイヤーのプレイヤー名
-#                               %displayname%:  ユーザーのDiscordアカウントとMinecraftプレーヤーの表示名がリンクされていた
-#                               %uuid%:         Discordアカウントとリンクされた、MinecraftプレイヤーのUUID
+#                               %displayname%:  ユーザーのDiscordアカウントにリンクされているMinecraftプレーヤーの表示名
+#                               %uuid%:         DiscordアカウントとリンクされているMinecraftプレイヤーのUUID
 #                               %mention%:      Discordアカウントへのメンション
 # DiscordAccountAlreadyLinked:  %uuid%:         ユーザーのリンクされたMinecraftアカウントのMinecraftuuid
 #                               %username%:     ユーザーのリンクされたMinecraftアカウントのMinecraftユーザー名
@@ -458,7 +458,7 @@ ServerWatchdogMessage: "<t:%timestamp%:R> %guildowner%、サーバーが%timeout
 # MinecraftNobodyFound:         %target%:       結果が見つからない原因となった入力
 #
 # Discord
-CodeGenerated: "あなたのリンクコードは%code%です。あなたのアカウントとリンクするために、このコードだけを含むメッセージをDiscord上のボット(%botname%)にPMを送ってください。"
+CodeGenerated: "あなたのリンクコードは%code%です。あなたのアカウントとリンクするために、このコードだけを含むメッセージをDiscord上のボット(%botname%)にDMを送ってください。"
 UnknownCode: "そのようなコードは知りません。もう一度やり直してください。"
 InvalidCode: "それがあなたのコードで正しいですか？リンクコードは4文字の数字です。"
 DiscordAccountLinked: "あなたのDiscordアカウントは、%name% (%uuid%)とリンクしました"

--- a/src/main/resources/messages/ko.yml
+++ b/src/main/resources/messages/ko.yml
@@ -97,6 +97,37 @@ MinecraftChatToDiscordMessageFormatNoPrimaryGroup: "%displayname% » %message%"
 #
 ChatChannelHookMessageFormat: "%channelcolor%[%channelnickname%]&r %message%"
 
+# LunaChat converted message
+# LunaChatConvertedMessageFormat: the format used when sending LunaChat converted messages to Discord
+# LunaChatConvertedMessageFormatNoPrimaryGroup: used in place of LunaChatConvertedMessageFormat
+#                                               when no primary group for the player was found
+# Available placeholders:
+# %username%:     raw player username
+#                  example: jeb_
+# %displayname%:  display name from things like nicknames
+#                  example: BigBossManJeb
+# %usernamenoescapes%:     raw player username without escaping discord format (for use in inline code & code block markdown)
+#                  example: jeb_
+# %displaynamenoescapes%:  display name from things like nicknames without escaping discord format (for use in inline code & code block markdown)
+#                  example: BigBossManJeb
+# %original%:     original message content
+#                  例: konnnitiha
+# %message%:      converted message content
+#                  例: こんにちは
+# %primarygroup%: the name of the user's primary group
+# %world%:        name of world player is in
+#                  example: world
+# %worldalias%:   alias of world player is in via Multiverse-Core
+#                  example: Mainland
+# %date%:         current date & time
+#                  example: Sun Jan 1 15:30:45 PDT 2017
+# %channelname%:  the name of the channel that the message was sent in, if the message was sent in a channel at all
+#                  example: Global
+# PlaceholderAPI placeholders are also supported
+
+LunaChatConvertedMessageFormat: "`[JP] %message%`"
+LunaChatConvertedMessageFormatNoPrimaryGroup: "`[JP] %message%`"
+
 # Dynmap 메시지
 #
 # DynmapNameFormat: Dynmap을 통해 전송된 사용자 이름 형식을 설정합니다. 이것은 dynmap 설정에서 보이지 않게 설정할 수 있습니다.)

--- a/src/main/resources/messages/nl.yml
+++ b/src/main/resources/messages/nl.yml
@@ -99,6 +99,37 @@ MinecraftChatToDiscordMessageFormatNoPrimaryGroup: "%displayname% » %message%"
 #
 ChatChannelHookMessageFormat: "%channelcolor%[%channelnickname%]&r %message%"
 
+# LunaChat converted message
+# LunaChatConvertedMessageFormat: the format used when sending LunaChat converted messages to Discord
+# LunaChatConvertedMessageFormatNoPrimaryGroup: used in place of LunaChatConvertedMessageFormat
+#                                               when no primary group for the player was found
+# Available placeholders:
+# %username%:     raw player username
+#                  example: jeb_
+# %displayname%:  display name from things like nicknames
+#                  example: BigBossManJeb
+# %usernamenoescapes%:     raw player username without escaping discord format (for use in inline code & code block markdown)
+#                  example: jeb_
+# %displaynamenoescapes%:  display name from things like nicknames without escaping discord format (for use in inline code & code block markdown)
+#                  example: BigBossManJeb
+# %original%:     original message content
+#                  例: konnnitiha
+# %message%:      converted message content
+#                  例: こんにちは
+# %primarygroup%: the name of the user's primary group
+# %world%:        name of world player is in
+#                  example: world
+# %worldalias%:   alias of world player is in via Multiverse-Core
+#                  example: Mainland
+# %date%:         current date & time
+#                  example: Sun Jan 1 15:30:45 PDT 2017
+# %channelname%:  the name of the channel that the message was sent in, if the message was sent in a channel at all
+#                  example: Global
+# PlaceholderAPI placeholders are also supported
+
+LunaChatConvertedMessageFormat: "`[JP] %message%`"
+LunaChatConvertedMessageFormatNoPrimaryGroup: "`[JP] %message%`"
+
 # Dynmap-berichten
 #
 # DynmapNameFormat: de indeling voor het gebruikersnaamgedeelte van het bericht dat naar Dynmap is verzonden (dit kan verborgen zijn, afhankelijk van de dynmap-instellingen)

--- a/src/main/resources/messages/pl.yml
+++ b/src/main/resources/messages/pl.yml
@@ -97,6 +97,37 @@ MinecraftChatToDiscordMessageFormatNoPrimaryGroup: "%displayname% » %message%"
 #
 ChatChannelHookMessageFormat: "%channelcolor%[%channelnickname%]&r %message%"
 
+# LunaChat converted message
+# LunaChatConvertedMessageFormat: the format used when sending LunaChat converted messages to Discord
+# LunaChatConvertedMessageFormatNoPrimaryGroup: used in place of LunaChatConvertedMessageFormat
+#                                               when no primary group for the player was found
+# Available placeholders:
+# %username%:     raw player username
+#                  example: jeb_
+# %displayname%:  display name from things like nicknames
+#                  example: BigBossManJeb
+# %usernamenoescapes%:     raw player username without escaping discord format (for use in inline code & code block markdown)
+#                  example: jeb_
+# %displaynamenoescapes%:  display name from things like nicknames without escaping discord format (for use in inline code & code block markdown)
+#                  example: BigBossManJeb
+# %original%:     original message content
+#                  例: konnnitiha
+# %message%:      converted message content
+#                  例: こんにちは
+# %primarygroup%: the name of the user's primary group
+# %world%:        name of world player is in
+#                  example: world
+# %worldalias%:   alias of world player is in via Multiverse-Core
+#                  example: Mainland
+# %date%:         current date & time
+#                  example: Sun Jan 1 15:30:45 PDT 2017
+# %channelname%:  the name of the channel that the message was sent in, if the message was sent in a channel at all
+#                  example: Global
+# PlaceholderAPI placeholders are also supported
+
+LunaChatConvertedMessageFormat: "`[JP] %message%`"
+LunaChatConvertedMessageFormatNoPrimaryGroup: "`[JP] %message%`"
+
 # Wiadomości Dynmap
 #
 # DynmapNameFormat: format części zawierającej nazwę użytkownika w wiadomości wysyłanej do Dynmap (może być ukryty w zależności od ustawień dynmap)

--- a/src/main/resources/messages/ru.yml
+++ b/src/main/resources/messages/ru.yml
@@ -97,6 +97,37 @@ MinecraftChatToDiscordMessageFormatNoPrimaryGroup: "%displayname% » %message%"
 #
 ChatChannelHookMessageFormat: "%channelcolor%[%channelnickname%]&r %message%"
 
+# LunaChat converted message
+# LunaChatConvertedMessageFormat: the format used when sending LunaChat converted messages to Discord
+# LunaChatConvertedMessageFormatNoPrimaryGroup: used in place of LunaChatConvertedMessageFormat
+#                                               when no primary group for the player was found
+# Available placeholders:
+# %username%:     raw player username
+#                  example: jeb_
+# %displayname%:  display name from things like nicknames
+#                  example: BigBossManJeb
+# %usernamenoescapes%:     raw player username without escaping discord format (for use in inline code & code block markdown)
+#                  example: jeb_
+# %displaynamenoescapes%:  display name from things like nicknames without escaping discord format (for use in inline code & code block markdown)
+#                  example: BigBossManJeb
+# %original%:     original message content
+#                  例: konnnitiha
+# %message%:      converted message content
+#                  例: こんにちは
+# %primarygroup%: the name of the user's primary group
+# %world%:        name of world player is in
+#                  example: world
+# %worldalias%:   alias of world player is in via Multiverse-Core
+#                  example: Mainland
+# %date%:         current date & time
+#                  example: Sun Jan 1 15:30:45 PDT 2017
+# %channelname%:  the name of the channel that the message was sent in, if the message was sent in a channel at all
+#                  example: Global
+# PlaceholderAPI placeholders are also supported
+
+LunaChatConvertedMessageFormat: "`[JP] %message%`"
+LunaChatConvertedMessageFormatNoPrimaryGroup: "`[JP] %message%`"
+
 # Dynmap сообщения
 #
 # DynmapNameFormat: формат ника, отправляемого в Dynmap (это может быть скрыто в зависимости от настроек dynmap)

--- a/src/main/resources/messages/zh.yml
+++ b/src/main/resources/messages/zh.yml
@@ -96,6 +96,37 @@ MinecraftChatToDiscordMessageFormatNoPrimaryGroup: "%displayname% » %message%"
 #
 ChatChannelHookMessageFormat: "%channelcolor%[%channelnickname%]&r %message%"
 
+# LunaChat converted message
+# LunaChatConvertedMessageFormat: the format used when sending LunaChat converted messages to Discord
+# LunaChatConvertedMessageFormatNoPrimaryGroup: used in place of LunaChatConvertedMessageFormat
+#                                               when no primary group for the player was found
+# Available placeholders:
+# %username%:     raw player username
+#                  example: jeb_
+# %displayname%:  display name from things like nicknames
+#                  example: BigBossManJeb
+# %usernamenoescapes%:     raw player username without escaping discord format (for use in inline code & code block markdown)
+#                  example: jeb_
+# %displaynamenoescapes%:  display name from things like nicknames without escaping discord format (for use in inline code & code block markdown)
+#                  example: BigBossManJeb
+# %original%:     original message content
+#                  例: konnnitiha
+# %message%:      converted message content
+#                  例: こんにちは
+# %primarygroup%: the name of the user's primary group
+# %world%:        name of world player is in
+#                  example: world
+# %worldalias%:   alias of world player is in via Multiverse-Core
+#                  example: Mainland
+# %date%:         current date & time
+#                  example: Sun Jan 1 15:30:45 PDT 2017
+# %channelname%:  the name of the channel that the message was sent in, if the message was sent in a channel at all
+#                  example: Global
+# PlaceholderAPI placeholders are also supported
+
+LunaChatConvertedMessageFormat: "`[JP] %message%`"
+LunaChatConvertedMessageFormatNoPrimaryGroup: "`[JP] %message%`"
+
 # Dynmap讯息
 #
 # DynmapNameFormat: 发送到Dynmap的消息的用户名部分的格式（根据dynmap设置，可能会隐藏）


### PR DESCRIPTION
## What did I do?
- Add LunaChatBukkitPostJapanizeEvent Hook
- Add LunaChatConvertedMessageFormat to the messages.yml
- Corrected Japanese translation
### Why?
Many people using LunaChat use the Japanese conversion feature (called Japanize in LunaChat) as well as the channel chat function. However, when using the channel chat function, the Japanese conversion string is not sent to Discord. Therefore, I wrote code so that the Japanese conversion string can also be sent to Discord.

And some Japanese translations were strange, so I fixed them.