### PR TITLE
Update Adventure Version to 4.17.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -211,7 +211,7 @@ dependencies {
     compileOnly("org.apache.logging.log4j:log4j-core:2.0-beta9")
 
     // adventure, adventure-platform, MCDiscordReserializer
-    val adventureVersion = "4.14.0"
+    val adventureVersion = "4.17.0"
     api("net.kyori:adventure-api:${adventureVersion}")
     api("net.kyori:adventure-text-minimessage:${adventureVersion}")
     api("net.kyori:adventure-text-serializer-legacy:${adventureVersion}")


### PR DESCRIPTION
Fixes the "font" tag not working in chat messages in 1.20.3+