### PR TITLE
fix: don't overwrite ban messages when syncing bans

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordBanListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordBanListener.java
@@ -55,6 +55,7 @@ public class DiscordBanListener extends ListenerAdapter {
         }
 
         String reason = LangUtil.Message.BAN_DISCORD_TO_MINECRAFT.toString();
+        if (Bukkit.getBanList(BanList.Type.NAME).isBanned(offlinePlayer.getName())) return; // if they are already banned we don't want to overwrite the original ban reason
         Bukkit.getBanList(BanList.Type.NAME).addBan(offlinePlayer.getName(), reason, null, "Discord");
         if (offlinePlayer.isOnline()) {
             // also kick them because adding them to the BanList isn't enough


### PR DESCRIPTION
At the moment if someone is banned in game by an admin, and ban sync is enabled, they are then banned in the Discord by DiscordSRV. DiscordSRV listens to this and then it bans them in Minecraft again, which overwrites the reason of the original Minecraft ban. This pr changes it so those who are already banned in Minecraft aren't banned again to stop this happening 
