### PR TITLE
Add nChat support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -174,6 +174,7 @@ repositories {
     maven("https://oss.sonatype.org/content/repositories/snapshots")
     maven("https://s01.oss.sonatype.org/content/repositories/snapshots")
     maven("https://nexus.scarsz.me/content/groups/public/")
+    maven("https://repo.nickuc.com/maven2/") // For nChat hook
 }
 
 dependencies {
@@ -259,6 +260,7 @@ dependencies {
     compileOnly("com.dthielke.herochat:Herochat:5.6.5")
     compileOnly("br.com.devpaulo:legendchat:1.1.5")
     compileOnly("com.github.ucchyocean.lc:LunaChat:3.0.16")
+    compileOnly("com.nickuc.chat:nchat-api:5.6")
     compileOnly("com.palmergames.bukkit:TownyChat:0.45")
     compileOnly("mineverse.aust1n46:venturechat:2.20.1")
     compileOnly("com.comphenix.protocol:ProtocolLib:4.5.0")

--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -1066,6 +1066,7 @@ public class DiscordSRV extends JavaPlugin {
                 "github.scarsz.discordsrv.hooks.chat.ChattyChatHook",
                 "github.scarsz.discordsrv.hooks.chat.FancyChatHook",
                 "github.scarsz.discordsrv.hooks.chat.HerochatHook",
+                "github.scarsz.discordsrv.hooks.chat.NChatHook", // nChat Hook needs to work before LegendChat
                 "github.scarsz.discordsrv.hooks.chat.LegendChatHook",
                 "github.scarsz.discordsrv.hooks.chat.LunaChatHook",
                 "github.scarsz.discordsrv.hooks.chat.TownyChatHook",

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/NChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/NChatHook.java
@@ -1,0 +1,68 @@
+/*
+ * DiscordSRV - https://github.com/DiscordSRV/DiscordSRV
+ *
+ * Copyright (C) 2016 - 2022 Austin "Scarsz" Shapiro
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ */
+
+package github.scarsz.discordsrv.hooks.chat;
+
+import com.nickuc.chat.api.events.PublicMessageEvent;
+import com.nickuc.chat.api.nChatAPI;
+import github.scarsz.discordsrv.DiscordSRV;
+import github.scarsz.discordsrv.util.LangUtil;
+import github.scarsz.discordsrv.util.MessageUtil;
+import github.scarsz.discordsrv.util.PlayerUtil;
+import github.scarsz.discordsrv.util.PluginUtil;
+import net.kyori.adventure.text.Component;
+import org.bukkit.ChatColor;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.plugin.Plugin;
+
+public class NChatHook implements ChatHook {
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onMessage(PublicMessageEvent event) {
+        DiscordSRV.getPlugin().processChatMessage(event.getSender().getPlayer(), event.getMessage(), event.getChannel().getName(), event.isCancelled(), event);
+    }
+
+    @Override
+    public void broadcastMessageToChannel(String channelName, Component message) {
+        nChatAPI.getApi().getChannelByName(channelName).ifPresent(chatChannel -> {
+            String legacy = MessageUtil.toLegacy(message);
+            String chatChannelCommand = chatChannel.getCommand();
+            String chatChannelNickname = chatChannelCommand != null ? chatChannelCommand : Character.toString(chatChannel.getName().charAt(0));
+            String chatChannelColor = ChatColor.getLastColors(chatChannel.getFormat());
+
+            String plainMessage = LangUtil.Message.CHAT_CHANNEL_MESSAGE.toString()
+                    .replace("%channelname%", chatChannel.getName())
+                    .replace("%channelnickname%", chatChannelNickname)
+                    .replace("%message%", legacy)
+                    .replace("%channelcolor%", MessageUtil.toLegacy(MessageUtil.toComponent(MessageUtil.translateLegacy(chatChannelColor))));
+
+            String translatedMessage = MessageUtil.translateLegacy(plainMessage);
+            nChatAPI.getApi().handleVirtualMessage(translatedMessage, chatChannel, virtualMessageEvent ->
+                    PlayerUtil.notifyPlayersOfMentions(player -> virtualMessageEvent.getRecipients().contains(player), legacy));
+        });
+    }
+
+    @Override
+    public Plugin getPlugin() {
+        return PluginUtil.getPlugin("nChat");
+    }
+
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -13,7 +13,7 @@ loadbefore: [
 ]
 softdepend: [
   # Chat plugins
-  Chatty, FancyChat, Herochat, Legendchat, LunaChat, TownyChat, VentureChat,
+  Chatty, FancyChat, Herochat, Legendchat, LunaChat, nChat, TownyChat, VentureChat,
   # Vanish plugins
   Essentials, PhantomAdmin, SuperVanish,
   # Misc. plugins


### PR DESCRIPTION
nChat is a relatively popular chat plugin on Brazilian and Portuguese servers. The plugin previously worked with DiscordSRV via a **Legendchat API implementation**, but after the recent addition of [Paper Plugins](https://github.com/PaperMC/Paper/pull/8108/) , it is no longer possible to spoof and implement the Legendchat API.

**I make this Pull Request to add proper compatibility with nChat.**

**nChat Download** _(if required)_
https://repo.nickuc.com/download?name=nChat