### PR TITLE
Fix colour stripping bypass

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/util/MessageUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/MessageUtil.java
@@ -76,7 +76,7 @@ public class MessageUtil {
      * Pattern for capturing both ampersand and the legacy section sign color codes.
      * @see #LEGACY_SECTION
      */
-    public static final Pattern STRIP_PATTERN = Pattern.compile("(?<!<@)[&§\u007F](?i)[0-9a-fklmnorx]");
+    public static final Pattern STRIP_PATTERN = Pattern.compile("(?:(?<!<@)&|[§\u007F])(?i)[0-9a-fklmnorx]");
 
     /**
      * Pattern for capturing section sign color codes.


### PR DESCRIPTION
Fixes being able to bypass colour code filtering when you don't have a role in `DiscordChatChannelRolesAllowedToUseColorCodesInChat`

e.g. Sending `<@§aTEXT` in Discord will currently show in Minecraft as `<@TEXT` where `TEXT` is green.