### PR TITLE
Fix NPE when account link manager hasn't been created yet

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordAccountLinkListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordAccountLinkListener.java
@@ -92,6 +92,12 @@ public class DiscordAccountLinkListener extends ListenerAdapter {
     @Override
     public void onGuildMemberJoin(GuildMemberJoinEvent event) {
         Member member = event.getMember();
+
+        if (DiscordSRV.getPlugin().getAccountLinkManager() == null) {
+            DiscordSRV.debug(Debug.ACCOUNT_LINKING, "AccountLinkManager is null, not processing join event");
+            return;
+        }
+
         // add linked role and nickname back to people when they rejoin the server
         UUID uuid = DiscordSRV.getPlugin().getAccountLinkManager().getUuid(event.getUser().getId());
         if (uuid != null) {


### PR DESCRIPTION
On large servers with a lot of users constantly joining and leaving, it isn't rare for people to join the Discord server in between the Discord bot starting and the account link manager being created