### PR TITLE
Fix: Linked discord role config option not working with role IDs

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/objects/managers/link/AbstractAccountLinkManager.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/managers/link/AbstractAccountLinkManager.java
@@ -123,7 +123,7 @@ public abstract class AbstractAccountLinkManager extends AccountLinkManager {
         } else {
             String roleName = DiscordSRV.config().getString("MinecraftDiscordAccountLinkedRoleNameToAddUserTo");
             try {
-                Role roleToAdd = DiscordUtil.getJda().getRolesByName(roleName, true).stream().findFirst().orElse(null);
+                Role roleToAdd = DiscordUtil.resolveRole(roleName);
                 if (roleToAdd != null) {
                     Member member = roleToAdd.getGuild().getMemberById(discordId);
                     if (member != null) {
@@ -151,7 +151,7 @@ public abstract class AbstractAccountLinkManager extends AccountLinkManager {
         } else {
             try {
                 // remove user from linked role
-                Role role = DiscordUtil.getJda().getRolesByName(DiscordSRV.config().getString("MinecraftDiscordAccountLinkedRoleNameToAddUserTo"), true).stream().findFirst().orElse(null);
+                Role role = DiscordUtil.resolveRole(DiscordSRV.config().getString("MinecraftDiscordAccountLinkedRoleNameToAddUserTo"));
                 if (role != null) {
                     Member member = role.getGuild().getMemberById(discordId);
                     if (member != null) {


### PR DESCRIPTION
When MinecraftDiscordAccountLinkedRoleNameToAddUserTo was updated to allow role IDs as well, the change to use DiscordUtil.resolveRole() was not applied to all locations where the config option was referenced. This fixes that issue.