### PR TITLE
Don't count console and chat channel IDs as equal if both are unset

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/util/DebugUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/DebugUtil.java
@@ -295,8 +295,8 @@ public class DebugUtil {
         }
 
         String consoleChannelId = DiscordSRV.config().getString("DiscordConsoleChannelId");
-        if (!consoleChannelId.matches("^0*$") && DiscordSRV.getPlugin().getChannels().values().stream().filter(Objects::nonNull)
-                .anyMatch(channelId -> channelId.equals(consoleChannelId))) {
+        if (consoleChannelId != null && !consoleChannelId.matches("^0*$")
+            && DiscordSRV.getPlugin().getChannels().values().stream().filter(Objects::nonNull).anyMatch(channelId -> channelId.equals(consoleChannelId))) {
             messages.add(new Message(Message.Type.CONSOLE_AND_CHAT_SAME_CHANNEL));
         }
 

--- a/src/main/java/github/scarsz/discordsrv/util/DebugUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/DebugUtil.java
@@ -296,7 +296,7 @@ public class DebugUtil {
 
         String consoleChannelId = DiscordSRV.config().getString("DiscordConsoleChannelId");
         if (consoleChannelId != null && !consoleChannelId.matches("^0*$")
-            && DiscordSRV.getPlugin().getChannels().values().stream().filter(Objects::nonNull).anyMatch(channelId -> channelId.equals(consoleChannelId))) {
+                && DiscordSRV.getPlugin().getChannels().values().stream().filter(Objects::nonNull).anyMatch(channelId -> channelId.equals(consoleChannelId))) {
             messages.add(new Message(Message.Type.CONSOLE_AND_CHAT_SAME_CHANNEL));
         }
 

--- a/src/main/java/github/scarsz/discordsrv/util/DebugUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/DebugUtil.java
@@ -295,7 +295,7 @@ public class DebugUtil {
         }
 
         String consoleChannelId = DiscordSRV.config().getString("DiscordConsoleChannelId");
-        if (DiscordSRV.getPlugin().getChannels().values().stream().filter(Objects::nonNull)
+        if (!consoleChannelId.matches("^0*$") && DiscordSRV.getPlugin().getChannels().values().stream().filter(Objects::nonNull)
                 .anyMatch(channelId -> channelId.equals(consoleChannelId))) {
             messages.add(new Message(Message.Type.CONSOLE_AND_CHAT_SAME_CHANNEL));
         }


### PR DESCRIPTION
Makes it so debug reports won't fail the `CONSOLE_AND_CHAT_SAME_CHANNEL` test if the console and chat channel IDs are both unset.