### PR TITLE
Comment that nickname sync is controlled by a permission

### DIFF
--- a/src/main/resources/synchronization/da.yml
+++ b/src/main/resources/synchronization/da.yml
@@ -1,4 +1,5 @@
 # Minecraft -> Discord kaldenavnsynkronisering
+# Can be controlled per player through the use of the 'discordsrv.nicknamesync' permission (granted by default)
 #
 # NicknameSynchronizationEnabled: om der automatisk skal indstilles discord-brugerens kaldenavn til kaldenavnsformatet
 # NicknameSynchronizationCycleTime: antal minutter mellem gentagne gange udløsning af synkronisering for alle online spillere

--- a/src/main/resources/synchronization/de.yml
+++ b/src/main/resources/synchronization/de.yml
@@ -1,4 +1,5 @@
 # Minecraft -> Discord-Spitznamensynchronisation
+# Can be controlled per player through the use of the 'discordsrv.nicknamesync' permission (granted by default)
 #
 # NicknameSynchronizationEnabled: Gibt an, ob der Spitzname des Discord-Benutzers automatisch auf das Spitznamenformat gesetzt werden soll
 # NicknameSynchronizationCycleTime: Anzahl der Minuten zwischen dem wiederholten Auslösen der Synchronisation für alle Online-Spieler

--- a/src/main/resources/synchronization/en.yml
+++ b/src/main/resources/synchronization/en.yml
@@ -1,4 +1,5 @@
 # Minecraft -> Discord nickname synchronization
+# Controlled by the 'discordsrv.nicknamesync' permission
 #
 # NicknameSynchronizationEnabled: whether to set the discord user's nickname to the nickname format automatically
 # NicknameSynchronizationCycleTime: amount of minutes between repeatedly triggering synchronization for all online players
@@ -18,6 +19,7 @@ NicknameSynchronizationCycleTime: 3
 NicknameSynchronizationFormat: "%displayname%"
 
 # Minecraft group <-> Discord role synchronization
+# Controlled by the 'discordsrv.sync.<group>' and 'discordsrv.sync.deny.<group>' permissions
 # Requires Vault
 #
 # GroupRoleSynchronizationGroupsAndRolesToSync: these are roles/groups you'd like synchronized between Discord and Minecraft

--- a/src/main/resources/synchronization/en.yml
+++ b/src/main/resources/synchronization/en.yml
@@ -1,5 +1,5 @@
 # Minecraft -> Discord nickname synchronization
-# Can be controlled per player through the use of the 'discordsrv.nicknamesync' permission
+# Can be controlled per player through the use of the 'discordsrv.nicknamesync' permission (granted by default)
 #
 # NicknameSynchronizationEnabled: whether to set the discord user's nickname to the nickname format automatically
 # NicknameSynchronizationCycleTime: amount of minutes between repeatedly triggering synchronization for all online players

--- a/src/main/resources/synchronization/en.yml
+++ b/src/main/resources/synchronization/en.yml
@@ -19,7 +19,6 @@ NicknameSynchronizationCycleTime: 3
 NicknameSynchronizationFormat: "%displayname%"
 
 # Minecraft group <-> Discord role synchronization
-# Controlled by the 'discordsrv.sync.<group>' and 'discordsrv.sync.deny.<group>' permissions
 # Requires Vault
 #
 # GroupRoleSynchronizationGroupsAndRolesToSync: these are roles/groups you'd like synchronized between Discord and Minecraft

--- a/src/main/resources/synchronization/en.yml
+++ b/src/main/resources/synchronization/en.yml
@@ -1,5 +1,5 @@
 # Minecraft -> Discord nickname synchronization
-# Controlled by the 'discordsrv.nicknamesync' permission
+# Can be controlled per player through the use of the 'discordsrv.nicknamesync' permission
 #
 # NicknameSynchronizationEnabled: whether to set the discord user's nickname to the nickname format automatically
 # NicknameSynchronizationCycleTime: amount of minutes between repeatedly triggering synchronization for all online players

--- a/src/main/resources/synchronization/es.yml
+++ b/src/main/resources/synchronization/es.yml
@@ -1,4 +1,5 @@
 # Minecraft -> Sincronización de apodos de Discord
+# Can be controlled per player through the use of the 'discordsrv.nicknamesync' permission (granted by default)
 #
 # NicknameSynchronizationEnabled: si establecer o no el apodo del usuario de la discordia en el formato de apodo automáticamente
 # NicknameSynchronizationCycleTime: cantidad de minutos entre la activación repetida de la sincronización para todos los jugadores en línea

--- a/src/main/resources/synchronization/et.yml
+++ b/src/main/resources/synchronization/et.yml
@@ -1,4 +1,5 @@
 # Minecraft -> Discord nickname synchronization
+# Can be controlled per player through the use of the 'discordsrv.nicknamesync' permission (granted by default)
 #
 # NicknameSynchronizationEnabled: whether to set the discord user's nickname to the nickname format automatically
 # NicknameSynchronizationCycleTime: amount of minutes between repeatedly triggering synchronization for all online players

--- a/src/main/resources/synchronization/fr.yml
+++ b/src/main/resources/synchronization/fr.yml
@@ -1,4 +1,5 @@
 # Minecraft -> Synchronisation des pseudonymes Discord
+# Can be controlled per player through the use of the 'discordsrv.nicknamesync' permission (granted by default)
 #
 # NicknameSynchronizationEnabled: définir automatiquement ou non le pseudonyme de l'utilisateur Discord au format pseudonyme
 # NicknameSynchronizationCycleTime: nombre de minutes entre le déclenchement répété de la synchronisation pour tous les joueurs en ligne

--- a/src/main/resources/synchronization/ja.yml
+++ b/src/main/resources/synchronization/ja.yml
@@ -1,4 +1,5 @@
 # Minecraft->Discordのニックネームの同期
+# Can be controlled per player through the use of the 'discordsrv.nicknamesync' permission (granted by default)
 #
 # NicknameSynchronizationEnabled：Discordユーザーのニックネームをニックネーム形式に自動的に設定するかどうか
 # NicknameSynchronizationCycleTime：すべてのオンラインプレーヤーの同期を繰り返しトリガーする間の分数

--- a/src/main/resources/synchronization/ko.yml
+++ b/src/main/resources/synchronization/ko.yml
@@ -1,4 +1,5 @@
 # Minecraft-> Discord 닉네임 동기화
+# Can be controlled per player through the use of the 'discordsrv.nicknamesync' permission (granted by default)
 #
 # NicknameSynchronizationEnabled : 불일치 사용자의 닉네임을 닉네임 형식으로 자동 설정할지 여부
 # NicknameSynchronizationCycleTime : 모든 온라인 플레이어에 대해 반복적으로 동기화를 트리거하는 간격 (분)

--- a/src/main/resources/synchronization/nl.yml
+++ b/src/main/resources/synchronization/nl.yml
@@ -1,4 +1,5 @@
 # Minecraft -> Discord-bijnaamsynchronisatie
+# Can be controlled per player through the use of the 'discordsrv.nicknamesync' permission (granted by default)
 #
 # NicknameSynchronizationEnabled: het al dan niet automatisch instellen van de bijnaam van de onenigheidsgebruiker in het bijnaamformaat
 # NicknameSynchronizationCycleTime: aantal minuten tussen het herhaaldelijk activeren van synchronisatie voor alle online spelers

--- a/src/main/resources/synchronization/pl.yml
+++ b/src/main/resources/synchronization/pl.yml
@@ -1,4 +1,5 @@
 # Minecraft -> Synchronizacja pseudonimów na Discordzie
+# Can be controlled per player through the use of the 'discordsrv.nicknamesync' permission (granted by default)
 #
 # NicknameSynchronizationEnabled: czy automatycznie ustawić pseudonim użytkownika discorda na format pseudonimu
 # NicknameSynchronizationCycleTime: liczba minut między wielokrotnym uruchamianiem synchronizacji dla wszystkich graczy online

--- a/src/main/resources/synchronization/ru.yml
+++ b/src/main/resources/synchronization/ru.yml
@@ -1,4 +1,5 @@
 # Синхронизация никнеймов
+# Can be controlled per player through the use of the 'discordsrv.nicknamesync' permission (granted by default)
 #
 # В Discord будет такой же ник, как в Minecraft
 # NicknameSynchronizationEnabled: Включить - true, отключить - false

--- a/src/main/resources/synchronization/uk.yml
+++ b/src/main/resources/synchronization/uk.yml
@@ -1,4 +1,5 @@
 # Синхронізація нікнеймів у Discord (буде такий же нік, як у Minecraft)
+# Can be controlled per player through the use of the 'discordsrv.nicknamesync' permission (granted by default)
 #
 # NicknameSynchronizationEnabled: Увімкнути - true, вимкнути - false
 # NicknameSynchronizationCycleTime: Час (у хвилинах) - як часто DiscordSRV буде синхронізувати ніки гравців.

--- a/src/main/resources/synchronization/zh.yml
+++ b/src/main/resources/synchronization/zh.yml
@@ -1,4 +1,5 @@
 # Minecraft-> Discord昵称同步
+# Can be controlled per player through the use of the 'discordsrv.nicknamesync' permission (granted by default)
 #
 # NicknameSynchronizationEnabled：是否将不和用户的昵称自动设置为昵称格式
 # NicknameSynchronizationCycleTime：重复触发所有在线播放器同步之间的分钟数


### PR DESCRIPTION
If no changes are wanted for the EN config then I will translate it for the other languages.