### PR TITLE
Migrate ProxyHost option with new default value

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/util/ConfigUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/ConfigUtil.java
@@ -128,6 +128,8 @@ public class ConfigUtil {
             if (option.equals("AvatarUrl") && value.contains("https://crafatar.com")) {
                 DiscordSRV.warning("AvatarUrl config option contained \"https://crafatar.com\"; Crafatar no longer allows queries from Discord so the new default provider will be used instead.");
                 value = "\"\"";
+            } else if (option.equals("ProxyHost") && value.equals("\"https://example.com\"")) {
+                value = "\"example.com\"";
             }
             optionValue = new StringBuilder(value);
         }


### PR DESCRIPTION
Currently, updating from the release to the snapshot means the old ProxyHost default value stays in the config, so the plugin sees the value as non-default and tries to use it.

Since the new default is a correction, it is better to convert it than to have the plugin ignore it too.