### PR TITLE
Fix "Could not find org.bukkit.craftbukkit.advancement.CraftAdvancement" on 1.8.8

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/util/NMSUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/NMSUtil.java
@@ -75,8 +75,12 @@ public class NMSUtil {
                 }
             }
 
-            class_Advancement = fixBukkitClass("org.bukkit.craftbukkit.advancement.CraftAdvancement");
-            method_Advancement_getHandle = class_Advancement.getMethod("getHandle");
+            try {
+                class_Advancement = fixBukkitClass("org.bukkit.craftbukkit.advancement.CraftAdvancement");
+                method_Advancement_getHandle = class_Advancement.getMethod("getHandle");
+            } catch (ClassNotFoundException ex) {
+                // Unsupported on the server
+            }
 
             class_CraftPlayer = fixBukkitClass("org.bukkit.craftbukkit.entity.CraftPlayer");
             method_CraftPlayer_getHandle = class_CraftPlayer.getMethod("getHandle");
@@ -193,7 +197,7 @@ public class NMSUtil {
         return null;
     }
 
-    public static Object getHandle(Advancement advancement) {
+    public static Object getHandle(Object advancement) {
         if (failed) return null;
 
         try {


### PR DESCRIPTION
Tested and confirmed fixed. Thanks for your consideration in pulling this.