### PR TITLE
Fix alerts not working for events that share their HandlerList

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/modules/alerts/AlertListener.java
+++ b/src/main/java/github/scarsz/discordsrv/modules/alerts/AlertListener.java
@@ -228,7 +228,8 @@ public class AlertListener implements Listener, EventListener {
         }
         if (!active) {
             // remove us from HandlerLists that we don't need (we can do this here, since we have the full class name)
-            if (event instanceof Event) ((Event) event).getHandlers().unregister(this);
+            if (event instanceof Event && Arrays.stream(event.getClass().getDeclaredMethods()).anyMatch(e -> e.getName().equals("getHandlers")))
+                ((Event) event).getHandlers().unregister(this);
             return;
         }
 


### PR DESCRIPTION
- Events that sharing HandlerList shouldn't be unregistered.
- [Example (QuickShop events)](https://github.com/PotatoCraft-Studio/QuickShop-Reremake/blob/master/src/main/java/org/maxgamer/quickshop/api/event/AbstractQSEvent.java)