### PR TITLE
Include author in DiscordGuildMessagePreBroadcastEvent

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -1882,7 +1882,7 @@ public class DiscordSRV extends JavaPlugin {
         if (chatHook == null || channel == null) {
             if (channel != null && !channel.equalsIgnoreCase("global")) return; // don't send messages for non-global channels with no plugin hooks
             DiscordGuildMessagePreBroadcastEvent preBroadcastEvent = api.callEvent(new DiscordGuildMessagePreBroadcastEvent
-                    (channel, message, PlayerUtil.getOnlinePlayers()));
+                    (author, channel, message, PlayerUtil.getOnlinePlayers()));
             message = preBroadcastEvent.getMessage();
             channel = preBroadcastEvent.getChannel();
             MessageUtil.sendMessage(preBroadcastEvent.getRecipients(), message);

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePreBroadcastEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePreBroadcastEvent.java
@@ -20,6 +20,7 @@
 
 package github.scarsz.discordsrv.api.events;
 
+import net.dv8tion.jda.api.entities.User;
 import net.kyori.adventure.text.Component;
 import org.bukkit.command.CommandSender;
 
@@ -34,14 +35,20 @@ import java.util.List;
 @SuppressWarnings("LombokGetterMayBeUsed")
 public class DiscordGuildMessagePreBroadcastEvent extends Event {
 
+    private final User author;
     private String channel;
     private Component message;
     private final List<? extends CommandSender> recipients;
 
-    public DiscordGuildMessagePreBroadcastEvent(String channel, Component message, List<? extends CommandSender> recipients) {
+    public DiscordGuildMessagePreBroadcastEvent(User author, String channel, Component message, List<? extends CommandSender> recipients) {
+        this.author = author;
         this.channel = channel;
         this.message = message;
         this.recipients = recipients;
+    }
+
+    public User getAuthor() {
+        return this.author;
     }
 
     public String getChannel() {


### PR DESCRIPTION
In lieu of a native `/ignore` feature not coming back (https://github.com/DiscordSRV/DiscordSRV/issues/603), I'm working on an addon to `/ignore` Discord-to-MC messages from specific users, through subscribing to [`DiscordGuildMessagePreBroadcastEvent`](https://github.com/DiscordSRV/DiscordSRV/blob/master/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePreBroadcastEvent.java) and altering recipients. I need the author of the Discord message to do so, however currently this requires storing the author from [`DiscordGuildMessagePostProcessEvent`](https://github.com/DiscordSRV/DiscordSRV/blob/master/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePostProcessEvent.java) and later grabbing it based on the message. This is feels like a hacky and cumbersome workaround, given that the author is available in the method that fires `DiscordGuildMessagePreBroadcastEvent`: [`‎DiscordSRV::broadcastMessageToMinecraftServer‎`](https://github.com/DiscordSRV/DiscordSRV/blob/master/src/main/java/github/scarsz/discordsrv/DiscordSRV.java#L1876).

Having the author be accessible from `DiscordGuildMessagePreBroadcastEvent` would eliminate the need for a workaround and make it trivial to implement `/ignore` syncing as an addon (possibly closing https://github.com/DiscordSRV/DiscordSRV/issues/1234 and https://github.com/DiscordSRV/DiscordSRV/issues/1625).