### PR TITLE
add 1.21.9 GameProfile properties method name to nms util

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/util/NMSUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/NMSUtil.java
@@ -20,12 +20,12 @@
 
 package github.scarsz.discordsrv.util;
 
-import org.apache.commons.codec.binary.Base64;
-import org.bukkit.Bukkit;
 import github.scarsz.discordsrv.Debug;
 import github.scarsz.discordsrv.DiscordSRV;
+import org.apache.commons.codec.binary.Base64;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
-import org.bukkit.advancement.Advancement;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -91,7 +91,12 @@ public class NMSUtil {
                 class_GameProfile = getClass("net.minecraft.util.com.mojang.authlib.GameProfile");
                 class_GameProfileProperty = getClass("net.minecraft.util.com.mojang.authlib.properties.Property");
             }
-            method_GameProfile_getProperties = class_GameProfile.getMethod("getProperties");
+
+            method_GameProfile_getProperties = getMethod(class_GameProfile, "getProperties");
+            if (method_GameProfile_getProperties == null) {
+                method_GameProfile_getProperties = getMethod(class_GameProfile, "properties");
+            }
+
             field_GameProfileProperty_value = class_GameProfileProperty.getDeclaredField("value");
             field_GameProfileProperty_value.setAccessible(true);
             field_PropertyMap_properties = method_GameProfile_getProperties.getReturnType().getDeclaredField("properties");
@@ -107,6 +112,14 @@ public class NMSUtil {
         Class<?> result = null;
         try {
             result = NMSUtil.class.getClassLoader().loadClass(className);
+        } catch (Exception ignored) {}
+        return result;
+    }
+
+    public static Method getMethod(Class<?> methodClass, String methodName) {
+        Method result = null;
+        try {
+            result = methodClass.getMethod(methodName);
         } catch (Exception ignored) {}
         return result;
     }

--- a/src/main/java/github/scarsz/discordsrv/util/NMSUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/NMSUtil.java
@@ -20,12 +20,12 @@
 
 package github.scarsz.discordsrv.util;
 
-import github.scarsz.discordsrv.Debug;
-import github.scarsz.discordsrv.DiscordSRV;
 import org.apache.commons.codec.binary.Base64;
 import org.bukkit.Bukkit;
+import github.scarsz.discordsrv.Debug;
+import github.scarsz.discordsrv.DiscordSRV;
 import org.bukkit.entity.Player;
-
+import org.bukkit.advancement.Advancement;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;


### PR DESCRIPTION
GameProfile::getProperties method has been renamed to "properties" in minecraft 1.21.9