### PR TITLE
Add support for using fully qualified names in alerts, deprecate using simple names in alerts

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/modules/alerts/AlertListener.java
+++ b/src/main/java/github/scarsz/discordsrv/modules/alerts/AlertListener.java
@@ -212,10 +212,10 @@ public class AlertListener implements Listener, EventListener {
                     Method method = null;
                     Class<?> handlerListClass = eventClass;
                     while (method == null && handlerListClass != null) {
-                        handlerListClass = handlerListClass.getSuperclass();
                         try {
-                            method = eventClass.getDeclaredMethod("getHandlerList");
+                            method = handlerListClass.getDeclaredMethod("getHandlerList");
                         } catch (NoSuchMethodException ignored) {}
+                        handlerListClass = handlerListClass.getSuperclass();
                     }
 
                     if (method == null) {

--- a/src/main/java/github/scarsz/discordsrv/modules/alerts/AlertListener.java
+++ b/src/main/java/github/scarsz/discordsrv/modules/alerts/AlertListener.java
@@ -276,7 +276,8 @@ public class AlertListener implements Listener, EventListener {
 
     private void runAlertsForEvent(Object event) {
         boolean command = event instanceof PlayerCommandPreprocessEvent || event instanceof ServerCommandEvent;
-        String eventClassName = event.getClass().getName();
+
+        String eventClassName = getEventClassName(event);
         boolean active = (command && anyCommandTrigger)
                 || activeTriggers.contains(eventClassName.toLowerCase(Locale.ROOT))
                 || activeTriggers.contains(getEventName(event).toLowerCase(Locale.ROOT));
@@ -367,6 +368,11 @@ public class AlertListener implements Listener, EventListener {
         return finalTriggers;
     }
 
+    private String getEventClassName(Object event) {
+        return event.getClass().getName()
+                .replace("github.scarsz.discordsrv.dependencies.jda", "net.".concat("dv8tion.jda"));
+    }
+
     private String getEventName(Object event) {
         return event instanceof Event ? ((Event) event).getEventName() : event.getClass().getSimpleName();
     }
@@ -410,7 +416,7 @@ public class AlertListener implements Listener, EventListener {
 
         MessageFormat messageFormat = DiscordSRV.getPlugin().getMessageFromConfiguration("Alerts." + alertIndex);
 
-        String eventClassName = event.getClass().getName();
+        String eventClassName = getEventClassName(event);
         String eventName = getEventName(event);
         for (String trigger : triggers) {
             if (trigger.startsWith("/")) {

--- a/src/main/resources/alerts/da.yml
+++ b/src/main/resources/alerts/da.yml
@@ -79,7 +79,7 @@
 #
 Alerts:
   # Eksempel konfiguration på at sende en besked til "fish" DiscordSRV kanal, når en spiller successfuldt fanger en fisk
-  #- Trigger: PlayerFishEvent
+  #- Trigger: org.bukkit.event.player.PlayerFishEvent
   #  Channel: fisk
   #  Conditions:
   #    - state.name() == 'CAUGHT_FISH'
@@ -90,7 +90,7 @@ Alerts:
   #      Name: "{name} fangede en ${caught.itemStack.type.name()}!"
 
   # Eksempel konfiguration til at sende Matrix anti-cheat beskeder
-  #- Trigger: PlayerViolationEvent
+  #- Trigger: me.rerere.matrix.api.events.PlayerViolationEvent
   #  Channel: matrix
   #  Conditions:
   #    - violations >= 5 # Ikke send events til spillere med < 5 krænkelser

--- a/src/main/resources/alerts/de.yml
+++ b/src/main/resources/alerts/de.yml
@@ -79,7 +79,7 @@
 #
 Alerts:
   # Example config to send messages to the "fish" DiscordSRV channel when a player successfully catches a fish
-  #- Trigger: PlayerFishEvent
+  #- Trigger: org.bukkit.event.player.PlayerFishEvent
   #  Channel: fish
   #  Conditions:
   #    - state.name() == 'CAUGHT_FISH'
@@ -90,7 +90,7 @@ Alerts:
   #      Name: "{name} caught a ${caught.itemStack.type.name()}!"
 
   # Example config to send Matrix anti-cheat messages
-  #- Trigger: PlayerViolationEvent
+  #- Trigger: me.rerere.matrix.api.events.PlayerViolationEvent
   #  Channel: matrix
   #  Conditions:
   #    - violations >= 5 # don't send events for players with < 5 violations

--- a/src/main/resources/alerts/en.yml
+++ b/src/main/resources/alerts/en.yml
@@ -79,7 +79,7 @@
 #
 Alerts:
   # Example config to send messages to the "fish" DiscordSRV channel when a player successfully catches a fish
-  #- Trigger: PlayerFishEvent
+  #- Trigger: org.bukkit.event.player.PlayerFishEvent
   #  Channel: fish
   #  Conditions:
   #    - state.name() == 'CAUGHT_FISH'
@@ -90,7 +90,7 @@ Alerts:
   #      Name: "{name} caught a ${caught.itemStack.type.name()}!"
 
   # Example config to send Matrix anti-cheat messages
-  #- Trigger: PlayerViolationEvent
+  #- Trigger: me.rerere.matrix.api.events.PlayerViolationEvent
   #  Channel: matrix
   #  Conditions:
   #    - violations >= 5 # don't send events for players with < 5 violations

--- a/src/main/resources/alerts/es.yml
+++ b/src/main/resources/alerts/es.yml
@@ -79,7 +79,7 @@
 #
 Alerts:
   # Example config to send messages to the "fish" DiscordSRV channel when a player successfully catches a fish
-  #- Trigger: PlayerFishEvent
+  #- Trigger: org.bukkit.event.player.PlayerFishEvent
   #  Channel: fish
   #  Conditions:
   #    - state.name() == 'CAUGHT_FISH'
@@ -90,7 +90,7 @@ Alerts:
   #      Name: "{name} caught a ${caught.itemStack.type.name()}!"
 
   # Example config to send Matrix anti-cheat messages
-  #- Trigger: PlayerViolationEvent
+  #- Trigger: me.rerere.matrix.api.events.PlayerViolationEvent
   #  Channel: matrix
   #  Conditions:
   #    - violations >= 5 # don't send events for players with < 5 violations

--- a/src/main/resources/alerts/et.yml
+++ b/src/main/resources/alerts/et.yml
@@ -79,7 +79,7 @@
 #
 Alerts:
   # Example config to send messages to the "fish" DiscordSRV channel when a player successfully catches a fish
-  #- Trigger: PlayerFishEvent
+  #- Trigger: org.bukkit.event.player.PlayerFishEvent
   #  Channel: fish
   #  Conditions:
   #    - state.name() == 'CAUGHT_FISH'
@@ -90,7 +90,7 @@ Alerts:
   #      Name: "{name} püüdis ${caught.itemStack.type.name()}!"
 
   # Example config to send Matrix anti-cheat messages
-  #- Trigger: PlayerViolationEvent
+  #- Trigger: me.rerere.matrix.api.events.PlayerViolationEvent
   #  Channel: matrix
   #  Conditions:
   #    - violations >= 5 # don't send events for players with < 5 violations

--- a/src/main/resources/alerts/fr.yml
+++ b/src/main/resources/alerts/fr.yml
@@ -79,7 +79,7 @@
 #
 Alerts:
   # Exemple de configuration pour envoyer des messages au canal "fish" de DiscordSRV lorsqu'un joueur attrape un poisson avec succès
-  #- Trigger: PlayerFishEvent
+  #- Trigger: org.bukkit.event.player.PlayerFishEvent
   #  Channel: fish
   #  Conditions:
   #    - state.name() == 'CAUGHT_FISH'
@@ -90,7 +90,7 @@ Alerts:
   #      Name: "{name} a attrapé un ${caught.itemStack.type.name()}!"
 
   # Exemple de configuration pour envoyer des messages anti-triche Matrix
-  #- Trigger: PlayerViolationEvent
+  #- Trigger: me.rerere.matrix.api.events.PlayerViolationEvent
   #  Channel: matrix
   #  Conditions:
   #    - violations >= 5 # ne pas envoyer d'événements pour les joueurs avec < 5 violations

--- a/src/main/resources/alerts/ja.yml
+++ b/src/main/resources/alerts/ja.yml
@@ -79,7 +79,7 @@
 #
 Alerts:
   # Example config to send messages to the "fish" DiscordSRV channel when a player successfully catches a fish
-  #- Trigger: PlayerFishEvent
+  #- Trigger: org.bukkit.event.player.PlayerFishEvent
   #  Channel: fish
   #  Conditions:
   #    - state.name() == 'CAUGHT_FISH'
@@ -90,7 +90,7 @@ Alerts:
   #      Name: "{name} caught a ${caught.itemStack.type.name()}!"
 
   # Example config to send Matrix anti-cheat messages
-  #- Trigger: PlayerViolationEvent
+  #- Trigger: me.rerere.matrix.api.events.PlayerViolationEvent
   #  Channel: matrix
   #  Conditions:
   #    - violations >= 5 # don't send events for players with < 5 violations

--- a/src/main/resources/alerts/ko.yml
+++ b/src/main/resources/alerts/ko.yml
@@ -79,7 +79,7 @@
 #
 Alerts:
   # Example config to send messages to the "fish" DiscordSRV channel when a player successfully catches a fish
-  #- Trigger: PlayerFishEvent
+  #- Trigger: org.bukkit.event.player.PlayerFishEvent
   #  Channel: fish
   #  Conditions:
   #    - state.name() == 'CAUGHT_FISH'
@@ -90,7 +90,7 @@ Alerts:
   #      Name: "{name} caught a ${caught.itemStack.type.name()}!"
 
   # Example config to send Matrix anti-cheat messages
-  #- Trigger: PlayerViolationEvent
+  #- Trigger: me.rerere.matrix.api.events.PlayerViolationEvent
   #  Channel: matrix
   #  Conditions:
   #    - violations >= 5 # don't send events for players with < 5 violations

--- a/src/main/resources/alerts/nb.yml
+++ b/src/main/resources/alerts/nb.yml
@@ -79,7 +79,7 @@
 #
 Alerts:
   # Konfigurasjonsmal for å sende en melding til DiscordSRV-kanalen "fisk" når en spiller fanger en fisk
-  #- Trigger: PlayerFishEvent
+  #- Trigger: org.bukkit.event.player.PlayerFishEvent
   #  Channel: fish
   #  Conditions:
   #    - state.name() == 'CAUGHT_FISH'
@@ -90,7 +90,7 @@ Alerts:
   #      Name: "{name} fanget en ${caught.itemStack.type.name()}!"
 
   # Konfigurasjonsmal for å sende Matrix' anti-juksekode-meldinger
-  #- Trigger: PlayerViolationEvent
+  #- Trigger: me.rerere.matrix.api.events.PlayerViolationEvent
   #  Channel: matrix
   #  Conditions:
   #    - violations >= 5 # Ikke send events til spillere med mindre enn 5 overtredelser

--- a/src/main/resources/alerts/nl.yml
+++ b/src/main/resources/alerts/nl.yml
@@ -79,7 +79,7 @@
 #
 Alerts:
   # Example config to send messages to the "fish" DiscordSRV channel when a player successfully catches a fish
-  #- Trigger: PlayerFishEvent
+  #- Trigger: org.bukkit.event.player.PlayerFishEvent
   #  Channel: fish
   #  Conditions:
   #    - state.name() == 'CAUGHT_FISH'
@@ -90,7 +90,7 @@ Alerts:
   #      Name: "{name} caught a ${caught.itemStack.type.name()}!"
 
   # Example config to send Matrix anti-cheat messages
-  #- Trigger: PlayerViolationEvent
+  #- Trigger: me.rerere.matrix.api.events.PlayerViolationEvent
   #  Channel: matrix
   #  Conditions:
   #    - violations >= 5 # don't send events for players with < 5 violations

--- a/src/main/resources/alerts/pl.yml
+++ b/src/main/resources/alerts/pl.yml
@@ -79,7 +79,7 @@
 #
 Alerts:
   # Przykładowa konfiguracja wysyłania wiadomości na kanał DiscordSRV „fish”, gdy graczowi uda się złapać rybę
-  #- Trigger: PlayerFishEvent
+  #- Trigger: org.bukkit.event.player.PlayerFishEvent
   #  Channel: fish
   #  Conditions:
   #    - state.name() == 'CAUGHT_FISH'
@@ -90,7 +90,7 @@ Alerts:
   #      Name: "{name} caught a ${caught.itemStack.type.name()}!"
 
   # Przykładowa konfiguracja do wysyłania wiadomości Matrix zapobiegających oszustwom
-  #- Trigger: PlayerViolationEvent
+  #- Trigger: me.rerere.matrix.api.events.PlayerViolationEvent
   #  Channel: matrix
   #  Conditions:
   #    - violations >= 5 # don't send events for players with < 5 violations

--- a/src/main/resources/alerts/ru.yml
+++ b/src/main/resources/alerts/ru.yml
@@ -78,7 +78,7 @@
 #
 Alerts:
   # Конфиг-образец, отправляет сообщение в канал "fish", когда игрок ловит рыбу
-  #- Trigger: PlayerFishEvent
+  #- Trigger: org.bukkit.event.player.PlayerFishEvent
   #  Channel: fish
   #  Conditions:
   #    - state.name() == 'CAUGHT_FISH'
@@ -89,7 +89,7 @@ Alerts:
   #      Name: "{name} поймал ${caught.itemStack.type.name()}!"
 
   # Конфиг-образец, чтобы отправлять уведомления античита Matrix
-  #- Trigger: PlayerViolationEvent
+  #- Trigger: me.rerere.matrix.api.events.PlayerViolationEvent
   #  Channel: matrix
   #  Conditions:
   #    - violations >= 5 # Не отправлять инфу про тех, у кого меньше 5 нарушений

--- a/src/main/resources/alerts/uk.yml
+++ b/src/main/resources/alerts/uk.yml
@@ -77,7 +77,7 @@
 #
 Alerts:
   # Конфіг-зразок, відправляє повідомлення в канал "fish", коли гравець ловить рибу
-  #- Trigger: PlayerFishEvent
+  #- Trigger: org.bukkit.event.player.PlayerFishEvent
   #  Channel: fish
   #  Conditions:
   #    - state.name() == 'CAUGHT_FISH'
@@ -88,7 +88,7 @@ Alerts:
   #      Name: "{name} спіймав ${caught.itemStack.type.name()}!"
 
   # Конфіг-зразок, щоб надсилати повідомлення античита Matrix
-  #- Trigger: PlayerViolationEvent
+  #- Trigger: me.rerere.matrix.api.events.PlayerViolationEvent
   #  Channel: matrix
   #  Conditions:
   #    - violations >= 5 # Не надсилати інфу про тих, у кого менше 5 порушень

--- a/src/main/resources/alerts/zh.yml
+++ b/src/main/resources/alerts/zh.yml
@@ -79,7 +79,7 @@
 #
 Alerts:
   # Example config to send messages to the "fish" DiscordSRV channel when a player successfully catches a fish
-  #- Trigger: PlayerFishEvent
+  #- Trigger: org.bukkit.event.player.PlayerFishEvent
   #  Channel: fish
   #  Conditions:
   #    - state.name() == 'CAUGHT_FISH'
@@ -90,7 +90,7 @@ Alerts:
   #      Name: "{name} caught a ${caught.itemStack.type.name()}!"
 
   # Example config to send Matrix anti-cheat messages
-  #- Trigger: PlayerViolationEvent
+  #- Trigger: me.rerere.matrix.api.events.PlayerViolationEvent
   #  Channel: matrix
   #  Conditions:
   #    - violations >= 5 # don't send events for players with < 5 violations


### PR DESCRIPTION
There is no way to listen for events without knowing the entire class name. 
The current hack to get around this is to register a listener to every event, but this comes with various problems such as:
- Performance problems (some events trigger *very* frequently)
  + Being unable to unregister from unused events reliably, due to some events sharing their HandlerList (see below attempted fix and resulting lag problems)
- Having to replace the allLists field value to detect new events being added to it
  + This field is final [as of Paper 1.21.5](https://github.com/PaperMC/Paper/commit/f00727c57e564f3a8cb875183a54142feb693db7#diff-4cee0ef308b207a5a696351757900f4ff517340c4a655754486cf9ba45dcd7d2R34)


Fixes GH-1793 (In cases where no simple names are used)  
Fixes GH-1814

Docs PR: https://github.com/DiscordSRV/Documentation/pull/85