### PR TITLE
Default AvatarUrl use overlay

### DIFF
--- a/src/main/resources/config/da.yml
+++ b/src/main/resources/config/da.yml
@@ -87,7 +87,7 @@ Experiment_WebhookChatMessageUsernameFilters: {}
 # Embed & webhook billede/avatar url format
 # Alternativ integreret avatar-url til offlineservere:
 # https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafthead.net/avatar/{uuid-nodashes}/{size}#{texture}
+AvatarUrl: https://crafthead.net/helm/{uuid-nodashes}/{size}#{texture}
 
 # Reserializer
 # Konverterer formatering (fed, kursiv, understregning, gennemstregning) mellem Minecraft og Discord

--- a/src/main/resources/config/de.yml
+++ b/src/main/resources/config/de.yml
@@ -87,7 +87,7 @@ Experiment_WebhookChatMessageUsernameFilters: {}
 # Einbetten und Webhook-Bild-/Avatar-URL-Format
 # Alternative Einbettungs-Avatar-URL für Offline-Server:
 # https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafatar.com/avatars/{uuid-nodashes}?overlay&size={size}
+AvatarUrl: https://crafthead.net/avatar/{uuid-nodashes}/{size}#{texture}
 
 # Reserializer
 # Konvertiert die Formatierung (fett, kursiv, unterstreicht) zwischen Minecraft und Discord

--- a/src/main/resources/config/de.yml
+++ b/src/main/resources/config/de.yml
@@ -87,7 +87,7 @@ Experiment_WebhookChatMessageUsernameFilters: {}
 # Einbetten und Webhook-Bild-/Avatar-URL-Format
 # Alternative Einbettungs-Avatar-URL für Offline-Server:
 # https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafthead.net/avatar/{uuid-nodashes}/{size}#{texture}
+AvatarUrl: https://crafthead.net/helm/{uuid-nodashes}/{size}#{texture}
 
 # Reserializer
 # Konvertiert die Formatierung (fett, kursiv, unterstreicht) zwischen Minecraft und Discord

--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -87,7 +87,7 @@ Experiment_WebhookChatMessageUsernameFilters: {}
 # Embed & webhook image/avatar url format
 # Alternative embed avatar url for offline servers:
 # https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafthead.net/avatar/{uuid-nodashes}/{size}#{texture}
+AvatarUrl: https://crafthead.net/helm/{uuid-nodashes}/{size}#{texture}
 
 # Reserializer
 # Converts formatting (bold, italics, underline, strikethrough) between Minecraft and Discord

--- a/src/main/resources/config/es.yml
+++ b/src/main/resources/config/es.yml
@@ -87,7 +87,7 @@ Experiment_WebhookChatMessageUsernameFilters: {}
 # Formato de URL de avatar/imagen para insertar y webhook
 # URL de avatar incrustada alternativa para servidores fuera de línea:
 # https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafthead.net/avatar/{uuid-nodashes}/{size}#{texture}
+AvatarUrl: https://crafthead.net/helm/{uuid-nodashes}/{size}#{texture}
 
 # Reserializer
 # Convierte el formato (negrita, cursiva, subrayado) entre Minecraft y Discord

--- a/src/main/resources/config/et.yml
+++ b/src/main/resources/config/et.yml
@@ -87,7 +87,7 @@ Experiment_WebhookChatMessageUsernameFilters: {}
 # Embed & webhook image/avatar url format
 # Alternative embed avatar url for offline servers:
 # https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafthead.net/avatar/{uuid-nodashes}/{size}#{texture}
+AvatarUrl: https://crafthead.net/helm/{uuid-nodashes}/{size}#{texture}
 
 # Reserializer
 # Converts formatting (bold, italics, underline, strikethrough) between Minecraft and Discord

--- a/src/main/resources/config/fr.yml
+++ b/src/main/resources/config/fr.yml
@@ -87,7 +87,7 @@ Experiment_WebhookChatMessageUsernameFilters: {}
 # Format d'URL d'image/avatar d'intégration et de webhook
 # URL d'avatar d'intégration alternative pour les serveurs hors ligne:
 # https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafthead.net/avatar/{uuid-nodashes}/{size}#{texture}
+AvatarUrl: https://crafthead.net/helm/{uuid-nodashes}/{size}#{texture}
 
 # Reserializer
 # Convertit le formatage (gras, italique, souligné) entre Minecraft et Discord

--- a/src/main/resources/config/ja.yml
+++ b/src/main/resources/config/ja.yml
@@ -88,7 +88,7 @@ Experiment_WebhookChatMessageUsernameFilters: {}
 # 埋め込みと Webhook の画像/アバター URLの形式
 # オフラインサーバー用の代替埋め込みアバターURL:
 # https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafthead.net/avatar/{uuid-nodashes}/{size}#{texture}
+AvatarUrl: https://crafthead.net/helm/{uuid-nodashes}/{size}#{texture}
 
 # 書式の再変換
 # MinecraftとDiscord間の書式設定（太字、斜体、下線、取り消し線）を変換する

--- a/src/main/resources/config/ko.yml
+++ b/src/main/resources/config/ko.yml
@@ -88,7 +88,7 @@ Experiment_WebhookChatMessageUsernameFilters: {}
 # 임베드 및 웹훅 이미지/아바타 URL 형식
 # 오프라인 서버용 대체 아바타 URL 포함:
 # https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafthead.net/avatar/{uuid-nodashes}/{size}#{texture}
+AvatarUrl: https://crafthead.net/helm/{uuid-nodashes}/{size}#{texture}
 
 # Reserializer
 # 예를 들어 서식을 변환합니다. 굵은 기울임 꼴, 마인 크래프트와 Discord 사이에 밑줄

--- a/src/main/resources/config/nl.yml
+++ b/src/main/resources/config/nl.yml
@@ -87,7 +87,7 @@ Experiment_WebhookChatMessageUsernameFilters: {}
 # Insluiten & webhook afbeelding/avatar url-formaat
 # Alternatieve ingesloten avatar-url voor offline servers:
 # https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafthead.net/avatar/{uuid-nodashes}/{size}#{texture}
+AvatarUrl: https://crafthead.net/helm/{uuid-nodashes}/{size}#{texture}
 
 # Reserializer
 # Converteert opmaak (vetgedrukt, cursief, onderstreept) tussen Minecraft en Discord

--- a/src/main/resources/config/pl.yml
+++ b/src/main/resources/config/pl.yml
@@ -87,7 +87,7 @@ Experiment_WebhookChatMessageUsernameFilters: {}
 # Osadzanie i formatowanie adresu URL obrazu/awataru w webhooku
 # Alternatywny adres URL wbudowanego awatara dla serwerów offline:
 # https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafthead.net/avatar/{uuid-nodashes}/{size}#{texture}
+AvatarUrl: https://crafthead.net/helm/{uuid-nodashes}/{size}#{texture}
 
 # Reserializer
 # Konwertuje formatowanie (pogrubienie, kursywa, podkreślenie, przekreślenie) między Minecraft i Discord

--- a/src/main/resources/config/ru.yml
+++ b/src/main/resources/config/ru.yml
@@ -87,7 +87,7 @@ Experiment_WebhookChatMessageUsernameFilters: {}
 # Встраивание и формат URL-адреса изображения / аватара веб-перехватчика
 # Альтернативный URL-адрес для встраивания аватара для офлайн-серверов:
 # https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafthead.net/avatar/{uuid-nodashes}/{size}#{texture}
+AvatarUrl: https://crafthead.net/helm/{uuid-nodashes}/{size}#{texture}
 
 # Reserializer
 # Преобразует форматирование (жирный, курсив, подчеркивание) между Minecraft и Discord

--- a/src/main/resources/config/uk.yml
+++ b/src/main/resources/config/uk.yml
@@ -87,7 +87,7 @@ Experiment_WebhookChatMessageUsernameFilters: {}
 # Вбудовування та формат URL-адреси зображення / аватара веб-перехоплювача
 # Альтернативна URL-адреса для вбудовування аватара для офлайн-серверів:
 # https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafthead.net/avatar/{uuid-nodashes}/{size}#{texture}
+AvatarUrl: https://crafthead.net/helm/{uuid-nodashes}/{size}#{texture}
 
 # Reserializer
 # Перетворює форматування (жирний, курсив, підкреслення) між Minecraft та Discord

--- a/src/main/resources/config/zh.yml
+++ b/src/main/resources/config/zh.yml
@@ -87,7 +87,7 @@ Experiment_WebhookChatMessageUsernameFilters: {}
 # 嵌入和 webhook 图像/头像 url 格式
 # 离线服务器的替代嵌入头像网址:
 # https://cravatar.eu/helmavatar/{username}/{size}.png#{texture}
-AvatarUrl: https://crafthead.net/avatar/{uuid-nodashes}/{size}#{texture}
+AvatarUrl: https://crafthead.net/helm/{uuid-nodashes}/{size}#{texture}
 
 # Reserializer
 # 转换格式，例如 Minecraft和Discord之间的粗体，斜体，下划线


### PR DESCRIPTION
Make the default AvatarUrl include the head overlay like it did when it was using crafatar.