### PR TITLE
Escape markdown backslashes

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/util/DiscordUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/DiscordUtil.java
@@ -193,7 +193,7 @@ public class DiscordUtil {
      * @return String with markdown escaped
      */
     public static String escapeMarkdown(String text) {
-        return text == null ? "" : text.replace("_", "\\_").replace("*", "\\*").replace("~", "\\~").replace("|", "\\|").replace(">", "\\>").replace("`", "\\`");
+        return text == null ? "" : text.replace("\\", "\\\\").replace("_", "\\_").replace("*", "\\*").replace("~", "\\~").replace("|", "\\|").replace(">", "\\>").replace("`", "\\`");
     }
 
     /**


### PR DESCRIPTION
Makes the `DiscordUtil.escapeMarkdown` method escape backslashes to prevent bypassing.

e.g. `\_text\_` ran through escapeMarkdown would output `\\_text\\_` and be displayed in italics: \\_text_\\