### PR TITLE
fix typo it's to its where you want the possessive pronoun

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Without this, we can't help.
 # Translating
 If you'd like to help DiscordSRV by translating it to a new language, you'll need to fork the repo and make
 edits to your fork's `develop` branch, specifically copy + pasting the English config, messages, synchronization, alerts and voice files and
-translating everything except the names of values. Also, add the language and it's associated 639-1 code to
+translating everything except the names of values. Also, add the language and its associated 639-1 code to
 `src/main/java/github/scarsz/discordsrv/util/LangUtil.java` and translate the messages there.
 
 # Submitting a pull request

--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -699,7 +699,7 @@ public class DiscordSRV extends JavaPlugin {
                     }
 
                     // this sleep is here to prevent OkHTTP from repeatedly trying to query DNS servers with no
-                    // delay of it's own when internet connectivity is lost. that's extremely bad because it'll be
+                    // delay of its own when internet connectivity is lost. that's extremely bad because it'll be
                     // spitting errors into the console and consuming 100% cpu
                     try {
                         Thread.sleep(500);
@@ -1497,7 +1497,7 @@ public class DiscordSRV extends JavaPlugin {
                         Field configField = null;
                         Class<?> targetClass = logger.getClass();
 
-                        // get a field named config or privateConfig from the logger class or any of it's super classes
+                        // get a field named config or privateConfig from the logger class or any of its super classes
                         while (targetClass != null) {
                             try {
                                 configField = targetClass.getDeclaredField("config");
@@ -2154,7 +2154,7 @@ public class DiscordSRV extends JavaPlugin {
         }
 
         if (username.startsWith("*")) {
-            // geyser adds * to beginning of it's usernames
+            // geyser adds * to beginning of its usernames
             username = username.substring(1);
         }
         try {
@@ -2251,7 +2251,7 @@ public class DiscordSRV extends JavaPlugin {
     }
 
     /**
-     * @return Whether DiscordSRV should disable it's update checker. Doing so is dangerous and can lead to
+     * @return Whether DiscordSRV should disable its update checker. Doing so is dangerous and can lead to
      * security vulnerabilities. You shouldn't use this.
      */
     public static boolean isUpdateCheckDisabled() {

--- a/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
+++ b/src/main/java/github/scarsz/discordsrv/api/ApiManager.java
@@ -56,7 +56,7 @@ import java.util.stream.Collectors;
  * <br>
  * <p>To register your class to receive events:</p>
  * <ol>
- *     <li>Have a class with methods marked {@link Subscribe} that take the event to listen for as it's <i>only</i> parameter</li>
+ *     <li>Have a class with methods marked {@link Subscribe} that take the event to listen for as its <i>only</i> parameter</li>
  *     <li>Pass an instance of that class to {@link #subscribe(Object)}</li>
  * </ol>
  * <p>{@link ListenerPriority} can optionally be set, defaulting to ListenerPriority.NORMAL</p>
@@ -360,7 +360,7 @@ public class ApiManager extends ListenerAdapter {
     }
 
     /**
-     * Attempt to find the owning {@link Plugin} of the offending class and print the provided throwable to it's logger
+     * Attempt to find the owning {@link Plugin} of the offending class and print the provided throwable to its logger
      * @param offendingClass the offending plugin class
      * @param throwable throwable to print
      * @return whether the plugin was successfully determined

--- a/src/main/java/github/scarsz/discordsrv/objects/managers/GroupSynchronizationManager.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/managers/GroupSynchronizationManager.java
@@ -475,7 +475,7 @@ public class GroupSynchronizationManager extends ListenerAdapter implements List
         } catch (Throwable t) {
             name = permission.getClass().getName();
         }
-        DiscordSRV.error(problem + ". Caused by a error in Vault or it's permissions provider: " + name, throwable);
+        DiscordSRV.error(problem + ". Caused by a error in Vault or its permissions provider: " + name, throwable);
     }
 
     public void resyncEveryone(SyncCause cause) {

--- a/src/main/java/github/scarsz/discordsrv/util/DebugUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/DebugUtil.java
@@ -613,7 +613,7 @@ public class DebugUtil {
 
     /**
      * Upload the given file map to the current reporting service
-     * @param files A Map representing a structure of file name & it's contents
+     * @param files A Map representing a structure of file name & its contents
      * @param requester Person who requested the debug report
      * @return A user-friendly message of how the report went
      */


### PR DESCRIPTION
Title is self explanatory. This PR replaces cases where "it's" was used incorrectly in place of the possessive pronoun "its."