### PR TITLE
Add support for MultiverseCore API v5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -184,6 +184,8 @@ repositories {
     maven("https://oss.sonatype.org/content/repositories/snapshots")
     maven("https://s01.oss.sonatype.org/content/repositories/snapshots")
     maven("https://nexus.scarsz.me/content/groups/public/")
+    // Multiverse-Core v5
+    maven("https://repo.onarandombox.com/content/groups/public/")
 }
 
 dependencies {
@@ -283,6 +285,7 @@ dependencies {
 
     // world hooks
     compileOnly("com.onarandombox.MultiverseCore:Multiverse-Core:2.4")
+    compileOnly("org.mvplugins.multiverse.core:multiverse-core:5.0.0-SNAPSHOT")
 
     // misc hooks
     compileOnly("org.dynmap:dynmap-api:2.0")

--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -37,7 +37,7 @@ import github.scarsz.discordsrv.hooks.PluginHook;
 import github.scarsz.discordsrv.hooks.VaultHook;
 import github.scarsz.discordsrv.hooks.chat.ChatHook;
 import github.scarsz.discordsrv.hooks.vanish.VanishHook;
-import github.scarsz.discordsrv.hooks.world.MultiverseCoreHook;
+import github.scarsz.discordsrv.hooks.world.WorldHook;
 import github.scarsz.discordsrv.listeners.*;
 import github.scarsz.discordsrv.modules.alerts.AlertListener;
 import github.scarsz.discordsrv.modules.requirelink.RequireLinkModule;
@@ -1130,7 +1130,10 @@ public class DiscordSRV extends JavaPlugin {
                 // dynmap
                 "github.scarsz.discordsrv.hooks.DynmapHook",
                 // luckperms
-                "github.scarsz.discordsrv.hooks.permissions.LuckPermsHook"
+                "github.scarsz.discordsrv.hooks.permissions.LuckPermsHook",
+                // world hooks
+                "github.scarsz.discordsrv.hooks.world.MultiverseCoreV4Hook",
+                "github.scarsz.discordsrv.hooks.world.MultiverseCoreV5Hook"
         }) {
             try {
                 Class<?> hookClass = Class.forName(hookClassName);
@@ -1659,6 +1662,23 @@ public class DiscordSRV extends JavaPlugin {
         }
     }
 
+    /**
+     * Gets the alias for the given world
+     *
+     * @param world The name of the world to get the alias for
+     * @return The world's alias or the provided string if no alias or supported WorldHook was found
+     */
+    public String getWorldAlias(String world) {
+        WorldHook worldHook = pluginHooks.stream()
+                .filter(hook -> hook instanceof WorldHook)
+                .map(hook -> (WorldHook) hook)
+                .findAny()
+                .orElse(null);
+
+        if (worldHook == null) return world;
+        return worldHook.getWorldAlias(world);
+    }
+
     @Deprecated
     public void processChatMessage(Player player, String message, String channel, boolean cancelled) {
         this.processChatMessage(player, message, channel, cancelled, null);
@@ -1786,7 +1806,7 @@ public class DiscordSRV extends JavaPlugin {
                     .replace("%primarygroup%", userPrimaryGroup)
                     .replace("%usernamenoescapes%", MessageUtil.strip(player.getName()))
                     .replace("%world%", player.getWorld().getName())
-                    .replace("%worldalias%", MessageUtil.strip(MultiverseCoreHook.getWorldAlias(player.getWorld().getName())));
+                    .replace("%worldalias%", MessageUtil.strip(getWorldAlias(player.getWorld().getName())));
             // Replace the PAPI placeholders in the message pattern
             discordMessagePattern = PlaceholderUtil.replacePlaceholdersToDiscord(discordMessagePattern, player);
 

--- a/src/main/java/github/scarsz/discordsrv/hooks/world/MultiverseCoreHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/world/MultiverseCoreHook.java
@@ -28,8 +28,17 @@ import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 
+/**
+ * @deprecated Kept for backwards compatibility
+ */
+@Deprecated
+@SuppressWarnings("unused")
 public class MultiverseCoreHook implements PluginHook {
 
+    /**
+     * @deprecated Use {@link DiscordSRV#getWorldAlias(String)} instead
+     */
+    @Deprecated
     public static String getWorldAlias(String world) {
         try {
             if (!PluginUtil.pluginHookIsEnabled("Multiverse-Core")) return world;

--- a/src/main/java/github/scarsz/discordsrv/hooks/world/MultiverseCoreV4Hook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/world/MultiverseCoreV4Hook.java
@@ -1,0 +1,41 @@
+package github.scarsz.discordsrv.hooks.world;
+
+import com.onarandombox.MultiverseCore.MultiverseCore;
+import com.onarandombox.MultiverseCore.api.MultiverseWorld;
+import github.scarsz.discordsrv.util.PluginUtil;
+import org.apache.commons.lang3.StringUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+
+public class MultiverseCoreV4Hook implements WorldHook {
+
+    @Override
+    public String getWorldAlias(String world) {
+        MultiverseCore mvPlugin = (MultiverseCore) Bukkit.getPluginManager().getPlugin("Multiverse-Core");
+        if (mvPlugin == null) return world;
+
+        MultiverseWorld mvWorld = mvPlugin.getMVWorldManager().getMVWorld(world);
+        if (mvWorld == null) return world;
+
+        String alias = mvWorld.getAlias();
+        return StringUtils.isNotBlank(alias) ? alias : world;
+    }
+
+    @Override
+    public Plugin getPlugin() {
+        return PluginUtil.getPlugin("Multiverse-Core");
+    }
+
+    @Override
+    public boolean isEnabled() {
+        boolean enabled = getPlugin() != null && getPlugin().isEnabled() && PluginUtil.pluginHookIsEnabled(getPlugin().getName());
+        if (!enabled) return false;
+
+        try {
+            Class.forName("com.onarandombox.MultiverseCore.MultiverseCore");
+            return true;
+        } catch (ClassNotFoundException ignored) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/github/scarsz/discordsrv/hooks/world/MultiverseCoreV5Hook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/world/MultiverseCoreV5Hook.java
@@ -1,0 +1,44 @@
+package github.scarsz.discordsrv.hooks.world;
+
+import github.scarsz.discordsrv.util.PluginUtil;
+import org.apache.commons.lang3.StringUtils;
+import org.bukkit.plugin.Plugin;
+import org.mvplugins.multiverse.core.MultiverseCoreApi;
+import org.mvplugins.multiverse.core.world.MultiverseWorld;
+import org.mvplugins.multiverse.core.world.WorldManager;
+import org.mvplugins.multiverse.external.vavr.control.Option;
+
+public class MultiverseCoreV5Hook implements WorldHook {
+
+    @Override
+    public String getWorldAlias(String world) {
+        MultiverseCoreApi mvApi = MultiverseCoreApi.get();
+        WorldManager worldManager = mvApi.getWorldManager();
+
+        Option<MultiverseWorld> optionalWorld = worldManager.getWorld(world);
+        if (optionalWorld.isEmpty()) return world;
+
+        MultiverseWorld mvWorld = optionalWorld.get();
+        String alias = mvWorld.getAlias();
+        return StringUtils.isNotBlank(alias) ? alias : world;
+    }
+
+    @Override
+    public Plugin getPlugin() {
+        return PluginUtil.getPlugin("Multiverse-Core");
+    }
+
+    @Override
+    public boolean isEnabled() {
+        Plugin plugin = getPlugin();
+        boolean enabled = plugin != null && plugin.isEnabled() && PluginUtil.pluginHookIsEnabled(plugin.getName());
+        if (!enabled) return false;
+
+        try {
+            Class.forName("org.mvplugins.multiverse.core.MultiverseCoreApi");
+            return true;
+        } catch (ClassNotFoundException ignored) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/github/scarsz/discordsrv/hooks/world/WorldHook.java
+++ b/src/main/java/github/scarsz/discordsrv/hooks/world/WorldHook.java
@@ -1,0 +1,14 @@
+package github.scarsz.discordsrv.hooks.world;
+
+import github.scarsz.discordsrv.hooks.PluginHook;
+
+public interface WorldHook extends PluginHook {
+
+    /**
+     * Gets the alias for the given world
+     *
+     * @param world The name of the world to get the alias for
+     * @return The world's alias or the provided string if no alias was found
+     */
+    String getWorldAlias(String world);
+}

--- a/src/main/java/github/scarsz/discordsrv/listeners/DiscordChatListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/DiscordChatListener.java
@@ -26,7 +26,6 @@ import github.scarsz.discordsrv.DiscordSRV;
 import github.scarsz.discordsrv.api.events.*;
 import github.scarsz.discordsrv.hooks.DynmapHook;
 import github.scarsz.discordsrv.hooks.VaultHook;
-import github.scarsz.discordsrv.hooks.world.MultiverseCoreHook;
 import github.scarsz.discordsrv.objects.proxy.CommandSenderDynamicProxy;
 import github.scarsz.discordsrv.util.*;
 import net.dv8tion.jda.api.entities.Message;
@@ -454,7 +453,7 @@ public class DiscordChatListener extends ListenerAdapter {
                         .replace("%displayname%", MessageUtil.strip(player.getDisplayName()))
                         .replace("%primarygroup%", userPrimaryGroup)
                         .replace("%world%", player.getWorld().getName())
-                        .replace("%worldalias%", MessageUtil.strip(MultiverseCoreHook.getWorldAlias(player.getWorld().getName())));
+                        .replace("%worldalias%", MessageUtil.strip(DiscordSRV.getPlugin().getWorldAlias(player.getWorld().getName())));
 
                 // use PlaceholderAPI if available
                 playerFormat = PlaceholderUtil.replacePlaceholdersToDiscord(playerFormat, player);


### PR DESCRIPTION
Added support for the new Multiverse Core v5 which introduced API breaking changes, which resulted in breaking DiscordSRV's Minecraft -> Discord message forwarding feature.

Multiverse Core v4 is still supported