### PR TITLE
Remove redundant closing tag in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A Minecraft to Discord and back link plugin
     <tr>
         <td align="center" width="50%">
             <a href="https://www.jetbrains.com/idea/"><img src="https://resources.jetbrains.com/storage/products/company/brand/logos/jetbrains.svg" alt="Jetbrains" width="400px"></a>
-            <p><strong>IntelliJ IDEA - The Leading Java and Kotlin IDE</strong></a></p>
+            <p><strong>IntelliJ IDEA - The Leading Java and Kotlin IDE</strong></p>
         </td>
         <td align="center" width="50%">
             <a href="http://www.ej-technologies.com/products/jprofiler/overview.html"><img src="https://www.ej-technologies.com/images/product_banners/jprofiler_large.png" alt="JProfiler" width="150px"></img></a>


### PR DESCRIPTION
Hi maintainers,

This PR removes an extra `</a>` tag in the README.md file.
The tag had no matching `<a>` tag, so this is just a minor cleanup.

Thanks.