### PR TITLE
Fixed wrong Japanese translations

### DIFF
--- a/src/main/resources/linking/ja.yml
+++ b/src/main/resources/linking/ja.yml
@@ -26,7 +26,7 @@ Require linked account to play:
   # ボットの名前のプレースホルダーとして{BOT}を使用します
   # ボットのDMに必要なコードのプレースホルダーとして{CODE}を使用します
   # プレイヤーがDiscordサーバーに参加するために必要な招待リンクのプレースホルダーとして{INVITE}を使用します。config.ymlで設定されたDiscordInviteLinkを使用します
-  Not linked message: "&7プレイするには、&bDiscord&7アカウントをリンクする必要があります。\n\n&7アカウントをリンクするには、&b{CODE}&7のみを含むDiscordサーバーの&b{BOT}&7にDMを送信します。\n\n&7Discordの招待 » &b{INVITE}"
+  Not linked message: "&7プレイするには、&bDiscord&7アカウントをリンクする必要があります。\n\n&7アカウントをリンクするには、&b{CODE}&7をそのまま、Discordサーバーの&b{BOT}&7にDMを送信してください。\n\n&7Discordの招待 » &b{INVITE}"
 
   # 有効にした場合、プレイヤーはアカウントをリンクするだけでなく、ボットがいるDiscordサーバーのメンバーである必要があります。
   #
@@ -49,8 +49,8 @@ Require linked account to play:
     Kick message: "&cプレイするには、Twitchに登録する必要があります。"
 
   Messages:
-    DiscordSRV still starting: "&cサーバーがまだDiscordに接続しているため、現在リンクステータスを確認できません。\n\nしばらくしてからもう一度お試しください。"
-    Not in server: "&c現在、Discordサーバーの一部ではありません。\n\n{INVITE}に参加してください！"
-    Failed to find subscriber role: "&cDiscordでサブスクライバーの役割を見つけることができませんでした。\n\nこの問題については、サーバー管理者にお問い合わせください。"
-    Failed for unknown reason: "&cアカウントの確認中にエラーが発生しました。\n\nこの問題については、サーバー管理者にお問い合わせください。"
-    Kicked for unlinking: "&cアカウントのリンクを解除したためサーバーから追い出されました。\n\nサーバーに再度参加して、アカウントを再度リンクしてください。"
+    DiscordSRV still starting: "&cサーバーがDiscordに接続できていないため、現在リンクステータスを確認できません。\n\nしばらくしてからもう一度お試しください。"
+    Not in server: "&cDiscordサーバーに参加していません。\n\n{INVITE}に参加してください！"
+    Failed to find subscriber role: "&cDiscordで登録者ロールを見つけることができませんでした。\n\nサーバー管理者にお問い合わせください。"
+    Failed for unknown reason: "&cアカウントの確認中にエラーが発生しました。\n\nサーバー管理者にお問い合わせください。"
+    Kicked for unlinking: "&cアカウントのリンクを解除したため、サーバーから追い出されました。\n\nサーバーに再度参加して、アカウントをリンクしてください。"


### PR DESCRIPTION
Fixed wrong Japanese translations.

Below is the modified translation.
- Not linked message
- DiscordSRV still starting
- Not in server
- Failed to find subscriber role
- Failed for unknown reason
- Kicked for unlinking