### PR TITLE
Fix texture string extraction

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/util/NMSUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/NMSUtil.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 
 public class NMSUtil {
 
-    private static final Pattern TEXTURE_URL_PATTERN = Pattern.compile("https?://.+(?<texture>\\w{64})\"");
+    private static final Pattern TEXTURE_URL_PATTERN = Pattern.compile("https?://.+?(?<texture>\\w+)\"");
 
     protected static String versionPrefix = "";
     protected static boolean failed = false;

--- a/src/main/java/github/scarsz/discordsrv/util/NMSUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/NMSUtil.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 
 public class NMSUtil {
 
-    private static final Pattern TEXTURE_URL_PATTERN = Pattern.compile("https?://.+?(?<texture>\\w+)\"");
+    private static final Pattern TEXTURE_URL_PATTERN = Pattern.compile("https?://.+?(?<texture>\\w{60,64})\"");
 
     protected static String versionPrefix = "";
     protected static boolean failed = false;


### PR DESCRIPTION
Currently the regex pattern for extracting texture strings is `https?://.+(?<texture>\\w{64})\"`, which is usually ok as the JSON contains
```
    "SKIN" : {
      "url" : "http://textures.minecraft.net/texture/..."
    },
    "CAPE" : {
      "url" : "http://textures.minecraft.net/texture/..."
   }
```
so the SKIN url's texture will be extracted as it is first, however a user in a support ticket has a player who's texture string is only 63 characters, so was not matched by the regex causing the CAPE url's texture to be extracted instead. I have changed the regex to fix this.