### PR TITLE
Put commit hash in plugin.yml version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,9 @@ group = "com.discordsrv"
 val minecraftVersion = project.properties["minecraftVersion"]!!.toString()
 val targetJavaVersion = 1.8
 
+val commit = if (indraGit.isPresent) indraGit.commit()?.name() ?: "" else ""
+val fullVersion = (project.version.toString()) + if (project.version.toString().endsWith("-SNAPSHOT")) (if (commit.length >= 7) "-" + commit.substring(0, 7) else "") else ""
+
 java {
     val javaVersion = JavaVersion.toVersion(targetJavaVersion)
     sourceCompatibility = javaVersion
@@ -54,7 +57,7 @@ tasks {
     processResources {
         outputs.upToDateWhen { false }
         filter<ReplaceTokens>(mapOf(
-            "tokens" to mapOf("version" to project.version.toString()),
+            "tokens" to mapOf("version" to fullVersion),
             "beginToken" to "\${",
             "endToken" to "}"
         ))
@@ -78,9 +81,7 @@ tasks {
 
     // Set snapshot version for all jar tasks
     withType<Jar> {
-        val commit = if (indraGit.isPresent) indraGit.commit()?.name() ?: "" else ""
-        val version = (project.version.toString()) + if (archiveVersion.get().endsWith("-SNAPSHOT")) (if (commit.length >= 7) "-" + commit.substring(0, 7) else "") else ""
-        archiveVersion.set(version)
+        archiveVersion.set(fullVersion)
     }
 
     jar {


### PR DESCRIPTION
This would mean that we can see how many people are *actually* running the latest snapshot, which might be useful for making a decision about whether the build is stable enough.