### PR TITLE
Expand DiscordGuildMessagePreBroadcastEvent API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -180,7 +180,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
-    maven("https://papermc.io/repo/repository/maven-public/")
+    maven("https://repo.papermc.io/repository/maven-public/")
     maven("https://oss.sonatype.org/content/repositories/snapshots")
     maven("https://s01.oss.sonatype.org/content/repositories/snapshots")
     maven("https://nexus.scarsz.me/content/groups/public/")

--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -1882,13 +1882,13 @@ public class DiscordSRV extends JavaPlugin {
         if (chatHook == null || channel == null) {
             if (channel != null && !channel.equalsIgnoreCase("global")) return; // don't send messages for non-global channels with no plugin hooks
             DiscordGuildMessagePreBroadcastEvent preBroadcastEvent = api.callEvent(new DiscordGuildMessagePreBroadcastEvent
-                    (channel, message, PlayerUtil.getOnlinePlayers()));
+                    (channel, message, author, PlayerUtil.getOnlinePlayers()));
             message = preBroadcastEvent.getMessage();
             channel = preBroadcastEvent.getChannel();
             MessageUtil.sendMessage(preBroadcastEvent.getRecipients(), message);
             PlayerUtil.notifyPlayersOfMentions(null, MessageUtil.toLegacy(message));
         } else {
-            chatHook.broadcastMessageToChannel(channel, message);
+            chatHook.broadcastMessageToChannel(channel, message, author);
 
             // hacky fix to avoid api breakage :/
             message = message.replaceText(TextReplacementConfig.builder()

--- a/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePreBroadcastEvent.java
+++ b/src/main/java/github/scarsz/discordsrv/api/events/DiscordGuildMessagePreBroadcastEvent.java
@@ -20,27 +20,36 @@
 
 package github.scarsz.discordsrv.api.events;
 
+import net.dv8tion.jda.api.entities.User;
 import net.kyori.adventure.text.Component;
 import org.bukkit.command.CommandSender;
 
 import java.util.List;
 
+
 /**
- * <p>If there are no chat hooks found this event is called directly before a message from Discord is processed
- * and broadcasted to the Minecraft server</p>
+ * <p>Called before DiscordSRV broadcasts a message to a chat channel on the Minecraft server.</p>
+ *
+ * <p>Depending on the type of chat plugin used, {@link #getRecipients()} may return an immutable list.
+ * Using {@link #isRecipientsMutable()} can be used to check if the list is mutable, and recipients can
+ * be added or removed.</p>
+ *
+ * <p>Currently, only TownyChat and VentureChat support mutable recipient lists.</p>
  *
  * <p>At the time this event is called, the message, channel, and recipients can still be changed</p>
  */
-@SuppressWarnings("LombokGetterMayBeUsed")
+@SuppressWarnings({"LombokGetterMayBeUsed", "LombokSetterMayBeUsed"})
 public class DiscordGuildMessagePreBroadcastEvent extends Event {
 
     private String channel;
     private Component message;
+    private final User author;
     private final List<? extends CommandSender> recipients;
 
-    public DiscordGuildMessagePreBroadcastEvent(String channel, Component message, List<? extends CommandSender> recipients) {
+    public DiscordGuildMessagePreBroadcastEvent(String channel, Component message, User author, List<? extends CommandSender> recipients) {
         this.channel = channel;
         this.message = message;
+        this.author = author;
         this.recipients = recipients;
     }
 
@@ -50,6 +59,10 @@ public class DiscordGuildMessagePreBroadcastEvent extends Event {
 
     public Component getMessage() {
         return this.message;
+    }
+
+    public User getAuthor() {
+        return author;
     }
 
     public List<? extends CommandSender> getRecipients() {
@@ -62,5 +75,17 @@ public class DiscordGuildMessagePreBroadcastEvent extends Event {
 
     public void setMessage(Component message) {
         this.message = message;
+    }
+
+    public boolean isRecipientsMutable() {
+        // You can really only check if a list is mutable
+        // in java by trying to add or remove an element.
+        try {
+            recipients.add(null);
+            recipients.remove(null);
+            return true;
+        } catch (UnsupportedOperationException e) {
+            return false;
+        }
     }
 }

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/ChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/ChatHook.java
@@ -22,6 +22,7 @@ package github.scarsz.discordsrv.hooks.chat;
 
 import github.scarsz.discordsrv.hooks.PluginHook;
 import github.scarsz.discordsrv.util.MessageUtil;
+import net.dv8tion.jda.api.entities.User;
 import net.kyori.adventure.text.Component;
 
 public interface ChatHook extends PluginHook {
@@ -31,7 +32,7 @@ public interface ChatHook extends PluginHook {
         throw new UnsupportedOperationException(getClass().getName() + " has no implementation for broadcastMessageToChannel");
     }
 
-    default void broadcastMessageToChannel(String channel, Component message) {
+    default void broadcastMessageToChannel(String channel, Component message, User author) {
         broadcastMessageToChannel(channel, MessageUtil.toLegacy(message));
     }
 

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/HerochatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/HerochatHook.java
@@ -26,16 +26,20 @@ import com.dthielke.herochat.Chatter;
 import com.dthielke.herochat.Herochat;
 import github.scarsz.discordsrv.Debug;
 import github.scarsz.discordsrv.DiscordSRV;
+import github.scarsz.discordsrv.api.events.DiscordGuildMessagePreBroadcastEvent;
 import github.scarsz.discordsrv.util.LangUtil;
 import github.scarsz.discordsrv.util.MessageUtil;
 import github.scarsz.discordsrv.util.PlayerUtil;
 import github.scarsz.discordsrv.util.PluginUtil;
+import net.dv8tion.jda.api.entities.User;
 import net.kyori.adventure.text.Component;
 import org.apache.commons.lang3.StringUtils;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.plugin.Plugin;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -50,9 +54,18 @@ public class HerochatHook implements ChatHook {
     }
 
     @Override
-    public void broadcastMessageToChannel(String channel, Component message) {
+    public void broadcastMessageToChannel(String channel, Component message, User author) {
         Channel chatChannel = getChannelByCaseInsensitiveName(channel);
         if (chatChannel == null) return; // no suitable channel found
+
+        DiscordGuildMessagePreBroadcastEvent event = DiscordSRV.api.callEvent(new DiscordGuildMessagePreBroadcastEvent
+                (channel, message, author, Collections.unmodifiableList(getChannelRecipients(chatChannel))));
+        message = event.getMessage();
+        if (!channel.equals(event.getChannel())) {
+            chatChannel = getChannelByCaseInsensitiveName(event.getChannel());
+            if (chatChannel == null) return; // no suitable channel found
+        }
+
         String legacy = MessageUtil.toLegacy(message);
 
         String plainMessage = LangUtil.Message.CHAT_CHANNEL_MESSAGE.toString()
@@ -64,12 +77,8 @@ public class HerochatHook implements ChatHook {
         String translatedMessage = MessageUtil.translateLegacy(plainMessage);
         chatChannel.sendRawMessage(translatedMessage);
 
-        PlayerUtil.notifyPlayersOfMentions(player ->
-                        chatChannel.getMembers().stream()
-                                .map(Chatter::getPlayer)
-                                .collect(Collectors.toList())
-                                .contains(player),
-                legacy);
+        List<Player> recipients = getChannelRecipients(chatChannel);
+        PlayerUtil.notifyPlayersOfMentions(recipients::contains, legacy);
     }
 
     private static Channel getChannelByCaseInsensitiveName(String name) {
@@ -94,4 +103,13 @@ public class HerochatHook implements ChatHook {
         return PluginUtil.getPlugin("Herochat");
     }
 
+
+    private List<Player> getChannelRecipients(Channel channel) {
+        return PlayerUtil.getOnlinePlayers().stream()
+                .filter(player -> channel.getMembers().stream()
+                        .map(Chatter::getPlayer)
+                        .collect(Collectors.toList())
+                        .contains(player))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/NChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/NChatHook.java
@@ -22,16 +22,22 @@ package github.scarsz.discordsrv.hooks.chat;
 
 import com.nickuc.chat.api.events.PublicMessageEvent;
 import com.nickuc.chat.api.nChatAPI;
+import com.nickuc.chat.channel.PublicChannel;
 import github.scarsz.discordsrv.DiscordSRV;
+import github.scarsz.discordsrv.api.events.DiscordGuildMessagePreBroadcastEvent;
 import github.scarsz.discordsrv.util.LangUtil;
 import github.scarsz.discordsrv.util.MessageUtil;
 import github.scarsz.discordsrv.util.PlayerUtil;
 import github.scarsz.discordsrv.util.PluginUtil;
+import net.dv8tion.jda.api.entities.User;
 import net.kyori.adventure.text.Component;
 import org.bukkit.ChatColor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.plugin.Plugin;
+
+import java.util.Collections;
+import java.util.Optional;
 
 public class NChatHook implements ChatHook {
 
@@ -41,23 +47,33 @@ public class NChatHook implements ChatHook {
     }
 
     @Override
-    public void broadcastMessageToChannel(String channelName, Component message) {
-        nChatAPI.getApi().getChannelByName(channelName).ifPresent(chatChannel -> {
-            String legacy = MessageUtil.toLegacy(message);
-            String chatChannelCommand = chatChannel.getCommand();
-            String chatChannelNickname = chatChannelCommand != null ? chatChannelCommand : Character.toString(chatChannel.getName().charAt(0));
-            String chatChannelColor = ChatColor.getLastColors(chatChannel.getFormat());
+    public void broadcastMessageToChannel(String channelName, Component message, User author) {
+        DiscordGuildMessagePreBroadcastEvent event = DiscordSRV.api.callEvent(new DiscordGuildMessagePreBroadcastEvent
+                (channelName, message, author, Collections.emptyList())); // I don't see how we can include the recipients on this one
+        channelName = event.getChannel();
+        message = event.getMessage();
 
-            String plainMessage = LangUtil.Message.CHAT_CHANNEL_MESSAGE.toString()
-                    .replace("%channelname%", chatChannel.getName())
-                    .replace("%channelnickname%", chatChannelNickname)
-                    .replace("%message%", legacy)
-                    .replace("%channelcolor%", MessageUtil.toLegacy(MessageUtil.toComponent(MessageUtil.translateLegacy(chatChannelColor))));
 
-            String translatedMessage = MessageUtil.translateLegacy(plainMessage);
-            nChatAPI.getApi().handleVirtualMessage(translatedMessage, chatChannel, virtualMessageEvent ->
-                    PlayerUtil.notifyPlayersOfMentions(player -> virtualMessageEvent.getRecipients().contains(player), legacy));
-        });
+        Optional<PublicChannel> optionalChatChannel = nChatAPI.getApi().getChannelByName(channelName);
+        if (!optionalChatChannel.isPresent()) return;
+
+        PublicChannel chatChannel = optionalChatChannel.get();
+
+
+        String legacy = MessageUtil.toLegacy(message);
+        String chatChannelCommand = chatChannel.getCommand();
+        String chatChannelNickname = chatChannelCommand != null ? chatChannelCommand : Character.toString(chatChannel.getName().charAt(0));
+        String chatChannelColor = ChatColor.getLastColors(chatChannel.getFormat());
+
+        String plainMessage = LangUtil.Message.CHAT_CHANNEL_MESSAGE.toString()
+                .replace("%channelname%", chatChannel.getName())
+                .replace("%channelnickname%", chatChannelNickname)
+                .replace("%message%", legacy)
+                .replace("%channelcolor%", MessageUtil.toLegacy(MessageUtil.toComponent(MessageUtil.translateLegacy(chatChannelColor))));
+
+        String translatedMessage = MessageUtil.translateLegacy(plainMessage);
+        nChatAPI.getApi().handleVirtualMessage(translatedMessage, chatChannel, virtualMessageEvent ->
+                PlayerUtil.notifyPlayersOfMentions(player -> virtualMessageEvent.getRecipients().contains(player), legacy));
     }
 
     @Override

--- a/src/main/java/github/scarsz/discordsrv/hooks/chat/TownyChatHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/chat/TownyChatHook.java
@@ -25,10 +25,12 @@ import com.palmergames.bukkit.TownyChat.channels.Channel;
 import com.palmergames.bukkit.TownyChat.events.AsyncChatHookEvent;
 import github.scarsz.discordsrv.Debug;
 import github.scarsz.discordsrv.DiscordSRV;
+import github.scarsz.discordsrv.api.events.DiscordGuildMessagePreBroadcastEvent;
 import github.scarsz.discordsrv.util.LangUtil;
 import github.scarsz.discordsrv.util.MessageUtil;
 import github.scarsz.discordsrv.util.PlayerUtil;
 import github.scarsz.discordsrv.util.PluginUtil;
+import net.dv8tion.jda.api.entities.User;
 import net.kyori.adventure.text.Component;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
@@ -39,6 +41,7 @@ import org.bukkit.plugin.Plugin;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class TownyChatHook implements ChatHook {
 
@@ -93,7 +96,7 @@ public class TownyChatHook implements ChatHook {
     }
 
     @Override
-    public void broadcastMessageToChannel(String channel, Component message) {
+    public void broadcastMessageToChannel(String channel, Component message, User author) {
         // get instance of TownyChat plugin
         Chat instance = (Chat) Bukkit.getPluginManager().getPlugin("TownyChat");
 
@@ -105,22 +108,35 @@ public class TownyChatHook implements ChatHook {
 
         // return if channel was not available
         if (destinationChannel == null) return;
-        String legacy = MessageUtil.toLegacy(message);
 
+
+        Channel finalDestinationChannel = destinationChannel;
+        List<Player> recipients = PlayerUtil.getOnlinePlayers().stream()
+                .filter(player -> finalDestinationChannel.isPresent(player.getName()))
+                .collect(Collectors.toList());
+        DiscordGuildMessagePreBroadcastEvent event = DiscordSRV.api.callEvent(new DiscordGuildMessagePreBroadcastEvent(channel, message, author, recipients));
+        message = event.getMessage();
+
+        if (!channel.equals(event.getChannel())) {
+            destinationChannel = getChannelByCaseInsensitiveName(event.getChannel());
+            if (destinationChannel == null) return;
+        }
+
+        String legacy = MessageUtil.toLegacy(message);
         String plainMessage = LangUtil.Message.CHAT_CHANNEL_MESSAGE.toString()
                 .replace("%channelcolor%", destinationChannel.getMessageColour() != null ? destinationChannel.getMessageColour() : "")
                 .replace("%channelname%", destinationChannel.getName())
                 .replace("%channelnickname%", destinationChannel.getChannelTag() != null ? destinationChannel.getChannelTag() : "")
                 .replace("%message%", legacy);
-
         String translatedMessage = MessageUtil.translateLegacy(plainMessage);
-        for (Player player : PlayerUtil.getOnlinePlayers()) {
-            if (destinationChannel.isPresent(player.getName())) {
-                MessageUtil.sendMessage(player, translatedMessage);
-            }
+
+        for (Player player : recipients) {
+            MessageUtil.sendMessage(player, translatedMessage);
         }
 
-        PlayerUtil.notifyPlayersOfMentions(player -> destinationChannel.isPresent(player.getName()), legacy);
+
+        Channel finalDestinationChannel1 = destinationChannel;
+        PlayerUtil.notifyPlayersOfMentions(player -> finalDestinationChannel1.isPresent(player.getName()), legacy);
     }
 
     private static Channel getChannelByCaseInsensitiveName(String name) {


### PR DESCRIPTION
This PR expands this class' API so that the event is no longer *just* tied to broadcasting and now supports all the external plugins DiscordSRV hooks into.

It's not perfect, and the `recipients` list is unmodifiable in every `ChatHook` except for **TownyChat** and **VentureChat** because modifying the recievers isn't possible without changing the chat channel.

Majority of servers are using external chat plugins and not being able edit who can recieve XYZ message without cancelling the entire beforehand with something like `DiscordGuildMessagePreProcessEvent` limits what we can do with the API. _(e.g. No `/ignore` command capabilities or ignoring a specific player, no turning off DIscordSRV in-game chat for specific players, etc.)_

Some of these `ChatHook`s can also be edited to support modifying the recipient list later on in this PR too.