### PR TITLE
Chore: Fix Javadoc warnings

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -767,7 +767,7 @@ public class DiscordSRV extends JavaPlugin {
             }
         }
 
-        OkHttpClient httpClient = httpClientBuilder.build(); 
+        OkHttpClient httpClient = httpClientBuilder.build();
 
         // set custom RestAction failure handler
         Consumer<? super Throwable> defaultFailure = RestAction.getDefaultFailure();
@@ -2235,6 +2235,7 @@ public class DiscordSRV extends JavaPlugin {
         return getDestinationTextChannelForGameChannelName(getOptionalChannel(gameChannel));
     }
 
+    @SuppressWarnings("LombokGetterMayBeUsed")
     public AccountLinkManager getAccountLinkManager() {
         return this.accountLinkManager;
     }

--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -157,7 +157,7 @@ public class DiscordSRV extends JavaPlugin {
     public static String version = "";
 
     // Managers
-    @Getter private AccountLinkManager accountLinkManager;
+    private AccountLinkManager accountLinkManager;
     @Getter private CommandManager commandManager = new CommandManager();
     @Getter private GroupSynchronizationManager groupSynchronizationManager = new GroupSynchronizationManager();
     @Getter private IncompatibleClientManager incompatibleClientManager = new IncompatibleClientManager();
@@ -2235,4 +2235,7 @@ public class DiscordSRV extends JavaPlugin {
         return getDestinationTextChannelForGameChannelName(getOptionalChannel(gameChannel));
     }
 
+    public AccountLinkManager getAccountLinkManager() {
+        return this.accountLinkManager;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/ListenerPriority.java
+++ b/src/main/java/github/scarsz/discordsrv/api/ListenerPriority.java
@@ -26,6 +26,7 @@ package github.scarsz.discordsrv.api;
  * depending on Bukkit classes when they might not be available</p>
  * <p>Defaults to {@link #NORMAL} in {@link Subscribe} annotations where it's not specifically set</p>
  */
+@SuppressWarnings("LombokGetterMayBeUsed")
 public enum ListenerPriority {
 
     /**

--- a/src/main/java/github/scarsz/discordsrv/api/ListenerPriority.java
+++ b/src/main/java/github/scarsz/discordsrv/api/ListenerPriority.java
@@ -20,8 +20,6 @@
 
 package github.scarsz.discordsrv.api;
 
-import lombok.Getter;
-
 /**
  * <p>Completely inspired by the Bukkit API's EventPriority system</p>
  * <p>Event priorities mean the same as Bukkit's; it's in a separate enum to prevent
@@ -60,9 +58,12 @@ public enum ListenerPriority {
      */
     MONITOR(5);
 
-    @Getter private final int slot;
+    private final int slot;
     ListenerPriority(int slot) {
         this.slot = slot;
     }
 
+    public int getSlot() {
+        return this.slot;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/commands/CommandRegistrationError.java
+++ b/src/main/java/github/scarsz/discordsrv/api/commands/CommandRegistrationError.java
@@ -23,6 +23,7 @@ package github.scarsz.discordsrv.api.commands;
 import java.util.Objects;
 import net.dv8tion.jda.api.entities.Guild;
 
+@SuppressWarnings("LombokGetterMayBeUsed")
 public final class CommandRegistrationError {
 
     private final Guild guild;

--- a/src/main/java/github/scarsz/discordsrv/api/commands/CommandRegistrationError.java
+++ b/src/main/java/github/scarsz/discordsrv/api/commands/CommandRegistrationError.java
@@ -20,13 +20,43 @@
 
 package github.scarsz.discordsrv.api.commands;
 
-import lombok.Value;
+import java.util.Objects;
 import net.dv8tion.jda.api.entities.Guild;
 
-@Value
-public class CommandRegistrationError {
+public final class CommandRegistrationError {
 
-    Guild guild;
-    Throwable exception;
+    private final Guild guild;
+    private final Throwable exception;
 
+    public CommandRegistrationError(Guild guild, Throwable exception) {
+        this.guild = guild;
+        this.exception = exception;
+    }
+
+    public Guild getGuild() {
+        return this.guild;
+    }
+
+    public Throwable getException() {
+        return this.exception;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof CommandRegistrationError)) return false;
+        if (!Objects.equals(this.getGuild(), ((CommandRegistrationError) o).getGuild())) return false;
+        return Objects.equals(this.getException(), ((CommandRegistrationError) o).getException());
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        result = result * PRIME + (this.getGuild() == null ? 43 : this.getGuild().hashCode());
+        result = result * PRIME + (this.getException() == null ? 43 : this.getException().hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "CommandRegistrationError(guild=" + this.getGuild() + ", exception=" + this.getException() + ")";
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/commands/PluginSlashCommand.java
+++ b/src/main/java/github/scarsz/discordsrv/api/commands/PluginSlashCommand.java
@@ -31,6 +31,7 @@ import java.util.Set;
 /**
  * {@link CommandData} wrapper that includes the originating {@link Plugin}
  */
+@SuppressWarnings("LombokGetterMayBeUsed")
 public final class PluginSlashCommand {
 
     private final Plugin plugin;

--- a/src/main/java/github/scarsz/discordsrv/api/commands/PluginSlashCommand.java
+++ b/src/main/java/github/scarsz/discordsrv/api/commands/PluginSlashCommand.java
@@ -20,8 +20,6 @@
 
 package github.scarsz.discordsrv.api.commands;
 
-import lombok.Value;
-import lombok.experimental.NonFinal;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 import org.bukkit.plugin.Plugin;
@@ -33,46 +31,52 @@ import java.util.Set;
 /**
  * {@link CommandData} wrapper that includes the originating {@link Plugin}
  */
-@Value
-public class PluginSlashCommand {
+public final class PluginSlashCommand {
 
-    Plugin plugin;
-    CommandData commandData;
-    Set<String> guilds = new HashSet<>();
-    @NonFinal SlashCommandPriority priority;
+    private final Plugin plugin;
+    private final CommandData commandData;
+    private final Set<String> guilds = new HashSet<>();
+    private SlashCommandPriority priority;
 
     /**
      * Construct data for a new plugin-originating slash command
-     * @param plugin the owning plugin
+     *
+     * @param plugin      the owning plugin
      * @param commandData the built command data
      */
     public PluginSlashCommand(Plugin plugin, CommandData commandData) {
         this(plugin, commandData, SlashCommandPriority.NORMAL);
     }
+
     /**
      * Construct data for a new plugin-originating slash command
-     * @param plugin the owning plugin
+     *
+     * @param plugin      the owning plugin
      * @param commandData the built command data
-     * @param priority the priority of this slash command
+     * @param priority    the priority of this slash command
      */
     public PluginSlashCommand(Plugin plugin, CommandData commandData, SlashCommandPriority priority) {
         this(plugin, commandData, priority, (String[]) null);
     }
+
     /**
      * Construct data for a new plugin-originating slash command
-     * @param plugin the owning plugin
+     *
+     * @param plugin      the owning plugin
      * @param commandData the built command data
-     * @param guildIds the applicable guild IDs for this command. if not provided, command will be applicable to all guilds
+     * @param guildIds    the applicable guild IDs for this command. if not provided, command will be applicable to all guilds
      */
     public PluginSlashCommand(Plugin plugin, CommandData commandData, String... guildIds) {
         this(plugin, commandData, SlashCommandPriority.NORMAL, guildIds);
     }
+
     /**
      * Construct data for a new plugin-originating slash command
-     * @param plugin the owning plugin
+     *
+     * @param plugin      the owning plugin
      * @param commandData the built command data
-     * @param priority the priority of this slash command
-     * @param guildIds the applicable guild IDs for this command. if not provided, command will be applicable to all guilds
+     * @param priority    the priority of this slash command
+     * @param guildIds    the applicable guild IDs for this command. if not provided, command will be applicable to all guilds
      */
     public PluginSlashCommand(Plugin plugin, CommandData commandData, SlashCommandPriority priority, String... guildIds) {
         this.plugin = plugin;
@@ -80,8 +84,10 @@ public class PluginSlashCommand {
         this.priority = priority;
         if (guildIds != null) Collections.addAll(guilds, guildIds);
     }
+
     /**
      * Whether this plugin command is applicable to the given guild
+     *
      * @param guild the guild to check for
      * @return whether the guild is applicable for this command
      */
@@ -89,18 +95,22 @@ public class PluginSlashCommand {
         if (guild == null) return false;
         return this.guilds.isEmpty() || this.guilds.contains(guild.getId());
     }
+
     /**
-     * Add the given {@link Guild} to the list of guilds this command will be registered to, 
+     * Add the given {@link Guild} to the list of guilds this command will be registered to,
      * when none are provided the command will be registered to all guilds.
+     *
      * @param guild the guild to apply this command to
      * @return the {@link PluginSlashCommand} instance for chaining
      */
     public PluginSlashCommand addGuildFilter(Guild guild) {
         return addGuildFilter(guild.getId());
     }
+
     /**
-     * Add the given {@link Guild} id to the list of guilds this command will be registered to, 
+     * Add the given {@link Guild} id to the list of guilds this command will be registered to,
      * when none are provided the command will be registered to all guilds.
+     *
      * @param guildId the guild ID to apply this command to
      * @return the {@link PluginSlashCommand} instance for chaining
      */
@@ -108,18 +118,22 @@ public class PluginSlashCommand {
         this.guilds.add(guildId);
         return this;
     }
+
     /**
      * Remove the given {@link Guild} from the list of guilds this command will be registered to,
      * when none are provided the command will be registered to all guilds.
+     *
      * @param guild the guild to be removed
      * @return the {@link PluginSlashCommand} instance for chaining
      */
     public PluginSlashCommand removeGuildFilter(Guild guild) {
         return removeGuildFilter(guild.getId());
     }
+
     /**
      * Remove the given {@link Guild} id from the list of guilds this command will be registered to,
      * when none are provided the command will be registered to all guilds.
+     *
      * @param guildId the guild ID of the guild to be removed
      * @return the {@link PluginSlashCommand} instance for chaining
      */
@@ -127,8 +141,10 @@ public class PluginSlashCommand {
         this.guilds.remove(guildId);
         return this;
     }
+
     /**
      * Set the priority of this slash command when handling registration conflicts
+     *
      * @param priority the priority of this slash command
      * @return the {@link PluginSlashCommand} instance for chaining
      */
@@ -137,4 +153,57 @@ public class PluginSlashCommand {
         return this;
     }
 
+    public Plugin getPlugin() {
+        return this.plugin;
+    }
+
+    public CommandData getCommandData() {
+        return this.commandData;
+    }
+
+    public Set<String> getGuilds() {
+        return this.guilds;
+    }
+
+    public SlashCommandPriority getPriority() {
+        return this.priority;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof PluginSlashCommand)) return false;
+        final PluginSlashCommand other = (PluginSlashCommand) o;
+        final Object this$plugin = this.getPlugin();
+        final Object other$plugin = other.getPlugin();
+        if (this$plugin == null ? other$plugin != null : !this$plugin.equals(other$plugin)) return false;
+        final Object this$commandData = this.getCommandData();
+        final Object other$commandData = other.getCommandData();
+        if (this$commandData == null ? other$commandData != null : !this$commandData.equals(other$commandData))
+            return false;
+        final Object this$guilds = this.getGuilds();
+        final Object other$guilds = other.getGuilds();
+        if (this$guilds == null ? other$guilds != null : !this$guilds.equals(other$guilds)) return false;
+        final Object this$priority = this.getPriority();
+        final Object other$priority = other.getPriority();
+        if (this$priority == null ? other$priority != null : !this$priority.equals(other$priority)) return false;
+        return true;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $plugin = this.getPlugin();
+        result = result * PRIME + ($plugin == null ? 43 : $plugin.hashCode());
+        final Object $commandData = this.getCommandData();
+        result = result * PRIME + ($commandData == null ? 43 : $commandData.hashCode());
+        final Object $guilds = this.getGuilds();
+        result = result * PRIME + ($guilds == null ? 43 : $guilds.hashCode());
+        final Object $priority = this.getPriority();
+        result = result * PRIME + ($priority == null ? 43 : $priority.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "PluginSlashCommand(plugin=" + this.getPlugin() + ", commandData=" + this.getCommandData() + ", guilds=" + this.getGuilds() + ", priority=" + this.getPriority() + ")";
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/commands/SlashCommand.java
+++ b/src/main/java/github/scarsz/discordsrv/api/commands/SlashCommand.java
@@ -63,7 +63,7 @@ public @interface SlashCommand {
     SlashCommandPriority priority() default SlashCommandPriority.NORMAL;
 
     /**
-     * Tells DiscordSRV to automatically acknowledge the command & defer replying for you.
+     * Tells DiscordSRV to automatically acknowledge the command &amp; defer replying for you.
      * Reply deferring is required when your command might take longer than 3 seconds to execute.
      * If the reply is deferred, you have up to 15 minutes for your command to respond.
      * Until then, a "bot is thinking" message will be shown to the user that executed the command.

--- a/src/main/java/github/scarsz/discordsrv/api/events/AccountLinkedEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AccountLinkedEvent.java
@@ -21,24 +21,29 @@
 package github.scarsz.discordsrv.api.events;
 
 import github.scarsz.discordsrv.objects.managers.AccountLinkManager;
-import lombok.Getter;
+import java.util.UUID;
 import net.dv8tion.jda.api.entities.User;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
-
-import java.util.UUID;
 
 /**
  * <p>Called directly after an account pair is linked via DiscordSRV's {@link AccountLinkManager}</p>
  */
 public class AccountLinkedEvent extends Event {
 
-    @Getter private final OfflinePlayer player;
-    @Getter private final User user;
+    private final OfflinePlayer player;
+    private final User user;
 
     public AccountLinkedEvent(User user, UUID playerUuid) {
         this.player = Bukkit.getOfflinePlayer(playerUuid);
         this.user = user;
     }
 
+    public OfflinePlayer getPlayer() {
+        return this.player;
+    }
+
+    public User getUser() {
+        return this.user;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/AccountLinkedEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AccountLinkedEvent.java
@@ -29,6 +29,7 @@ import org.bukkit.OfflinePlayer;
 /**
  * <p>Called directly after an account pair is linked via DiscordSRV's {@link AccountLinkManager}</p>
  */
+@SuppressWarnings("LombokGetterMayBeUsed")
 public class AccountLinkedEvent extends Event {
 
     private final OfflinePlayer player;

--- a/src/main/java/github/scarsz/discordsrv/api/events/AccountUnlinkedEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AccountUnlinkedEvent.java
@@ -30,6 +30,7 @@ import org.bukkit.OfflinePlayer;
 /**
  * <p>Called directly after an account pair is unlinked via DiscordSRV's {@link AccountLinkManager}</p>
  */
+@SuppressWarnings("LombokGetterMayBeUsed")
 public class AccountUnlinkedEvent extends Event {
 
     private final OfflinePlayer player;

--- a/src/main/java/github/scarsz/discordsrv/api/events/AccountUnlinkedEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AccountUnlinkedEvent.java
@@ -22,21 +22,19 @@ package github.scarsz.discordsrv.api.events;
 
 import github.scarsz.discordsrv.objects.managers.AccountLinkManager;
 import github.scarsz.discordsrv.util.DiscordUtil;
-import lombok.Getter;
+import java.util.UUID;
 import net.dv8tion.jda.api.entities.User;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
-
-import java.util.UUID;
 
 /**
  * <p>Called directly after an account pair is unlinked via DiscordSRV's {@link AccountLinkManager}</p>
  */
 public class AccountUnlinkedEvent extends Event {
 
-    @Getter private final OfflinePlayer player;
-    @Getter private final String discordId;
-    @Getter private final User discordUser;
+    private final OfflinePlayer player;
+    private final String discordId;
+    private final User discordUser;
 
     public AccountUnlinkedEvent(String discordId, UUID playerUuid) {
         this.player = Bukkit.getOfflinePlayer(playerUuid);
@@ -44,4 +42,15 @@ public class AccountUnlinkedEvent extends Event {
         this.discordUser = DiscordUtil.getUserById(discordId);
     }
 
+    public OfflinePlayer getPlayer() {
+        return this.player;
+    }
+
+    public String getDiscordId() {
+        return this.discordId;
+    }
+
+    public User getDiscordUser() {
+        return this.discordUser;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePostProcessEvent.java
@@ -30,6 +30,7 @@ import org.bukkit.event.Event;
  * <p>Called after DiscordSRV has processed a achievement/advancement message but before being sent to Discord.
  * Modification is allow and will effect the message sent to Discord.</p>
  */
+@SuppressWarnings({"LombokGetterMayBeUsed", "LombokSetterMayBeUsed"})
 public class AchievementMessagePostProcessEvent extends GameEvent<Event> implements Cancellable {
 
     private boolean cancelled;

--- a/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePostProcessEvent.java
@@ -20,8 +20,6 @@
 
 package github.scarsz.discordsrv.api.events;
 
-import lombok.Getter;
-import lombok.Setter;
 import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import org.bukkit.entity.Player;
@@ -34,15 +32,15 @@ import org.bukkit.event.Event;
  */
 public class AchievementMessagePostProcessEvent extends GameEvent<Event> implements Cancellable {
 
-    @Getter @Setter private boolean cancelled;
+    private boolean cancelled;
 
-    @Getter private final String achievementName;
-    @Getter @Setter private String channel;
+    private final String achievementName;
+    private String channel;
 
-    @Getter @Setter private Message discordMessage;
-    @Getter @Setter private boolean usingWebhooks;
-    @Getter @Setter private String webhookName;
-    @Getter @Setter private String webhookAvatarUrl;
+    private Message discordMessage;
+    private boolean usingWebhooks;
+    private String webhookName;
+    private String webhookAvatarUrl;
 
     public AchievementMessagePostProcessEvent(String channel, Message discordMessage, Player player, String achievementName, Event triggeringBukkitEvent, boolean usingWebhooks, String webhookName, String webhookAvatarUrl, boolean cancelled) {
         super(player, triggeringBukkitEvent);
@@ -66,7 +64,7 @@ public class AchievementMessagePostProcessEvent extends GameEvent<Event> impleme
         this.webhookAvatarUrl = webhookAvatarUrl;
         setCancelled(cancelled);
     }
-    
+
     @Deprecated
     public AchievementMessagePostProcessEvent(String channel, String processedMessage, Player player, String achievementName, boolean cancelled) {
         super(player, null);
@@ -86,4 +84,55 @@ public class AchievementMessagePostProcessEvent extends GameEvent<Event> impleme
         this.discordMessage = new MessageBuilder(processedMessage).build();
     }
 
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public String getAchievementName() {
+        return this.achievementName;
+    }
+
+    public String getChannel() {
+        return this.channel;
+    }
+
+    public Message getDiscordMessage() {
+        return this.discordMessage;
+    }
+
+    public boolean isUsingWebhooks() {
+        return this.usingWebhooks;
+    }
+
+    public String getWebhookName() {
+        return this.webhookName;
+    }
+
+    public String getWebhookAvatarUrl() {
+        return this.webhookAvatarUrl;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public void setDiscordMessage(Message discordMessage) {
+        this.discordMessage = discordMessage;
+    }
+
+    public void setUsingWebhooks(boolean usingWebhooks) {
+        this.usingWebhooks = usingWebhooks;
+    }
+
+    public void setWebhookName(String webhookName) {
+        this.webhookName = webhookName;
+    }
+
+    public void setWebhookAvatarUrl(String webhookAvatarUrl) {
+        this.webhookAvatarUrl = webhookAvatarUrl;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePreProcessEvent.java
@@ -21,8 +21,6 @@
 package github.scarsz.discordsrv.api.events;
 
 import github.scarsz.discordsrv.objects.MessageFormat;
-import lombok.Getter;
-import lombok.Setter;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -32,11 +30,11 @@ import org.bukkit.event.Event;
  */
 public class AchievementMessagePreProcessEvent extends GameEvent<Event> implements Cancellable {
 
-    @Getter @Setter private boolean cancelled;
+    private boolean cancelled;
 
-    @Getter @Setter private String achievementName;
-    @Getter @Setter private String channel;
-    @Getter @Setter private MessageFormat messageFormat;
+    private String achievementName;
+    private String channel;
+    private MessageFormat messageFormat;
 
     public AchievementMessagePreProcessEvent(String channel, MessageFormat messageFormat, Player player, String achievementName, Event triggeringBukkitEvent) {
         super(player, triggeringBukkitEvent);
@@ -75,4 +73,35 @@ public class AchievementMessagePreProcessEvent extends GameEvent<Event> implemen
         this.messageFormat = messageFormat;
     }
 
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public String getAchievementName() {
+        return this.achievementName;
+    }
+
+    public String getChannel() {
+        return this.channel;
+    }
+
+    public MessageFormat getMessageFormat() {
+        return this.messageFormat;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    public void setAchievementName(String achievementName) {
+        this.achievementName = achievementName;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public void setMessageFormat(MessageFormat messageFormat) {
+        this.messageFormat = messageFormat;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/AchievementMessagePreProcessEvent.java
@@ -28,6 +28,7 @@ import org.bukkit.event.Event;
 /**
  * <p>Called before DiscordSRV has processed a achievement/advancement message, modifications may be overwritten by DiscordSRV's processing.</p>
  */
+@SuppressWarnings({"LombokGetterMayBeUsed", "LombokSetterMayBeUsed"})
 public class AchievementMessagePreProcessEvent extends GameEvent<Event> implements Cancellable {
 
     private boolean cancelled;

--- a/src/main/java/github/scarsz/discordsrv/api/events/ConfigReloadedEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/ConfigReloadedEvent.java
@@ -25,6 +25,7 @@ import org.bukkit.command.CommandSender;
 /**
  * <p>Called directly after the configuration was reloaded and the requester was informed.</p>
  */
+@SuppressWarnings("LombokGetterMayBeUsed")
 public class ConfigReloadedEvent extends Event {
 
     private final CommandSender requester;

--- a/src/main/java/github/scarsz/discordsrv/api/events/ConfigReloadedEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/ConfigReloadedEvent.java
@@ -20,7 +20,6 @@
 
 package github.scarsz.discordsrv.api.events;
 
-import lombok.Getter;
 import org.bukkit.command.CommandSender;
 
 /**
@@ -28,10 +27,13 @@ import org.bukkit.command.CommandSender;
  */
 public class ConfigReloadedEvent extends Event {
 
-    @Getter private final CommandSender requester;
+    private final CommandSender requester;
 
     public ConfigReloadedEvent(CommandSender requester) {
         this.requester = requester;
     }
 
+    public CommandSender getRequester() {
+        return this.requester;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePostProcessEvent.java
@@ -20,8 +20,6 @@
 
 package github.scarsz.discordsrv.api.events;
 
-import lombok.Getter;
-import lombok.Setter;
 import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import org.bukkit.entity.Player;
@@ -34,15 +32,15 @@ import org.bukkit.event.entity.PlayerDeathEvent;
  */
 public class DeathMessagePostProcessEvent extends GameEvent<PlayerDeathEvent> implements Cancellable {
 
-    @Getter @Setter private boolean cancelled;
+    private boolean cancelled;
 
-    @Getter private final String deathMessage;
-    @Getter @Setter private String channel;
+    private final String deathMessage;
+    private String channel;
 
-    @Getter @Setter private Message discordMessage;
-    @Getter @Setter private boolean usingWebhooks;
-    @Getter @Setter private String webhookName;
-    @Getter @Setter private String webhookAvatarUrl;
+    private Message discordMessage;
+    private boolean usingWebhooks;
+    private String webhookName;
+    private String webhookAvatarUrl;
 
     public DeathMessagePostProcessEvent(String channel, Message discordMessage, Player player, String deathMessage, PlayerDeathEvent triggeringBukkitEvent, boolean usingWebhooks, String webhookName, String webhookAvatarUrl, boolean cancelled) {
         super(player, triggeringBukkitEvent);
@@ -86,4 +84,55 @@ public class DeathMessagePostProcessEvent extends GameEvent<PlayerDeathEvent> im
         this.discordMessage = new MessageBuilder(processedMessage).build();
     }
 
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public String getDeathMessage() {
+        return this.deathMessage;
+    }
+
+    public String getChannel() {
+        return this.channel;
+    }
+
+    public Message getDiscordMessage() {
+        return this.discordMessage;
+    }
+
+    public boolean isUsingWebhooks() {
+        return this.usingWebhooks;
+    }
+
+    public String getWebhookName() {
+        return this.webhookName;
+    }
+
+    public String getWebhookAvatarUrl() {
+        return this.webhookAvatarUrl;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public void setDiscordMessage(Message discordMessage) {
+        this.discordMessage = discordMessage;
+    }
+
+    public void setUsingWebhooks(boolean usingWebhooks) {
+        this.usingWebhooks = usingWebhooks;
+    }
+
+    public void setWebhookName(String webhookName) {
+        this.webhookName = webhookName;
+    }
+
+    public void setWebhookAvatarUrl(String webhookAvatarUrl) {
+        this.webhookAvatarUrl = webhookAvatarUrl;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePostProcessEvent.java
@@ -30,6 +30,7 @@ import org.bukkit.event.entity.PlayerDeathEvent;
  * <p>Called after DiscordSRV has processed a death message but before being sent to Discord.
  * Modification is allow and will effect the message sent to Discord.</p>
  */
+@SuppressWarnings({"LombokGetterMayBeUsed", "LombokSetterMayBeUsed"})
 public class DeathMessagePostProcessEvent extends GameEvent<PlayerDeathEvent> implements Cancellable {
 
     private boolean cancelled;

--- a/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePreProcessEvent.java
@@ -21,8 +21,6 @@
 package github.scarsz.discordsrv.api.events;
 
 import github.scarsz.discordsrv.objects.MessageFormat;
-import lombok.Getter;
-import lombok.Setter;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.entity.PlayerDeathEvent;
@@ -32,11 +30,11 @@ import org.bukkit.event.entity.PlayerDeathEvent;
  */
 public class DeathMessagePreProcessEvent extends GameEvent<PlayerDeathEvent> implements Cancellable {
 
-    @Getter @Setter private boolean cancelled;
+    private boolean cancelled;
 
-    @Getter @Setter private String deathMessage;
-    @Getter @Setter private String channel;
-    @Getter @Setter private MessageFormat messageFormat;
+    private String deathMessage;
+    private String channel;
+    private MessageFormat messageFormat;
 
     public DeathMessagePreProcessEvent(String channel, MessageFormat messageFormat, Player player, String deathMessage, PlayerDeathEvent triggeringBukkitEvent) {
         super(player, triggeringBukkitEvent);
@@ -75,4 +73,35 @@ public class DeathMessagePreProcessEvent extends GameEvent<PlayerDeathEvent> imp
         this.messageFormat = messageFormat;
     }
 
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public String getDeathMessage() {
+        return this.deathMessage;
+    }
+
+    public String getChannel() {
+        return this.channel;
+    }
+
+    public MessageFormat getMessageFormat() {
+        return this.messageFormat;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    public void setDeathMessage(String deathMessage) {
+        this.deathMessage = deathMessage;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public void setMessageFormat(MessageFormat messageFormat) {
+        this.messageFormat = messageFormat;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DeathMessagePreProcessEvent.java
@@ -28,6 +28,7 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 /**
  * <p>Called before DiscordSRV has processed a death message, modifications may be overwritten by DiscordSRV's processing.</p>
  */
+@SuppressWarnings({"LombokGetterMayBeUsed", "LombokSetterMayBeUsed"})
 public class DeathMessagePreProcessEvent extends GameEvent<PlayerDeathEvent> implements Cancellable {
 
     private boolean cancelled;

--- a/src/main/java/github/scarsz/discordsrv/api/events/DebugReportedEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DebugReportedEvent.java
@@ -20,19 +20,24 @@
 
 package github.scarsz.discordsrv.api.events;
 
-import lombok.Getter;
-
 /**
  * <p>Called directly after a debug report was submitted to GitHub Gists and the requester was informed.</p>
  */
 public class DebugReportedEvent extends Event {
 
-    @Getter private final String requester;
-    @Getter private final String url;
+    private final String requester;
+    private final String url;
 
     public DebugReportedEvent(String requester, String url) {
         this.requester = requester;
         this.url = url;
     }
 
+    public String getRequester() {
+        return this.requester;
+    }
+
+    public String getUrl() {
+        return this.url;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/DebugReportedEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DebugReportedEvent.java
@@ -23,6 +23,7 @@ package github.scarsz.discordsrv.api.events;
 /**
  * <p>Called directly after a debug report was submitted to GitHub Gists and the requester was informed.</p>
  */
+@SuppressWarnings("LombokGetterMayBeUsed")
 public class DebugReportedEvent extends Event {
 
     private final String requester;

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordChatChannelListCommandMessageEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordChatChannelListCommandMessageEvent.java
@@ -20,8 +20,6 @@
 
 package github.scarsz.discordsrv.api.events;
 
-import lombok.Getter;
-import lombok.Setter;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
@@ -38,15 +36,15 @@ import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
  */
 public class DiscordChatChannelListCommandMessageEvent extends Event {
 
-    @Getter private Result result;
+    private Result result;
 
-    @Getter private final TextChannel channel;
-    @Getter private final Guild guild;
-    @Getter private final String message;
-    @Getter private final GuildMessageReceivedEvent triggeringJDAEvent;
+    private final TextChannel channel;
+    private final Guild guild;
+    private final String message;
+    private final GuildMessageReceivedEvent triggeringJDAEvent;
 
-    @Getter @Setter private String playerListMessage;
-    @Getter private int expiration;
+    private String playerListMessage;
+    private int expiration;
 
     public DiscordChatChannelListCommandMessageEvent(TextChannel channel, Guild guild, String message, GuildMessageReceivedEvent triggeringJDAEvent, String playerListMessage, int expiration, Result result) {
         this.channel = channel;
@@ -58,8 +56,40 @@ public class DiscordChatChannelListCommandMessageEvent extends Event {
         this.result = result;
     }
 
+    public Result getResult() {
+        return this.result;
+    }
+
+    public TextChannel getChannel() {
+        return this.channel;
+    }
+
+    public Guild getGuild() {
+        return this.guild;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    public GuildMessageReceivedEvent getTriggeringJDAEvent() {
+        return this.triggeringJDAEvent;
+    }
+
+    public String getPlayerListMessage() {
+        return this.playerListMessage;
+    }
+
+    public int getExpiration() {
+        return this.expiration;
+    }
+
     public void setResult(Result result) {
         this.result = result;
+    }
+
+    public void setPlayerListMessage(String playerListMessage) {
+        this.playerListMessage = playerListMessage;
     }
 
     public void setExpiration(int expiration) {

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordChatChannelListCommandMessageEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordChatChannelListCommandMessageEvent.java
@@ -38,7 +38,7 @@ import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
  */
 public class DiscordChatChannelListCommandMessageEvent extends Event {
 
-    @Getter @Setter private Result result;
+    @Getter private Result result;
 
     @Getter private final TextChannel channel;
     @Getter private final Guild guild;
@@ -46,7 +46,7 @@ public class DiscordChatChannelListCommandMessageEvent extends Event {
     @Getter private final GuildMessageReceivedEvent triggeringJDAEvent;
 
     @Getter @Setter private String playerListMessage;
-    @Getter @Setter private int expiration;
+    @Getter private int expiration;
 
     public DiscordChatChannelListCommandMessageEvent(TextChannel channel, Guild guild, String message, GuildMessageReceivedEvent triggeringJDAEvent, String playerListMessage, int expiration, Result result) {
         this.channel = channel;
@@ -56,6 +56,14 @@ public class DiscordChatChannelListCommandMessageEvent extends Event {
         this.playerListMessage = playerListMessage;
         this.expiration = expiration;
         this.result = result;
+    }
+
+    public void setResult(Result result) {
+        this.result = result;
+    }
+
+    public void setExpiration(int expiration) {
+        this.expiration = expiration;
     }
 
     public enum Result {

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordChatChannelListCommandMessageEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordChatChannelListCommandMessageEvent.java
@@ -34,6 +34,7 @@ import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
  * @see Result#NO_ACTION
  * @see Result#TREAT_AS_REGULAR_MESSAGE
  */
+@SuppressWarnings({"LombokGetterMayBeUsed", "LombokSetterMayBeUsed"})
 public class DiscordChatChannelListCommandMessageEvent extends Event {
 
     private Result result;

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordConsoleCommandPostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordConsoleCommandPostProcessEvent.java
@@ -20,7 +20,6 @@
 
 package github.scarsz.discordsrv.api.events;
 
-import lombok.Getter;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 
 /**
@@ -30,16 +29,8 @@ import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
  * <p>{@link #isSentInConsoleChannel()} returns true if the message was sent in your console command discord channel, and false otherwise</p>
  */
 public class DiscordConsoleCommandPostProcessEvent extends DiscordEvent<GuildMessageReceivedEvent>{
-
-    /**
-     * Whether it was sent in your guilds console channel
-     */
-    @Getter private boolean sentInConsoleChannel;
-
-    /**
-     * The command that was sent to the minecraft server from discord
-     */
-    @Getter private String command;
+    private boolean sentInConsoleChannel;
+    private String command;
 
     public DiscordConsoleCommandPostProcessEvent(GuildMessageReceivedEvent jdaEvent, String command, boolean sentInConsoleChannel) {
         super(jdaEvent.getJDA(), jdaEvent);
@@ -47,4 +38,17 @@ public class DiscordConsoleCommandPostProcessEvent extends DiscordEvent<GuildMes
         this.sentInConsoleChannel = sentInConsoleChannel;
     }
 
+    /**
+     * Whether it was sent in your guilds console channel
+     */
+    public boolean isSentInConsoleChannel() {
+        return this.sentInConsoleChannel;
+    }
+
+    /**
+     * The command that was sent to the minecraft server from discord
+     */
+    public String getCommand() {
+        return this.command;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordConsoleCommandPreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordConsoleCommandPreProcessEvent.java
@@ -21,8 +21,6 @@
 package github.scarsz.discordsrv.api.events;
 
 import github.scarsz.discordsrv.api.Cancellable;
-import lombok.Getter;
-import lombok.Setter;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 
 /**
@@ -31,11 +29,11 @@ import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
  * <p>At the time this event is called, the command can still be changed, and event cancelled</p>
  * <p>Cancelling the event will stop the command from being sent to the server</p>
  */
-public class DiscordConsoleCommandPreProcessEvent extends DiscordEvent<GuildMessageReceivedEvent> implements Cancellable{
+public class DiscordConsoleCommandPreProcessEvent extends DiscordEvent<GuildMessageReceivedEvent> implements Cancellable {
 
-    @Getter private boolean sentInConsoleChannel;
-    @Getter @Setter private boolean cancelled;
-    @Getter @Setter private String command;
+    private boolean sentInConsoleChannel;
+    private boolean cancelled;
+    private String command;
 
     public DiscordConsoleCommandPreProcessEvent(GuildMessageReceivedEvent jdaEvent, String command, boolean sentInConsoleChannel) {
         super(jdaEvent.getJDA(), jdaEvent);
@@ -44,4 +42,23 @@ public class DiscordConsoleCommandPreProcessEvent extends DiscordEvent<GuildMess
         this.command = command;
     }
 
+    public boolean isSentInConsoleChannel() {
+        return this.sentInConsoleChannel;
+    }
+
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public String getCommand() {
+        return this.command;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    public void setCommand(String command) {
+        this.command = command;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordConsoleCommandPreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordConsoleCommandPreProcessEvent.java
@@ -29,6 +29,7 @@ import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
  * <p>At the time this event is called, the command can still be changed, and event cancelled</p>
  * <p>Cancelling the event will stop the command from being sent to the server</p>
  */
+@SuppressWarnings({"LombokGetterMayBeUsed", "LombokSetterMayBeUsed"})
 public class DiscordConsoleCommandPreProcessEvent extends DiscordEvent<GuildMessageReceivedEvent> implements Cancellable {
 
     private boolean sentInConsoleChannel;

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordEvent.java
@@ -20,7 +20,6 @@
 
 package github.scarsz.discordsrv.api.events;
 
-import lombok.Getter;
 import net.dv8tion.jda.api.JDA;
 
 /**
@@ -29,16 +28,24 @@ import net.dv8tion.jda.api.JDA;
  */
 abstract class DiscordEvent<T> extends Event {
 
-    @Getter private final JDA jda;
-    @Getter private final T rawEvent;
+    private final JDA jda;
+    private final T rawEvent;
 
     DiscordEvent(JDA jda) {
         this.jda = jda;
         this.rawEvent = null;
     }
+
     DiscordEvent(JDA jda, T rawEvent) {
         this.jda = jda;
         this.rawEvent = rawEvent;
     }
 
+    public JDA getJda() {
+        return this.jda;
+    }
+
+    public T getRawEvent() {
+        return this.rawEvent;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordEvent.java
@@ -26,6 +26,7 @@ import net.dv8tion.jda.api.JDA;
  * <p>The superclass of all Discord-related events</p>
  * <p>Provides {@link #getJda()} and {@link #getRawEvent()}</p>
  */
+@SuppressWarnings("LombokGetterMayBeUsed")
 abstract class DiscordEvent<T> extends Event {
 
     private final JDA jda;

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePostBroadcastEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePostBroadcastEvent.java
@@ -29,6 +29,7 @@ import net.kyori.adventure.text.Component;
  * <p>At the time this event is called, {@link #getMessage()} would return what the final message
  * would look like in-game, including text like the author before the actual message</p>
  */
+@SuppressWarnings("LombokGetterMayBeUsed")
 public class DiscordGuildMessagePostBroadcastEvent extends Event {
 
     private final String channel;

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePostBroadcastEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePostBroadcastEvent.java
@@ -33,7 +33,7 @@ import net.kyori.adventure.text.Component;
 public class DiscordGuildMessagePostBroadcastEvent extends Event {
 
     @Getter private final String channel;
-    @Getter private final Component message;
+    private final Component message;
 
     @Deprecated
     public DiscordGuildMessagePostBroadcastEvent(String channel, String processedMessage) {
@@ -51,4 +51,7 @@ public class DiscordGuildMessagePostBroadcastEvent extends Event {
         return MessageUtil.toLegacy(message);
     }
 
+    public Component getMessage() {
+        return this.message;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePostBroadcastEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePostBroadcastEvent.java
@@ -21,7 +21,6 @@
 package github.scarsz.discordsrv.api.events;
 
 import github.scarsz.discordsrv.util.MessageUtil;
-import lombok.Getter;
 import net.kyori.adventure.text.Component;
 
 /**
@@ -32,7 +31,7 @@ import net.kyori.adventure.text.Component;
  */
 public class DiscordGuildMessagePostBroadcastEvent extends Event {
 
-    @Getter private final String channel;
+    private final String channel;
     private final Component message;
 
     @Deprecated
@@ -49,6 +48,10 @@ public class DiscordGuildMessagePostBroadcastEvent extends Event {
     @Deprecated
     public String getProcessedMessage() {
         return MessageUtil.toLegacy(message);
+    }
+
+    public String getChannel() {
+        return this.channel;
     }
 
     public Component getMessage() {

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePostProcessEvent.java
@@ -34,6 +34,7 @@ import net.kyori.adventure.text.Component;
  * {@link #setMinecraftMessage(Component)} to change the message that would be broadcasted in-game or
  * {@link #setCancelled(boolean)} to cancel it from being broadcasted altogether</p>
  */
+@SuppressWarnings({"LombokGetterMayBeUsed", "LombokSetterMayBeUsed"})
 public class DiscordGuildMessagePostProcessEvent extends DiscordEvent<GuildMessageReceivedEvent> implements Cancellable {
 
     private boolean cancelled;

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePostProcessEvent.java
@@ -49,7 +49,7 @@ public class DiscordGuildMessagePostProcessEvent extends DiscordEvent<GuildMessa
     /**
      * The message that will be sent to players in-game
      */
-    @Getter @Setter private Component minecraftMessage;
+    @Getter private Component minecraftMessage;
 
     @Deprecated
     public DiscordGuildMessagePostProcessEvent(GuildMessageReceivedEvent jdaEvent, boolean cancelled, String processedMessage) {
@@ -86,4 +86,7 @@ public class DiscordGuildMessagePostProcessEvent extends DiscordEvent<GuildMessa
         return MessageUtil.toLegacy(minecraftMessage);
     }
 
+    public void setMinecraftMessage(Component minecraftMessage) {
+        this.minecraftMessage = minecraftMessage;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePostProcessEvent.java
@@ -22,8 +22,6 @@ package github.scarsz.discordsrv.api.events;
 
 import github.scarsz.discordsrv.api.Cancellable;
 import github.scarsz.discordsrv.util.MessageUtil;
-import lombok.Getter;
-import lombok.Setter;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.kyori.adventure.text.Component;
@@ -38,18 +36,15 @@ import net.kyori.adventure.text.Component;
  */
 public class DiscordGuildMessagePostProcessEvent extends DiscordEvent<GuildMessageReceivedEvent> implements Cancellable {
 
-    @Getter @Setter private boolean cancelled;
+    private boolean cancelled;
 
-    @Getter private final User author;
-    @Getter private final TextChannel channel;
-    @Getter private final Guild guild;
-    @Getter private final Member member;
-    @Getter private final Message message;
+    private final User author;
+    private final TextChannel channel;
+    private final Guild guild;
+    private final Member member;
+    private final Message message;
 
-    /**
-     * The message that will be sent to players in-game
-     */
-    @Getter private Component minecraftMessage;
+    private Component minecraftMessage;
 
     @Deprecated
     public DiscordGuildMessagePostProcessEvent(GuildMessageReceivedEvent jdaEvent, boolean cancelled, String processedMessage) {
@@ -84,6 +79,41 @@ public class DiscordGuildMessagePostProcessEvent extends DiscordEvent<GuildMessa
     @Deprecated
     public String getProcessedMessage() {
         return MessageUtil.toLegacy(minecraftMessage);
+    }
+
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public User getAuthor() {
+        return this.author;
+    }
+
+    public TextChannel getChannel() {
+        return this.channel;
+    }
+
+    public Guild getGuild() {
+        return this.guild;
+    }
+
+    public Member getMember() {
+        return this.member;
+    }
+
+    public Message getMessage() {
+        return this.message;
+    }
+
+    /**
+     * The message that will be sent to players in-game
+     */
+    public Component getMinecraftMessage() {
+        return this.minecraftMessage;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 
     public void setMinecraftMessage(Component minecraftMessage) {

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePreBroadcastEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePreBroadcastEvent.java
@@ -20,8 +20,6 @@
 
 package github.scarsz.discordsrv.api.events;
 
-import lombok.Getter;
-import lombok.Setter;
 import net.kyori.adventure.text.Component;
 import org.bukkit.command.CommandSender;
 
@@ -35,9 +33,9 @@ import java.util.List;
  */
 public class DiscordGuildMessagePreBroadcastEvent extends Event {
 
-    @Getter @Setter private String channel;
-    @Getter @Setter private Component message;
-    @Getter private final List<? extends CommandSender> recipients;
+    private String channel;
+    private Component message;
+    private final List<? extends CommandSender> recipients;
 
     public DiscordGuildMessagePreBroadcastEvent(String channel, Component message, List<? extends CommandSender> recipients) {
         this.channel = channel;
@@ -45,4 +43,23 @@ public class DiscordGuildMessagePreBroadcastEvent extends Event {
         this.recipients = recipients;
     }
 
+    public String getChannel() {
+        return this.channel;
+    }
+
+    public Component getMessage() {
+        return this.message;
+    }
+
+    public List<? extends CommandSender> getRecipients() {
+        return this.recipients;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public void setMessage(Component message) {
+        this.message = message;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePreBroadcastEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePreBroadcastEvent.java
@@ -31,6 +31,7 @@ import java.util.List;
  *
  * <p>At the time this event is called, the message, channel, and recipients can still be changed</p>
  */
+@SuppressWarnings("LombokGetterMayBeUsed")
 public class DiscordGuildMessagePreBroadcastEvent extends Event {
 
     private String channel;

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePreProcessEvent.java
@@ -21,8 +21,6 @@
 package github.scarsz.discordsrv.api.events;
 
 import github.scarsz.discordsrv.api.Cancellable;
-import lombok.Getter;
-import lombok.Setter;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 
@@ -32,13 +30,13 @@ import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
  */
 public class DiscordGuildMessagePreProcessEvent extends DiscordEvent<GuildMessageReceivedEvent> implements Cancellable {
 
-    @Getter @Setter private boolean cancelled;
+    private boolean cancelled;
 
-    @Getter private final User author;
-    @Getter private final TextChannel channel;
-    @Getter private final Guild guild;
-    @Getter private final Member member;
-    @Getter private final Message message;
+    private final User author;
+    private final TextChannel channel;
+    private final Guild guild;
+    private final Member member;
+    private final Message message;
 
     public DiscordGuildMessagePreProcessEvent(GuildMessageReceivedEvent jdaEvent) {
         super(jdaEvent.getJDA(), jdaEvent);
@@ -49,4 +47,31 @@ public class DiscordGuildMessagePreProcessEvent extends DiscordEvent<GuildMessag
         this.message = jdaEvent.getMessage();
     }
 
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public User getAuthor() {
+        return this.author;
+    }
+
+    public TextChannel getChannel() {
+        return this.channel;
+    }
+
+    public Guild getGuild() {
+        return this.guild;
+    }
+
+    public Member getMember() {
+        return this.member;
+    }
+
+    public Message getMessage() {
+        return this.message;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePreProcessEvent.java
@@ -28,6 +28,7 @@ import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
  * <p>Called after {@link DiscordGuildMessageReceivedEvent} when the message was validated as coming from a linked channel</p>
  * <p>Guaranteed to be from a linked {@link TextChannel}</p>
  */
+@SuppressWarnings("LombokGetterMayBeUsed")
 public class DiscordGuildMessagePreProcessEvent extends DiscordEvent<GuildMessageReceivedEvent> implements Cancellable {
 
     private boolean cancelled;

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessageReceivedEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessageReceivedEvent.java
@@ -30,6 +30,7 @@ import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
  *
  * @see DiscordGuildMessagePreProcessEvent
  */
+@SuppressWarnings("LombokGetterMayBeUsed")
 public class DiscordGuildMessageReceivedEvent extends DiscordEvent<GuildMessageReceivedEvent> {
 
     private final User author;

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessageReceivedEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessageReceivedEvent.java
@@ -20,7 +20,6 @@
 
 package github.scarsz.discordsrv.api.events;
 
-import lombok.Getter;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 
@@ -28,15 +27,16 @@ import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
  * <p>Called directly after receiving a message through Discord from a {@link Guild} that was not sent by the bot</p>
  * <p>As this includes <i>every</i> message the bot receives, this event does
  * not necessarily guarantee the received message is from a linked chat channel</p>
+ *
  * @see DiscordGuildMessagePreProcessEvent
  */
 public class DiscordGuildMessageReceivedEvent extends DiscordEvent<GuildMessageReceivedEvent> {
 
-    @Getter private final User author;
-    @Getter private final TextChannel channel;
-    @Getter private final Guild guild;
-    @Getter private final Member member;
-    @Getter private final Message message;
+    private final User author;
+    private final TextChannel channel;
+    private final Guild guild;
+    private final Member member;
+    private final Message message;
 
     public DiscordGuildMessageReceivedEvent(GuildMessageReceivedEvent jdaEvent) {
         super(jdaEvent.getJDA(), jdaEvent);
@@ -47,4 +47,23 @@ public class DiscordGuildMessageReceivedEvent extends DiscordEvent<GuildMessageR
         this.message = jdaEvent.getMessage();
     }
 
+    public User getAuthor() {
+        return this.author;
+    }
+
+    public TextChannel getChannel() {
+        return this.channel;
+    }
+
+    public Guild getGuild() {
+        return this.guild;
+    }
+
+    public Member getMember() {
+        return this.member;
+    }
+
+    public Message getMessage() {
+        return this.message;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessageSentEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessageSentEvent.java
@@ -29,6 +29,7 @@ import net.dv8tion.jda.api.entities.TextChannel;
  * <p>Called directly after a message is sent to a {@link TextChannel} by the bot</p>
  * <b>Please not that this only includes message sent from {@link github.scarsz.discordsrv.util.DiscordUtil}, messages from API hooks may not trigger this</b>
  */
+@SuppressWarnings("LombokGetterMayBeUsed")
 public class DiscordGuildMessageSentEvent extends DiscordEvent {
 
     private final TextChannel channel;

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessageSentEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessageSentEvent.java
@@ -20,7 +20,6 @@
 
 package github.scarsz.discordsrv.api.events;
 
-import lombok.Getter;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
@@ -32,9 +31,9 @@ import net.dv8tion.jda.api.entities.TextChannel;
  */
 public class DiscordGuildMessageSentEvent extends DiscordEvent {
 
-    @Getter private final TextChannel channel;
-    @Getter private final Guild guild;
-    @Getter private final Message message;
+    private final TextChannel channel;
+    private final Guild guild;
+    private final Message message;
 
     public DiscordGuildMessageSentEvent(JDA jda, Message message) {
         super(jda);
@@ -43,4 +42,15 @@ public class DiscordGuildMessageSentEvent extends DiscordEvent {
         this.message = message;
     }
 
+    public TextChannel getChannel() {
+        return this.channel;
+    }
+
+    public Guild getGuild() {
+        return this.guild;
+    }
+
+    public Message getMessage() {
+        return this.message;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordPrivateMessageReceivedEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordPrivateMessageReceivedEvent.java
@@ -28,6 +28,7 @@ import net.dv8tion.jda.api.events.message.priv.PrivateMessageReceivedEvent;
 /**
  * <p>Called directly after receiving a message through Discord from a {@link PrivateChannel}</p>
  */
+@SuppressWarnings("LombokGetterMayBeUsed")
 public class DiscordPrivateMessageReceivedEvent extends DiscordEvent<PrivateMessageReceivedEvent> {
 
     private final User author;

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordPrivateMessageReceivedEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordPrivateMessageReceivedEvent.java
@@ -20,7 +20,6 @@
 
 package github.scarsz.discordsrv.api.events;
 
-import lombok.Getter;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.PrivateChannel;
 import net.dv8tion.jda.api.entities.User;
@@ -31,9 +30,9 @@ import net.dv8tion.jda.api.events.message.priv.PrivateMessageReceivedEvent;
  */
 public class DiscordPrivateMessageReceivedEvent extends DiscordEvent<PrivateMessageReceivedEvent> {
 
-    @Getter private final User author;
-    @Getter private final PrivateChannel channel;
-    @Getter private final Message message;
+    private final User author;
+    private final PrivateChannel channel;
+    private final Message message;
 
     public DiscordPrivateMessageReceivedEvent(PrivateMessageReceivedEvent jdaEvent) {
         super(jdaEvent.getJDA(), jdaEvent);
@@ -42,4 +41,15 @@ public class DiscordPrivateMessageReceivedEvent extends DiscordEvent<PrivateMess
         this.message = jdaEvent.getMessage();
     }
 
+    public User getAuthor() {
+        return this.author;
+    }
+
+    public PrivateChannel getChannel() {
+        return this.channel;
+    }
+
+    public Message getMessage() {
+        return this.message;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordPrivateMessageSentEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordPrivateMessageSentEvent.java
@@ -28,6 +28,7 @@ import net.dv8tion.jda.api.entities.User;
 /**
  * <p>Called directly after a message is sent to a {@link PrivateChannel} by the bot</p>
  */
+@SuppressWarnings("LombokGetterMayBeUsed")
 public class DiscordPrivateMessageSentEvent extends DiscordEvent {
 
     private final PrivateChannel channel;

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordPrivateMessageSentEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordPrivateMessageSentEvent.java
@@ -20,7 +20,6 @@
 
 package github.scarsz.discordsrv.api.events;
 
-import lombok.Getter;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.PrivateChannel;
@@ -31,9 +30,9 @@ import net.dv8tion.jda.api.entities.User;
  */
 public class DiscordPrivateMessageSentEvent extends DiscordEvent {
 
-    @Getter private final PrivateChannel channel;
-    @Getter private final Message message;
-    @Getter private final User recipient;
+    private final PrivateChannel channel;
+    private final Message message;
+    private final User recipient;
 
     public DiscordPrivateMessageSentEvent(JDA jda, Message message) {
         super(jda);
@@ -42,4 +41,15 @@ public class DiscordPrivateMessageSentEvent extends DiscordEvent {
         this.recipient = channel.getUser();
     }
 
+    public PrivateChannel getChannel() {
+        return this.channel;
+    }
+
+    public Message getMessage() {
+        return this.message;
+    }
+
+    public User getRecipient() {
+        return this.recipient;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/GameChatMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/GameChatMessagePostProcessEvent.java
@@ -20,8 +20,6 @@
 
 package github.scarsz.discordsrv.api.events;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -29,15 +27,15 @@ import org.bukkit.event.Event;
 /**
  * <p>Called after DiscordSRV has processed a Minecraft chat message but before being sent to Discord.
  * Modification is allow and will effect the message sent to Discord.</p>
- * 
+ *
  * <p>If a messages is coming from VentureChat over Bungee then {@link VentureChatMessagePostProcessEvent} would be called instead, due to the lack of the Player object</p>
  */
 public class GameChatMessagePostProcessEvent extends GameEvent<Event> implements Cancellable {
 
-    @Getter @Setter private boolean cancelled;
+    private boolean cancelled;
 
-    @Getter @Setter private String channel;
-    @Getter @Setter private String processedMessage;
+    private String channel;
+    private String processedMessage;
 
     public GameChatMessagePostProcessEvent(String channel, String processedMessage, Player player, boolean cancelled, Event event) {
         super(player, event);
@@ -51,4 +49,27 @@ public class GameChatMessagePostProcessEvent extends GameEvent<Event> implements
         this(channel, processedMessage, player, cancelled, null);
     }
 
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public String getChannel() {
+        return this.channel;
+    }
+
+    public String getProcessedMessage() {
+        return this.processedMessage;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public void setProcessedMessage(String processedMessage) {
+        this.processedMessage = processedMessage;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/GameChatMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/GameChatMessagePostProcessEvent.java
@@ -30,6 +30,7 @@ import org.bukkit.event.Event;
  *
  * <p>If a messages is coming from VentureChat over Bungee then {@link VentureChatMessagePostProcessEvent} would be called instead, due to the lack of the Player object</p>
  */
+@SuppressWarnings({"LombokGetterMayBeUsed", "LombokSetterMayBeUsed"})
 public class GameChatMessagePostProcessEvent extends GameEvent<Event> implements Cancellable {
 
     private boolean cancelled;

--- a/src/main/java/github/scarsz/discordsrv/api/events/GameChatMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/GameChatMessagePreProcessEvent.java
@@ -35,6 +35,7 @@ import org.bukkit.event.Event;
  *
  * <p>If a messages is coming from VentureChat over Bungee then {@link VentureChatMessagePreProcessEvent} would be called instead, due to the lack of the Player object</p>
  */
+@SuppressWarnings({"LombokGetterMayBeUsed", "LombokSetterMayBeUsed"})
 public class GameChatMessagePreProcessEvent extends GameEvent<Event> implements Cancellable {
 
     private boolean cancelled;

--- a/src/main/java/github/scarsz/discordsrv/api/events/GameChatMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/GameChatMessagePreProcessEvent.java
@@ -21,8 +21,6 @@
 package github.scarsz.discordsrv.api.events;
 
 import github.scarsz.discordsrv.util.MessageUtil;
-import lombok.Getter;
-import lombok.Setter;
 import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -34,15 +32,15 @@ import org.bukkit.event.Event;
  * <p>At the time this event is called, {@link #getMessage()} would return what the person <i>said</i>, not
  * the final message. You could change what they said using the {@link #setMessage(String)} method or use
  * {@link #setCancelled(boolean)} to cancel it from being processed altogether</p>
- * 
+ *
  * <p>If a messages is coming from VentureChat over Bungee then {@link VentureChatMessagePreProcessEvent} would be called instead, due to the lack of the Player object</p>
  */
 public class GameChatMessagePreProcessEvent extends GameEvent<Event> implements Cancellable {
 
-    @Getter @Setter private boolean cancelled;
+    private boolean cancelled;
 
-    @Getter @Setter private String channel;
-    @Getter @Setter private Component messageComponent;
+    private String channel;
+    private Component messageComponent;
 
     public GameChatMessagePreProcessEvent(String channel, Component message, Player player, Event event) {
         super(player, event);
@@ -70,4 +68,27 @@ public class GameChatMessagePreProcessEvent extends GameEvent<Event> implements 
         this.messageComponent = MessageUtil.toComponent(legacy, true);
     }
 
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public String getChannel() {
+        return this.channel;
+    }
+
+    public Component getMessageComponent() {
+        return this.messageComponent;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public void setMessageComponent(Component messageComponent) {
+        this.messageComponent = messageComponent;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/GameEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/GameEvent.java
@@ -22,6 +22,7 @@ package github.scarsz.discordsrv.api.events;
 
 import org.bukkit.entity.Player;
 
+@SuppressWarnings("LombokGetterMayBeUsed")
 abstract class GameEvent<T extends org.bukkit.event.Event> extends Event {
 
     final private Player player;

--- a/src/main/java/github/scarsz/discordsrv/api/events/GameEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/GameEvent.java
@@ -20,17 +20,23 @@
 
 package github.scarsz.discordsrv.api.events;
 
-import lombok.Getter;
 import org.bukkit.entity.Player;
 
 abstract class GameEvent<T extends org.bukkit.event.Event> extends Event {
 
-    @Getter final private Player player;
-    @Getter final private T triggeringBukkitEvent;
+    final private Player player;
+    final private T triggeringBukkitEvent;
 
     GameEvent(Player player, T triggeringBukkitEvent) {
         this.player = player;
         this.triggeringBukkitEvent = triggeringBukkitEvent;
     }
 
+    public Player getPlayer() {
+        return this.player;
+    }
+
+    public T getTriggeringBukkitEvent() {
+        return this.triggeringBukkitEvent;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/GuildSlashCommandUpdateEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/GuildSlashCommandUpdateEvent.java
@@ -43,11 +43,14 @@ public class GuildSlashCommandUpdateEvent extends Event implements Cancellable {
     @Getter @Setter private boolean cancelled;
 
     @Getter private final Guild guild;
-    @Getter private final Set<CommandData> commands;
+    private final Set<CommandData> commands;
 
     public GuildSlashCommandUpdateEvent(Guild guild, Set<CommandData> commands) {
         this.guild = guild;
         this.commands = commands;
     }
 
+    public Set<CommandData> getCommands() {
+        return this.commands;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/GuildSlashCommandUpdateEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/GuildSlashCommandUpdateEvent.java
@@ -36,6 +36,7 @@ import java.util.Set;
  * registering to this {@link Guild} altogether. Cancelling also leave slash commands originally registered in a
  * {@link Guild} untouched.</p>
  */
+@SuppressWarnings({"LombokGetterMayBeUsed", "LombokSetterMayBeUsed"})
 public class GuildSlashCommandUpdateEvent extends Event implements Cancellable {
 
     private boolean cancelled;

--- a/src/main/java/github/scarsz/discordsrv/api/events/GuildSlashCommandUpdateEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/GuildSlashCommandUpdateEvent.java
@@ -21,8 +21,6 @@
 package github.scarsz.discordsrv.api.events;
 
 import github.scarsz.discordsrv.api.Cancellable;
-import lombok.Getter;
-import lombok.Setter;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 
@@ -40,9 +38,9 @@ import java.util.Set;
  */
 public class GuildSlashCommandUpdateEvent extends Event implements Cancellable {
 
-    @Getter @Setter private boolean cancelled;
+    private boolean cancelled;
 
-    @Getter private final Guild guild;
+    private final Guild guild;
     private final Set<CommandData> commands;
 
     public GuildSlashCommandUpdateEvent(Guild guild, Set<CommandData> commands) {
@@ -50,7 +48,19 @@ public class GuildSlashCommandUpdateEvent extends Event implements Cancellable {
         this.commands = commands;
     }
 
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public Guild getGuild() {
+        return this.guild;
+    }
+
     public Set<CommandData> getCommands() {
         return this.commands;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/VentureChatEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/VentureChatEvent.java
@@ -22,6 +22,7 @@ package github.scarsz.discordsrv.api.events;
 
 import mineverse.Aust1n46.chat.api.events.VentureChatEvent;
 
+@SuppressWarnings("LombokGetterMayBeUsed")
 abstract class VentureChatMessageEvent extends Event {
 
     final private VentureChatEvent ventureChatEvent;

--- a/src/main/java/github/scarsz/discordsrv/api/events/VentureChatEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/VentureChatEvent.java
@@ -20,15 +20,17 @@
 
 package github.scarsz.discordsrv.api.events;
 
-import lombok.Getter;
 import mineverse.Aust1n46.chat.api.events.VentureChatEvent;
 
 abstract class VentureChatMessageEvent extends Event {
 
-    @Getter final private VentureChatEvent ventureChatEvent;
+    final private VentureChatEvent ventureChatEvent;
 
     VentureChatMessageEvent(VentureChatEvent ventureChatEvent) {
         this.ventureChatEvent = ventureChatEvent;
     }
 
+    public VentureChatEvent getVentureChatEvent() {
+        return this.ventureChatEvent;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/VentureChatMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/VentureChatMessagePostProcessEvent.java
@@ -20,8 +20,6 @@
 
 package github.scarsz.discordsrv.api.events;
 
-import lombok.Getter;
-import lombok.Setter;
 import mineverse.Aust1n46.chat.api.events.VentureChatEvent;
 import org.bukkit.event.Cancellable;
 
@@ -31,10 +29,10 @@ import org.bukkit.event.Cancellable;
  */
 public class VentureChatMessagePostProcessEvent extends VentureChatMessageEvent implements Cancellable {
 
-    @Getter @Setter private boolean cancelled;
+    private boolean cancelled;
 
-    @Getter @Setter private String channel;
-    @Getter @Setter private String processedMessage;
+    private String channel;
+    private String processedMessage;
 
     public VentureChatMessagePostProcessEvent(String channel, String processedMessage, VentureChatEvent ventureChatEvent, boolean cancelled) {
         super(ventureChatEvent);
@@ -43,4 +41,27 @@ public class VentureChatMessagePostProcessEvent extends VentureChatMessageEvent 
         setCancelled(cancelled);
     }
 
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public String getChannel() {
+        return this.channel;
+    }
+
+    public String getProcessedMessage() {
+        return this.processedMessage;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public void setProcessedMessage(String processedMessage) {
+        this.processedMessage = processedMessage;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/VentureChatMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/VentureChatMessagePostProcessEvent.java
@@ -27,6 +27,7 @@ import org.bukkit.event.Cancellable;
  * <p>Called after DiscordSRV has processed a VentureChat message from Bungee (when the VentureChatBungee config option is enabled) but before being sent to Discord.
  * Modification is allow and will effect the message sent to Discord.</p>
  */
+@SuppressWarnings({"LombokGetterMayBeUsed", "LombokSetterMayBeUsed"})
 public class VentureChatMessagePostProcessEvent extends VentureChatMessageEvent implements Cancellable {
 
     private boolean cancelled;

--- a/src/main/java/github/scarsz/discordsrv/api/events/VentureChatMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/VentureChatMessagePreProcessEvent.java
@@ -21,8 +21,6 @@
 package github.scarsz.discordsrv.api.events;
 
 import github.scarsz.discordsrv.util.MessageUtil;
-import lombok.Getter;
-import lombok.Setter;
 import mineverse.Aust1n46.chat.api.events.VentureChatEvent;
 import net.kyori.adventure.text.Component;
 import org.bukkit.event.Cancellable;
@@ -36,10 +34,10 @@ import org.bukkit.event.Cancellable;
  */
 public class VentureChatMessagePreProcessEvent extends VentureChatMessageEvent implements Cancellable {
 
-    @Getter @Setter private boolean cancelled;
+    private boolean cancelled;
 
-    @Getter @Setter private String channel;
-    @Getter @Setter private Component messageComponent;
+    private String channel;
+    private Component messageComponent;
 
     public VentureChatMessagePreProcessEvent(String channel, Component message, VentureChatEvent ventureChatEvent) {
         super(ventureChatEvent);
@@ -62,4 +60,27 @@ public class VentureChatMessagePreProcessEvent extends VentureChatMessageEvent i
         this.messageComponent = MessageUtil.toComponent(legacy, true);
     }
 
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public String getChannel() {
+        return this.channel;
+    }
+
+    public Component getMessageComponent() {
+        return this.messageComponent;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public void setMessageComponent(Component messageComponent) {
+        this.messageComponent = messageComponent;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/VentureChatMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/VentureChatMessagePreProcessEvent.java
@@ -32,6 +32,7 @@ import org.bukkit.event.Cancellable;
  * the final message. You could change what they said using the {@link #setMessage(String)} method or use
  * {@link #setCancelled(boolean)} to cancel it from being processed altogether</p>
  */
+@SuppressWarnings({"LombokGetterMayBeUsed", "LombokSetterMayBeUsed"})
 public class VentureChatMessagePreProcessEvent extends VentureChatMessageEvent implements Cancellable {
 
     private boolean cancelled;

--- a/src/main/java/github/scarsz/discordsrv/api/events/WatchdogMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/WatchdogMessagePostProcessEvent.java
@@ -20,8 +20,6 @@
 
 package github.scarsz.discordsrv.api.events;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.bukkit.event.Cancellable;
 
 /**
@@ -30,12 +28,12 @@ import org.bukkit.event.Cancellable;
  */
 public class WatchdogMessagePostProcessEvent extends Event implements Cancellable {
 
-    @Getter @Setter private boolean cancelled;
+    private boolean cancelled;
 
-    @Getter @Setter private String channel;
-    @Getter @Setter private String processedMessage;
+    private String channel;
+    private String processedMessage;
 
-    @Getter @Setter private int count;
+    private int count;
 
     public WatchdogMessagePostProcessEvent(String channel, String processedMessage, int count, boolean cancelled) {
         this.channel = channel;
@@ -44,4 +42,35 @@ public class WatchdogMessagePostProcessEvent extends Event implements Cancellabl
         setCancelled(cancelled);
     }
 
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public String getChannel() {
+        return this.channel;
+    }
+
+    public String getProcessedMessage() {
+        return this.processedMessage;
+    }
+
+    public int getCount() {
+        return this.count;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public void setProcessedMessage(String processedMessage) {
+        this.processedMessage = processedMessage;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/WatchdogMessagePostProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/WatchdogMessagePostProcessEvent.java
@@ -26,6 +26,7 @@ import org.bukkit.event.Cancellable;
  * <p>Called after DiscordSRV has processed a watchdog message but before being sent to Discord.
  * Modification is allow and will effect the message sent to Discord.</p>
  */
+@SuppressWarnings({"LombokGetterMayBeUsed", "LombokSetterMayBeUsed"})
 public class WatchdogMessagePostProcessEvent extends Event implements Cancellable {
 
     private boolean cancelled;

--- a/src/main/java/github/scarsz/discordsrv/api/events/WatchdogMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/WatchdogMessagePreProcessEvent.java
@@ -20,8 +20,6 @@
 
 package github.scarsz.discordsrv.api.events;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.bukkit.event.Cancellable;
 
 /**
@@ -29,12 +27,12 @@ import org.bukkit.event.Cancellable;
  */
 public class WatchdogMessagePreProcessEvent extends Event implements Cancellable {
 
-    @Getter @Setter private boolean cancelled;
+    private boolean cancelled;
 
-    @Getter @Setter private String channel;
-    @Getter @Setter private String message;
+    private String channel;
+    private String message;
 
-    @Getter @Setter private int count;
+    private int count;
 
     public WatchdogMessagePreProcessEvent(String channel, String message, int count, boolean cancelled) {
         this.channel = channel;
@@ -43,4 +41,35 @@ public class WatchdogMessagePreProcessEvent extends Event implements Cancellable
         setCancelled(cancelled);
     }
 
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public String getChannel() {
+        return this.channel;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    public int getCount() {
+        return this.count;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/api/events/WatchdogMessagePreProcessEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/WatchdogMessagePreProcessEvent.java
@@ -25,6 +25,7 @@ import org.bukkit.event.Cancellable;
 /**
  * <p>Called before DiscordSRV has processed a watchdog message, modifications may be overwritten by DiscordSRV's processing.</p>
  */
+@SuppressWarnings({"LombokGetterMayBeUsed", "LombokSetterMayBeUsed"})
 public class WatchdogMessagePreProcessEvent extends Event implements Cancellable {
 
     private boolean cancelled;

--- a/src/main/java/github/scarsz/discordsrv/objects/MessageFormat.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/MessageFormat.java
@@ -84,4 +84,7 @@ public class MessageFormat {
         this.colorRaw = color.getRGB();
     }
 
+    public void setColorRaw(int colorRaw) {
+        this.colorRaw = colorRaw;
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/objects/MessageFormat.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/MessageFormat.java
@@ -84,6 +84,7 @@ public class MessageFormat {
         this.colorRaw = color.getRGB();
     }
 
+    @SuppressWarnings("LombokSetterMayBeUsed")
     public void setColorRaw(int colorRaw) {
         this.colorRaw = colorRaw;
     }

--- a/src/main/java/github/scarsz/discordsrv/util/DiscordUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/DiscordUtil.java
@@ -90,7 +90,7 @@ public class DiscordUtil {
     private static final Pattern EMOTE_MENTION_PATTERN = Pattern.compile("(<a?:([a-zA-Z]{2,32}):[0-9]{16,20}>)");
 
     /**
-     * Converts Discord-compatible <@12345742934270> mentions to human readable @mentions
+     * Converts Discord-compatible &lt;@12345742934270> mentions to human readable @mentions
      * @param message the message
      * @return the converted message
      */
@@ -128,7 +128,7 @@ public class DiscordUtil {
     }
 
     /**
-     * Convert @mentions into Discord-compatible <@012345678901234567890> mentions
+     * Convert @mentions into Discord-compatible &lt;@012345678901234567890> mentions
      * @param message Message to convert
      * @param guild Guild to find names to convert
      * @return Contents of the given message with names converted to mentions

--- a/src/main/java/github/scarsz/discordsrv/util/LangUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/LangUtil.java
@@ -29,11 +29,11 @@ import java.util.Map;
 
 /**
  * <p>Made by Scarsz</p>
- * <p>German translations by Androkai & GerdSattler</p>
+ * <p>German translations by Androkai &amp; GerdSattler</p>
  * <p>Japanese translations by Ucchy</p>
  * <p>French translations by BrinDeNuage</p>
  * <p>Korean translations by Alex4386 (with MintNetwork)</p>
- * <p>Dutch translations by Mr Ceasar & Zarathos</p>
+ * <p>Dutch translations by Mr Ceasar &amp; Zarathos</p>
  * <p>Spanish translations by ZxFrankxZ</p>
  * <p>Russian translations by DmitryRendov</p>
  * <p>Estonian translations by Madis0</p>

--- a/src/main/java/github/scarsz/discordsrv/util/MessageUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/MessageUtil.java
@@ -47,7 +47,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Utility class for sending & editing messages from/for CommandSenders.
+ * Utility class for sending &amp; editing messages from/for CommandSenders.
  * Utilizes both MiniMessage and Minecraft's legacy formatting style.
  */
 public class MessageUtil {
@@ -85,7 +85,7 @@ public class MessageUtil {
     public static final Pattern STRIP_SECTION_ONLY_PATTERN = Pattern.compile("(?<!<@)§(?i)[0-9a-fklmnorx]");
 
     /**
-     * Pattern for translating color codes (legacy & adventure), excluding role mentions ({@code <@&role id>}).
+     * Pattern for translating color codes (legacy &amp; adventure), excluding role mentions ({@code <@&amp;role id>}).
      */
     public static final Pattern TRANSLATE_PATTERN = Pattern.compile("(?<!<@)(&)(?i)(?:[0-9a-fklmnorx]|#[0-9a-f]{6})");
 
@@ -366,7 +366,7 @@ public class MessageUtil {
     }
 
     /**
-     * Strips the given String of legacy Minecraft coloring (both & and §).
+     * Strips the given String of legacy Minecraft coloring (both &amp; and §).
      *
      * @param text the given String to strip colors and formatting from
      * @return the given String with coloring and formatting stripped
@@ -405,7 +405,7 @@ public class MessageUtil {
     }
 
     /**
-     * Strip the given String of legacy Minecraft coloring (both & and §). Useful for sending things to Discord.
+     * Strip the given String of legacy Minecraft coloring (both &amp; and §). Useful for sending things to Discord.
      *
      * @param text the given String to strip colors from
      * @return the given String with coloring stripped
@@ -433,7 +433,7 @@ public class MessageUtil {
     }
 
     /**
-     * Translates ampersand (&) characters into section signs (§) for color codes. Ignores role mentions.
+     * Translates ampersand (&amp;) characters into section signs (§) for color codes. Ignores role mentions.
      *
      * @param text the input text
      * @return the output text

--- a/src/main/java/github/scarsz/discordsrv/util/NamedValueFormatter.java
+++ b/src/main/java/github/scarsz/discordsrv/util/NamedValueFormatter.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
 
 /**
  * <p>Utility for replacing placeholders in Strings. You can provide the replacements directly as map entries or you can
- * provide a Function<String, String> that will map keys to their values.</p>
+ * provide a {@link java.util.function.Function Function&lt;String, String>} that will map keys to their values.</p>
  *
  * <p>Examples:
  * <ol>

--- a/src/main/java/github/scarsz/discordsrv/util/PlayerUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/PlayerUtil.java
@@ -223,7 +223,7 @@ public class PlayerUtil {
     /**
      * Returns whether the passed UUID is a v3 UUID. Offline UUIDs are v3, online are v4.
      * @param uuid the UUID to check
-     * @return whether the UUID is a v3 UUID & thus is offline
+     * @return whether the UUID is a v3 UUID &amp; thus is offline
      */
     public static boolean uuidIsOffline(UUID uuid) {
         return uuid.version() == 3;


### PR DESCRIPTION
Commits are organized in such a way that make it easy to revert unwanted changes.