### PR TITLE
AvatarUrl: Fix false positives of url not working offline

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -2098,8 +2098,8 @@ public class DiscordSRV extends JavaPlugin {
             DiscordSRV.warning("You should set your AvatarUrl (in config.yml) to an empty string (\"\") to get rid of this warning.");
         }
 
-        if (offline && !avatarUrl.contains("{username}") && !offlineUuidAvatarUrlNagged) {
-            DiscordSRV.error("Your AvatarUrl config option does not contain the {username} placeholder even though this server is using offline UUIDs.");
+        if (offline && (avatarUrl.contains("{uuid}") || avatarUrl.contains("{uuid-nodashes}")) && !offlineUuidAvatarUrlNagged) {
+            DiscordSRV.error("Your AvatarUrl config option contains {uuid} or {uuid-nodashes} but this server is using offline UUIDs.");
             offlineUuidAvatarUrlNagged = true;
         }
 


### PR DESCRIPTION
`{texture}` or a PlaceholderAPI placeholder is now more commonly the only identifier used in the AvatarUrl, so the plugin should see if offline servers are using `{uuid}` or `{uuid-dashless}` rather than seeing if they aren't using `{username}`