### PR TITLE
Debugger: Include " /discord" lines in relevant log lines.

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/util/DebugUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/DebugUtil.java
@@ -208,7 +208,7 @@ public class DebugUtil {
                 String line = br.readLine();
                 if (line == null) done = true;
                 else if (
-                    (line.toLowerCase().contains("discordsrv") && !line.toLowerCase().contains("[discordsrv] chat:"))
+                    line.toLowerCase().contains("discordsrv") && !line.toLowerCase().contains("[discordsrv] chat:")
                     || line.toLowerCase().contains(" /discord")
                 ) output.add(DiscordUtil.aggressiveStrip(line));
             }

--- a/src/main/java/github/scarsz/discordsrv/util/DebugUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/DebugUtil.java
@@ -207,11 +207,10 @@ public class DebugUtil {
             while (!done) {
                 String line = br.readLine();
                 if (line == null) done = true;
-                if (line != null
-                        && line.toLowerCase().contains("discordsrv")
-                        && !line.toLowerCase().contains("[discordsrv] chat:")) {
-                    output.add(DiscordUtil.aggressiveStrip(line));
-                }
+                else if (
+                    (line.toLowerCase().contains("discordsrv") && !line.toLowerCase().contains("[discordsrv] chat:"))
+                    || line.toLowerCase().contains(" /discord")
+                ) output.add(DiscordUtil.aggressiveStrip(line));
             }
         } catch (IOException e) {
             DiscordSRV.error(e);


### PR DESCRIPTION
This would be useful for making sure someone has followed the necessary debugging steps if they used `/discord ...` instead of `/discordsrv ...`.