### PR TITLE
Add placeholders for user ID

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordChatListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordChatListener.java
@@ -392,6 +392,7 @@ public class DiscordChatListener extends ListenerAdapter {
         return input.replace("%channelname%", event.getChannel().getName())
                 .replace("%name%", escape.apply(MessageUtil.strip(event.getMember() != null ? event.getMember().getEffectiveName() : event.getAuthor().getName())))
                 .replace("%username%", escape.apply(MessageUtil.strip(event.getAuthor().getName())))
+                .replace("%id%", event.getAuthor().getId())
                 .replace("%toprole%", escape.apply(DiscordUtil.getRoleName(!selectedRoles.isEmpty() ? selectedRoles.get(0) : null)))
                 .replace("%toproleinitial%", !selectedRoles.isEmpty() ? escape.apply(DiscordUtil.getRoleName(selectedRoles.get(0)).substring(0, 1)) : "")
                 .replace("%toprolealias%", getTopRoleAlias(!selectedRoles.isEmpty() ? selectedRoles.get(0) : null))
@@ -422,6 +423,7 @@ public class DiscordChatListener extends ListenerAdapter {
 
         return format.replace("%name%", escape.apply(MessageUtil.strip(repliedUserName)))
                 .replace("%username%", escape.apply(MessageUtil.strip(repliedMessage.getAuthor().getName())))
+                .replace("%id%", repliedMessage.getAuthor().getId())
                 .replace("%message%", message);
     }
 

--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordChatListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordChatListener.java
@@ -392,7 +392,7 @@ public class DiscordChatListener extends ListenerAdapter {
         return input.replace("%channelname%", event.getChannel().getName())
                 .replace("%name%", escape.apply(MessageUtil.strip(event.getMember() != null ? event.getMember().getEffectiveName() : event.getAuthor().getName())))
                 .replace("%username%", escape.apply(MessageUtil.strip(event.getAuthor().getName())))
-                .replace("%id%", event.getAuthor().getId())
+                .replace("%userid%", event.getAuthor().getId())
                 .replace("%toprole%", escape.apply(DiscordUtil.getRoleName(!selectedRoles.isEmpty() ? selectedRoles.get(0) : null)))
                 .replace("%toproleinitial%", !selectedRoles.isEmpty() ? escape.apply(DiscordUtil.getRoleName(selectedRoles.get(0)).substring(0, 1)) : "")
                 .replace("%toprolealias%", getTopRoleAlias(!selectedRoles.isEmpty() ? selectedRoles.get(0) : null))
@@ -423,7 +423,7 @@ public class DiscordChatListener extends ListenerAdapter {
 
         return format.replace("%name%", escape.apply(MessageUtil.strip(repliedUserName)))
                 .replace("%username%", escape.apply(MessageUtil.strip(repliedMessage.getAuthor().getName())))
-                .replace("%id%", repliedMessage.getAuthor().getId())
+                .replace("%userid%", repliedMessage.getAuthor().getId())
                 .replace("%message%", message);
     }
 

--- a/src/main/resources/messages/da.yml
+++ b/src/main/resources/messages/da.yml
@@ -26,6 +26,8 @@
 #                    eksempel: NotchIsMe
 # %username%:       persons brugernavn på Discord
 #                    eksempel: hak
+# %userid%:         person's ID on Discord
+#                    example: 1081004946872352958
 # %channelname%:    navnet på den kanal, som beskeden kommer fra
 #                    eksempel: server-chat
 # %reply%:          beskeden, der vises, når beskeden er et svar på en anden besked.
@@ -41,6 +43,8 @@
 #                   eksempel: NotchIsMe
 # %username%:      brugernavnet på den bruger, der bliver besvaret på Discord
 #                   eksempel: Notch
+# %userid%:        the ID of the user that is being replied to on Discord
+#                   example: 1081004946872352958
 # %message%:       indholdet af den besked, der besvares
 #
 # BEMÆRK: %reply% pladsholderen skal være til stede i formatet, hvis du ønsker, at DiscordToMinecraftMessageReplyFormat skal vises i din besked.

--- a/src/main/resources/messages/de.yml
+++ b/src/main/resources/messages/de.yml
@@ -28,6 +28,8 @@
 #                    z.B. NotchIsMe
 # %username%:       Name des Senders in Discord
 #                    z.B. Notch
+# %userid%:         person's ID on Discord
+#                    example: 1081004946872352958
 # %channelname%:    Name des Kanals, aus dem die Nachricht kommt
 #                    z.B. server-chat
 # %reply%:          Die Nachricht, die angezeigt wird, wenn die Nachricht eine Antwort auf eine andere Nachricht ist.
@@ -43,6 +45,8 @@
 #                    z.B. NotchIsMe
 # %username%:       Der Benutzername des Benutzers, auf den auf Discord geantwortet wird
 #                    z.B. Notch
+# %userid%:         the ID of the user that is being replied to on Discord
+#                    example: 1081004946872352958
 # %message%:        Der Inhalt der Nachricht, auf die geantwortet wird
 #
 # HINWEIS: Der Platzhalter %reply% muss im Format vorhanden sein, wenn das DiscordToMinecraftMessageReplyFormat in Ihrer Nachricht angezeigt werden soll.

--- a/src/main/resources/messages/en.yml
+++ b/src/main/resources/messages/en.yml
@@ -26,6 +26,8 @@
 #                    example: NotchIsMe
 # %username%:       person's username on Discord
 #                    example: Notch
+# %userid%:         person's ID on Discord
+#                    example: 1081004946872352958
 # %channelname%:    name of the channel that the message is coming from
 #                    example: server-chat
 # %reply%:          the message displayed when the message is a reply to another message.
@@ -41,6 +43,8 @@
 #                   example: NotchIsMe
 # %username%:      the username of the user that is being replied to on Discord
 #                   example: Notch
+# %userid%:        the ID of the user that is being replied to on Discord
+#                   example: 1081004946872352958
 # %message%:       the content of the message that is being replied to
 #
 # NOTE: The %reply% placeholder needs to be present in the format if you want the DiscordToMinecraftMessageReplyFormat to display in your message.

--- a/src/main/resources/messages/es.yml
+++ b/src/main/resources/messages/es.yml
@@ -26,6 +26,8 @@
 #                    ejemplo: NotchIsMe
 # %username%:       el nombre de la persona en Discord
 #                    ejemplo: Notch
+# %userid%:         person's ID on Discord
+#                    example: 1081004946872352958
 # %channelname%:    nombre del canal del que proviene el mensaje
 #                    ejemplo: server-chat
 # %reply%:          el mensaje que se muestra cuando el mensaje es una respuesta a otro mensaje.
@@ -41,6 +43,8 @@
 #                    ejemplo: NotchIsMe
 # %username%:       el nombre de usuario del usuario al que se responde en Discord
 #                    ejemplo: Notch
+# %userid%:         the ID of the user that is being replied to on Discord
+#                    example: 1081004946872352958
 # %message%:        el contenido del mensaje al que se responde
 #
 # NOTA: El marcador de posición %reply% debe estar presente en el formato si desea que DiscordToMinecraftMessageReplyFormat se muestre en su mensaje.

--- a/src/main/resources/messages/et.yml
+++ b/src/main/resources/messages/et.yml
@@ -26,6 +26,8 @@
 #                    example: NotchIsMe
 # %username%:       person's username on Discord
 #                    example: Notch
+# %userid%:         person's ID on Discord
+#                    example: 1081004946872352958
 # %channelname%:    name of the channel that the message is coming from
 #                    example: server-chat
 # %reply%:          the message displayed when the message is a reply to another message.
@@ -41,6 +43,8 @@
 #                   example: NotchIsMe
 # %username%:      the username of the user that is being replied to on Discord
 #                   example: Notch
+# %userid%:        the ID of the user that is being replied to on Discord
+#                   example: 1081004946872352958
 # %message%:       the content of the message that is being replied to
 #
 # NOTE: The %reply% placeholder needs to be present in the format if you want the DiscordToMinecraftMessageReplyFormat to display in your message.

--- a/src/main/resources/messages/fr.yml
+++ b/src/main/resources/messages/fr.yml
@@ -26,6 +26,8 @@
 #                    Exemple: NotchIsMe
 # %username%:       nom de l'utilisateur sur Discord
 #                    Exemple: Notch
+# %userid%:         person's ID on Discord
+#                    example: 1081004946872352958
 # %channelname%:    nom du channel depuis lequel provient le message
 #                    Exemple: server-chat
 # %reply%:          le message affiché lorsque le message est une réponse à un autre message.
@@ -41,6 +43,8 @@
 #                    Exemple: NotchIsMe
 # %username%:       le nom d'utilisateur de l'utilisateur auquel on répond sur Discord
 #                    Exemple: Notch
+# %userid%:         the ID of the user that is being replied to on Discord
+#                    example: 1081004946872352958
 # %message%:        le contenu du message auquel on répond
 #
 # REMARQUE: L'espace réservé %reply% doit être présent dans le format si vous souhaitez que le DiscordToMinecraftMessageReplyFormat s'affiche dans votre message.

--- a/src/main/resources/messages/ja.yml
+++ b/src/main/resources/messages/ja.yml
@@ -26,6 +26,8 @@
 #                    例: NotchIsMe
 # %username%:       Discordでの名前。
 #                    例: Notch
+# %userid%:         person's ID on Discord
+#                    example: 1081004946872352958
 # %channelname%:    メッセージが来るチャンネルの名前
 #                    例: server-chat
 # %reply%:          メッセージが別のメッセージへの返信である場合に表示されるメッセージ。
@@ -41,6 +43,8 @@
 #                    例:NotchIsMe
 # %username%:       Discordで返信されているユーザーのユーザー名
 #                    例:ノッチ
+# %userid%:         the ID of the user that is being replied to on Discord
+#                    example: 1081004946872352958
 # %message%: 返信されるメッセージの内容
 #
 # 注: DiscordToMinecraftMessageReplyFormatをメッセージに表示する場合は、%reply%プレースホルダーがフォーマットで存在する必要があります。

--- a/src/main/resources/messages/ko.yml
+++ b/src/main/resources/messages/ko.yml
@@ -26,6 +26,8 @@
 #                    예시: NotchIsMe
 # %username%:       디스코드 사용자 계정 이름을 표시합니다.
 #                    예시: Notch
+# %userid%:         person's ID on Discord
+#                    example: 1081004946872352958
 # %channelname%:    메시지가 전송된 디스코드 채널의 이름을 표시합니다.
 #                    예시: server-chat
 # %reply%:          메시지가 다른 메시지에 대한 응답 일 때 표시되는 메시지입니다.
@@ -41,6 +43,8 @@
 #                    예: NotchIsMe
 # %username%:       Discord에서 응답되는 사용자의 사용자 이름
 #                    예: Notch
+# %userid%:         the ID of the user that is being replied to on Discord
+#                    example: 1081004946872352958
 # %message%:         회신중인 메시지의 내용
 #
 # 참고: DiscordToMinecraftMessageReplyFormat을 메시지에 표시하려면 %reply% 자리 표시자가 형식으로 있어야합니다.

--- a/src/main/resources/messages/nl.yml
+++ b/src/main/resources/messages/nl.yml
@@ -26,6 +26,8 @@
 #                    Bijvoorbeeld: NotchIsMe
 # %username%:       De gebruikersnaam van de persoon op Discord
 #                    Bijvoorbeeld: Notch
+# %userid%:         person's ID on Discord
+#                    example: 1081004946872352958
 # %channelname%:    De naam van de channel waar het bericht vandaan komt.
 #                    Bijvoorbeeld: server-chat
 # %reply%:          het bericht dat wordt weergegeven als het bericht een antwoord is op een ander bericht.
@@ -41,6 +43,8 @@
 #                    Bijvoorbeeld: NotchIsMe
 # %gebruikersnaam%: de gebruikersnaam van de gebruiker waarop op Discord wordt gereageerd
 #                    Bijvoorbeeld: Notch
+# %userid%:         the ID of the user that is being replied to on Discord
+#                    example: 1081004946872352958
 # %message%:        de inhoud van het bericht waarop wordt gereageerd
 #
 # OPMERKING: De tijdelijke aanduiding %reply% moet aanwezig zijn in de indeling als u wilt dat de DiscordToMinecraftMessageReplyFormat in uw bericht wordt weergegeven.

--- a/src/main/resources/messages/pl.yml
+++ b/src/main/resources/messages/pl.yml
@@ -26,6 +26,8 @@
 #                     przykład: NotchIsMe
 # %username%:        nazwa użytkownika osoby na Discordzie
 #                     przykład: Notch
+# %userid%:          person's ID on Discord
+#                     example: 1081004946872352958
 # %channelname%:     nazwa kanału, z którego pochodzi wiadomość
 #                     przykład: czat-serwer
 # %reply%:           komunikat wyświetlany, gdy wiadomość jest odpowiedzią na inną wiadomość.
@@ -41,6 +43,8 @@
 #                   przykład: NotchIsMe
 # %username%:      nazwa użytkownika, na który udzielono odpowiedzi na Discordzie
 #                   przykład: Notch
+# %userid%:        the ID of the user that is being replied to on Discord
+#                   example: 1081004946872352958
 # %message%:       treść wiadomości, na którą udzielono odpowiedzi
 #
 # UWAGA: Symbol zastępczy %reply% musi być obecny w formacie, jeśli chcesz, aby DiscordToMinecraftMessageReplyFormat był wyświetlany w Twojej wiadomości.

--- a/src/main/resources/messages/ru.yml
+++ b/src/main/resources/messages/ru.yml
@@ -26,6 +26,8 @@
 #                    пример: NotchIsMe
 # %username%:       пользователя в Discord
 #                    пример: Notch
+# %userid%:         person's ID on Discord
+#                    example: 1081004946872352958
 # %channelname%:    имя канала, из которого поступает сообщение
 #                    пример: server-chat
 # %reply%:          сообщение, отображаемое, когда сообщение является ответом на другое сообщение.
@@ -41,6 +43,8 @@
 #                    example: NotchIsMe
 # %username%:       имя пользователя, которому отвечают в Discord.
 #                    пример: Notch
+# %userid%:         the ID of the user that is being replied to on Discord
+#                    example: 1081004946872352958
 # %message%:        содержание сообщения, на которое идет ответ
 #
 # ПРИМЕЧАНИЕ: Заполнитель %reply% должен присутствовать в формате, если вы хотите, чтобы DiscordToMinecraftMessageReplyFormat отображался в вашем сообщении.

--- a/src/main/resources/messages/uk.yml
+++ b/src/main/resources/messages/uk.yml
@@ -26,6 +26,8 @@
 #                    приклад: NotchIsMe
 # %username%:       користувача в Discord
 #                    приклад: Notch
+# %userid%:         person's ID on Discord
+#                    example: 1081004946872352958
 # %channelname%:    ім'я каналу, з якого надходить повідомлення
 #                    приклад: server-chat
 # %reply%:          повідомлення, яке відображається, коли повідомлення є відповіддю на інше повідомлення.
@@ -41,6 +43,8 @@
 #                    example: NotchIsMe
 # %username%:       ім'я користувача, якому відповідають у Discord.
 #                    приклад: Notch
+# %userid%:         the ID of the user that is being replied to on Discord
+#                    example: 1081004946872352958
 # %message%:        зміст повідомлення, на яке йде відповідь
 #
 # ПРИМІТКА: Заповнення %reply% має бути у форматі, якщо ви бажаєте, щоб DiscordToMinecraftMessageReplyFormat відображався у вашому повідомленні.

--- a/src/main/resources/messages/zh.yml
+++ b/src/main/resources/messages/zh.yml
@@ -26,6 +26,8 @@
 #                    範例: NotchIsMe
 # %username%:       Discord的用戶名。
 #                    範例: Notch
+# %userid%:         person's ID on Discord
+#                    example: 1081004946872352958
 # %channelname%:    發送訊息的頻道名稱
 #                    範例: server-chat
 # %reply%:         當該消息是對另一條消息的答覆時顯示的消息。
@@ -41,6 +43,8 @@
 #                   範例:NotchIsMe
 # %username%:      在Discord上被回復的用戶的用戶名
 #                   範例:缺口
+# %userid%:        the ID of the user that is being replied to on Discord
+#                   example: 1081004946872352958
 # %message%:       要回復的消息內容
 #
 # 注意：如果您希望 DiscordToMinecraftMessageReplyFormat 顯示在您的消息中，則 %reply% 佔位符需要以格式存在。


### PR DESCRIPTION
This adds the placeholder `%userid%` for and Discord -> Minecraft messages and replies
## Why?
Ideal use case is with MiniMessage's `<insert>` to let Minecraft players ping Discord users without having to grab their ID from the Discord. The following messages.yml config example showcases the use of these new placeholders:
```yml
DiscordToMinecraftChatMessageFormat: '%reply%[<aqua>Discord</aqua> | %toprolecolor%%toprolealias%<reset>] <insert:"<@%userid%>">%name%</insert> » %message%'
DiscordToMinecraftChatMessageFormatNoRole: '%reply%[<aqua>Discord</aqua>] <insert:"<@%userid%>">%name%</insert> » %message%'
DiscordToMinecraftAllRolesSeparator: ' | '
DiscordToMinecraftMessageReplyFormat: '<insert:"<@%userid%>"><hover:show_text:"%name% » %message%">[REPLY]</hover></insert> '
```
Now if you hold shift and click a Discord user's name, their mention will be inserted in the Minecraft chat.
Other possible use cases would be `<click>` tags to run commands that use the user's ID
If translation for these is needed, I'm able to do English and Spanish