### PR TITLE
only print one error message in topic updater

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -1418,22 +1418,36 @@ public class DiscordSRV extends JavaPlugin {
                     String serverVersion = Bukkit.getBukkitVersion();
                     String totalPlayers = Integer.toString(getTotalPlayerCount());
                     String shutdownTimestamp = Long.toString(System.currentTimeMillis() / 1000);
-                    DiscordUtil.setTextChannelTopic(
-                            getMainTextChannel(),
-                            LangUtil.Message.CHAT_CHANNEL_TOPIC_AT_SERVER_SHUTDOWN.toString()
-                                    .replaceAll("%time%|%date%", time)
-                                    .replace("%serverversion%", serverVersion)
-                                    .replace("%totalplayers%", totalPlayers)
-                                    .replace("%timestamp%", shutdownTimestamp)
-                    );
-                    DiscordUtil.setTextChannelTopic(
-                            getConsoleChannel(),
-                            LangUtil.Message.CONSOLE_CHANNEL_TOPIC_AT_SERVER_SHUTDOWN.toString()
-                                    .replaceAll("%time%|%date%", time)
-                                    .replace("%serverversion%", serverVersion)
-                                    .replace("%totalplayers%", totalPlayers)
-                                    .replace("%timestamp%", shutdownTimestamp)
-                    );
+
+                    TextChannel mainTextChannel = getMainTextChannel();
+
+                    try {
+                        DiscordUtil.setTextChannelTopic(
+                                mainTextChannel,
+                                LangUtil.Message.CHAT_CHANNEL_TOPIC_AT_SERVER_SHUTDOWN.toString()
+                                        .replaceAll("%time%|%date%", time)
+                                        .replace("%serverversion%", serverVersion)
+                                        .replace("%totalplayers%", totalPlayers)
+                                        .replace("%timestamp%", shutdownTimestamp)
+                        );
+                    } catch (PermissionException e) {
+                        DiscordSRV.warning("Could not set topic of channel #" + mainTextChannel.getName() + " because the bot does not have the \"" + e.getPermission().getName() + "\" permission");
+                    }
+
+                    TextChannel consoleChannel = getConsoleChannel();
+
+                    try {
+                        DiscordUtil.setTextChannelTopic(
+                                consoleChannel,
+                                LangUtil.Message.CONSOLE_CHANNEL_TOPIC_AT_SERVER_SHUTDOWN.toString()
+                                        .replaceAll("%time%|%date%", time)
+                                        .replace("%serverversion%", serverVersion)
+                                        .replace("%totalplayers%", totalPlayers)
+                                        .replace("%timestamp%", shutdownTimestamp)
+                        );
+                    } catch (PermissionException e) {
+                        DiscordSRV.warning("Could not set topic of channel #" + consoleChannel.getName() + " because the bot does not have the \"" + e.getPermission().getName() + "\" permission");
+                    }
                 }
 
                 for (ChannelUpdater.UpdaterChannel updaterChannel : getChannelUpdater().getUpdaterChannels()) {

--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -1418,7 +1418,6 @@ public class DiscordSRV extends JavaPlugin {
                     String serverVersion = Bukkit.getBukkitVersion();
                     String totalPlayers = Integer.toString(getTotalPlayerCount());
                     String shutdownTimestamp = Long.toString(System.currentTimeMillis() / 1000);
-
                     DiscordUtil.setTextChannelTopic(
                             getMainTextChannel(),
                             LangUtil.Message.CHAT_CHANNEL_TOPIC_AT_SERVER_SHUTDOWN.toString()
@@ -1427,7 +1426,6 @@ public class DiscordSRV extends JavaPlugin {
                                     .replace("%totalplayers%", totalPlayers)
                                     .replace("%timestamp%", shutdownTimestamp)
                     );
-
                     DiscordUtil.setTextChannelTopic(
                             getConsoleChannel(),
                             LangUtil.Message.CONSOLE_CHANNEL_TOPIC_AT_SERVER_SHUTDOWN.toString()

--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -1419,35 +1419,23 @@ public class DiscordSRV extends JavaPlugin {
                     String totalPlayers = Integer.toString(getTotalPlayerCount());
                     String shutdownTimestamp = Long.toString(System.currentTimeMillis() / 1000);
 
-                    TextChannel mainTextChannel = getMainTextChannel();
+                    DiscordUtil.setTextChannelTopic(
+                            getMainTextChannel(),
+                            LangUtil.Message.CHAT_CHANNEL_TOPIC_AT_SERVER_SHUTDOWN.toString()
+                                    .replaceAll("%time%|%date%", time)
+                                    .replace("%serverversion%", serverVersion)
+                                    .replace("%totalplayers%", totalPlayers)
+                                    .replace("%timestamp%", shutdownTimestamp)
+                    );
 
-                    try {
-                        DiscordUtil.setTextChannelTopic(
-                                mainTextChannel,
-                                LangUtil.Message.CHAT_CHANNEL_TOPIC_AT_SERVER_SHUTDOWN.toString()
-                                        .replaceAll("%time%|%date%", time)
-                                        .replace("%serverversion%", serverVersion)
-                                        .replace("%totalplayers%", totalPlayers)
-                                        .replace("%timestamp%", shutdownTimestamp)
-                        );
-                    } catch (PermissionException e) {
-                        DiscordSRV.warning("Could not set topic of channel #" + mainTextChannel.getName() + " because the bot does not have the \"" + e.getPermission().getName() + "\" permission");
-                    }
-
-                    TextChannel consoleChannel = getConsoleChannel();
-
-                    try {
-                        DiscordUtil.setTextChannelTopic(
-                                consoleChannel,
-                                LangUtil.Message.CONSOLE_CHANNEL_TOPIC_AT_SERVER_SHUTDOWN.toString()
-                                        .replaceAll("%time%|%date%", time)
-                                        .replace("%serverversion%", serverVersion)
-                                        .replace("%totalplayers%", totalPlayers)
-                                        .replace("%timestamp%", shutdownTimestamp)
-                        );
-                    } catch (PermissionException e) {
-                        DiscordSRV.warning("Could not set topic of channel #" + consoleChannel.getName() + " because the bot does not have the \"" + e.getPermission().getName() + "\" permission");
-                    }
+                    DiscordUtil.setTextChannelTopic(
+                            getConsoleChannel(),
+                            LangUtil.Message.CONSOLE_CHANNEL_TOPIC_AT_SERVER_SHUTDOWN.toString()
+                                    .replaceAll("%time%|%date%", time)
+                                    .replace("%serverversion%", serverVersion)
+                                    .replace("%totalplayers%", totalPlayers)
+                                    .replace("%timestamp%", shutdownTimestamp)
+                    );
                 }
 
                 for (ChannelUpdater.UpdaterChannel updaterChannel : getChannelUpdater().getUpdaterChannels()) {

--- a/src/main/java/github/scarsz/discordsrv/objects/threads/ChannelTopicUpdater.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/threads/ChannelTopicUpdater.java
@@ -24,6 +24,7 @@ import github.scarsz.discordsrv.DiscordSRV;
 import github.scarsz.discordsrv.util.DiscordUtil;
 import github.scarsz.discordsrv.util.LangUtil;
 import github.scarsz.discordsrv.util.PlaceholderUtil;
+import java.util.concurrent.atomic.AtomicBoolean;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.exceptions.PermissionException;
 import org.apache.commons.lang3.StringUtils;
@@ -32,45 +33,29 @@ import java.util.concurrent.TimeUnit;
 
 public class ChannelTopicUpdater extends Thread {
 
-    boolean lastUpdateChatChannelTopicFailed = false;
-    boolean lastUpdateConsoleChannelTopicFailed = false;
+    private final AtomicBoolean hasFailedUpdateChatChannelTopic = new AtomicBoolean(false);
+    private final AtomicBoolean hasFailedUpdateConsoleChannelTopic = new AtomicBoolean(false);
 
     public ChannelTopicUpdater() {
         setName("DiscordSRV - Channel Topic Updater");
     }
 
-    private boolean updateTopic(TextChannel channel, String topic, boolean lastFailed) {
+    private void updateTopic(TextChannel channel, String topic, AtomicBoolean hasFailed) {
         if (StringUtils.isNotBlank(topic)) {
             try {
                 DiscordUtil.setTextChannelTopic(channel, topic);
             } catch (PermissionException e) {
-                if (!lastFailed) {
+                if (!hasFailed.get()) {
                     DiscordSRV.warning("The bot requires the permission " + e.getPermission()
                             + " to set topic for the channel #" + channel.getName()
                             + ". Topic updating will not work until permission is given.");
 
-                    return true;
+                    hasFailed.set(true);
                 }
+                return;
             }
-
-            return false;
+            hasFailed.set(false);
         }
-
-        return lastFailed;
-    }
-
-    private void updateChatChannelTopic() {
-        TextChannel channel = DiscordSRV.getPlugin().getMainTextChannel();
-        String topic = PlaceholderUtil.replaceChannelUpdaterPlaceholders(LangUtil.Message.CHAT_CHANNEL_TOPIC.toString());
-
-        lastUpdateChatChannelTopicFailed = updateTopic(channel, topic, lastUpdateChatChannelTopicFailed);
-    }
-
-    private void updateConsoleChannelTopic() {
-        TextChannel channel = DiscordSRV.getPlugin().getConsoleChannel();
-        String topic = PlaceholderUtil.replaceChannelUpdaterPlaceholders(LangUtil.Message.CONSOLE_CHANNEL_TOPIC.toString());
-
-        lastUpdateConsoleChannelTopicFailed = updateTopic(channel, topic, lastUpdateConsoleChannelTopicFailed);
     }
 
     @Override
@@ -80,8 +65,11 @@ public class ChannelTopicUpdater extends Thread {
             if (rate < 10) rate = 10;
 
             if (DiscordUtil.getJda() != null) {
-                updateChatChannelTopic();
-                updateConsoleChannelTopic();
+                String chatTopic = PlaceholderUtil.replaceChannelUpdaterPlaceholders(LangUtil.Message.CHAT_CHANNEL_TOPIC.toString());
+                updateTopic(DiscordSRV.getPlugin().getMainTextChannel(), chatTopic, hasFailedUpdateChatChannelTopic);
+
+                String consoleTopic = PlaceholderUtil.replaceChannelUpdaterPlaceholders(LangUtil.Message.CONSOLE_CHANNEL_TOPIC.toString());
+                updateTopic(DiscordSRV.getPlugin().getConsoleChannel(), consoleTopic, hasFailedUpdateConsoleChannelTopic);
             } else {
                 DiscordSRV.debug("Skipping channel topic update cycle, JDA was null");
             }

--- a/src/main/java/github/scarsz/discordsrv/objects/threads/ChannelTopicUpdater.java
+++ b/src/main/java/github/scarsz/discordsrv/objects/threads/ChannelTopicUpdater.java
@@ -39,7 +39,7 @@ public class ChannelTopicUpdater extends Thread {
         setName("DiscordSRV - Channel Topic Updater");
     }
 
-    boolean updateTopic(TextChannel channel, String topic, boolean lastFailed) {
+    private boolean updateTopic(TextChannel channel, String topic, boolean lastFailed) {
         if (StringUtils.isNotBlank(topic)) {
             try {
                 DiscordUtil.setTextChannelTopic(channel, topic);
@@ -59,14 +59,14 @@ public class ChannelTopicUpdater extends Thread {
         return lastFailed;
     }
 
-    void updateChatChannelTopic() {
+    private void updateChatChannelTopic() {
         TextChannel channel = DiscordSRV.getPlugin().getMainTextChannel();
         String topic = PlaceholderUtil.replaceChannelUpdaterPlaceholders(LangUtil.Message.CHAT_CHANNEL_TOPIC.toString());
 
         lastUpdateChatChannelTopicFailed = updateTopic(channel, topic, lastUpdateChatChannelTopicFailed);
     }
 
-    void updateConsoleChannelTopic() {
+    private void updateConsoleChannelTopic() {
         TextChannel channel = DiscordSRV.getPlugin().getConsoleChannel();
         String topic = PlaceholderUtil.replaceChannelUpdaterPlaceholders(LangUtil.Message.CONSOLE_CHANNEL_TOPIC.toString());
 

--- a/src/main/java/github/scarsz/discordsrv/util/DiscordUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/DiscordUtil.java
@@ -504,7 +504,7 @@ public class DiscordUtil {
      * @param channel The channel to set the topic of
      * @param topic The new topic to be set
      */
-    public static void setTextChannelTopic(TextChannel channel, String topic) {
+    public static void setTextChannelTopic(TextChannel channel, String topic) throws PermissionException {
         if (channel == null) {
             DiscordSRV.debug("Attempted to set status of null channel");
             return;
@@ -514,10 +514,7 @@ public class DiscordUtil {
             channel.getManager().setTopic(topic).queue();
         } catch (Exception e) {
             if (e instanceof PermissionException) {
-                PermissionException pe = (PermissionException) e;
-                if (pe.getPermission() != Permission.UNKNOWN) {
-                    DiscordSRV.warning("Could not set topic of channel " + channel + " because the bot does not have the \"" + pe.getPermission().getName() + "\" permission");
-                }
+                throw e;
             } else {
                 DiscordSRV.warning("Could not set topic of channel " + channel + " because \"" + e.getMessage() + "\"");
             }

--- a/src/main/java/github/scarsz/discordsrv/util/DiscordUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/DiscordUtil.java
@@ -504,21 +504,32 @@ public class DiscordUtil {
      * @param channel The channel to set the topic of
      * @param topic The new topic to be set
      */
-    public static void setTextChannelTopic(TextChannel channel, String topic) throws PermissionException {
+    public static void setTextChannelTopic(TextChannel channel, String topic) {
+        setTextChannelTopic(channel, topic, throwable -> {
+            if (throwable instanceof PermissionException) {
+                PermissionException permissionException = (PermissionException) throwable;
+                if (permissionException.getPermission() != Permission.UNKNOWN) {
+                    DiscordSRV.warning("Could not set topic of channel #" + channel + " because the bot does not have the \"" + permissionException.getPermission().getName() + "\" permission");
+                }
+            } else {
+                DiscordSRV.warning("Could not set topic of channel #" + channel + " because \"" + throwable.getMessage() + "\"");
+            }
+        });
+    }
+
+    /**
+     * Set the topic message of the given channel
+     * @param channel The channel to set the topic of
+     * @param topic The new topic to be set
+     * @param failure A failure callback that will be called if the Request encounters an exception
+     */
+    public static void setTextChannelTopic(TextChannel channel, String topic, Consumer<? super Throwable> failure) {
         if (channel == null) {
             DiscordSRV.debug("Attempted to set status of null channel");
             return;
         }
 
-        try {
-            channel.getManager().setTopic(topic).queue();
-        } catch (Exception e) {
-            if (e instanceof PermissionException) {
-                throw e;
-            } else {
-                DiscordSRV.warning("Could not set topic of channel " + channel + " because \"" + e.getMessage() + "\"");
-            }
-        }
+        channel.getManager().setTopic(topic).queue(null, failure);
     }
 
     /**


### PR DESCRIPTION
This fixes what I perceive to be a flaw where the bot will flood the console if it doesn't have the permission to manage channels.

<img width="1051" height="708" alt="image" src="https://github.com/user-attachments/assets/d5de100e-9885-41bf-b69d-571511a241ec" />

It replaces that with the following message
<img width="1041" height="125" alt="image" src="https://github.com/user-attachments/assets/5fd3ff19-b63e-43d3-84e4-a68b1753d36a" />

This PR also necessarily changed `DiscordUtil.setTextChannelTopic` to throw a `PermissionException` when your bot lacks permission to set the channel settings, instead of printing a generic message for that case. Which, I think is slightly better anyway, but it did require touching code in `DiscordSRV` as well.