### PR TITLE
Update Chatty api to 3.0.0-SNAPSHOT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -262,7 +262,7 @@ dependencies {
     ///
     
     // chat hooks
-    compileOnly("ru.mrbrikster:chatty-api:2.18.2")
+    compileOnly("ru.brikster:chatty-api:3.0.0-SNAPSHOT") // published to maven local
     compileOnly("br.com.finalcraft:fancychat:1.0.2")
     compileOnly("com.dthielke.herochat:Herochat:5.6.5")
     compileOnly("br.com.devpaulo:legendchat:1.1.5")

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/ChattyChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/ChattyChatHook.java
@@ -74,13 +74,7 @@ public class ChattyChatHook implements ChatHook {
     }
 
     private ChattyApi getApi() {
-        Plugin chatty = getPlugin();
-        try {
-            return (ChattyApi) chatty.getClass().getMethod("api").invoke(chatty);
-        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-            DiscordSRV.error("Unable to get Chatty plugin", e);
-            return null;
-        }
+        return ChattyApi.instance();
     }
 
     @Override


### PR DESCRIPTION
Fix DiscordSRV does not work with Chatty version 3.0.0-SNAPSHOT. This will break hook Chatty 2.19.14 or below.