### PR TITLE
Flatten MiniMessage tags in Minecraft -> Discord chat format

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/github/scarsz/discordsrv/DiscordSRV.java
@@ -1811,6 +1811,12 @@ public class DiscordSRV extends JavaPlugin {
             // Replace the PAPI placeholders in the message pattern
             discordMessagePattern = PlaceholderUtil.replacePlaceholdersToDiscord(discordMessagePattern, player);
 
+            // Flatten MiniMessage tags from the substituted pattern. LuckPerms prefixes and PAPI
+            // expansions commonly return MiniMessage (eg. <gradient:red:blue>Owner</gradient>); since
+            // the format pattern itself is never reserialized to Discord markdown, those tags would
+            // otherwise appear in chat as literal text. See DiscordSRV/DiscordSRV#1868.
+            discordMessagePattern = MessageUtil.stripMiniMessage(discordMessagePattern);
+
             /*
             // Reserialize the message pattern, in the case the placeholders added more color codes.
             // DiscordSRV is not ready for this yet. Leaving this here for when that faithful day comes upon us.

--- a/src/main/java/github/scarsz/discordsrv/util/MessageUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/MessageUtil.java
@@ -37,6 +37,7 @@ import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
@@ -375,6 +376,20 @@ public class MessageUtil {
      */
     public static String strip(String text) {
         return stripLegacy(text);
+    }
+
+    /**
+     * Parses the given String as MiniMessage and serializes it to plain text, removing all
+     * MiniMessage tags (eg. {@code <gradient:red:blue>Owner</gradient>} -&gt; {@code Owner}).
+     * Unlike {@link #stripMiniTokens(String)} this uses the actual MiniMessage parser, so
+     * nested, malformed, or escaped tags are handled the same way the renderer would.
+     *
+     * @param text the input that may contain MiniMessage tags
+     * @return the same text with all MiniMessage formatting flattened to plain characters
+     */
+    public static String stripMiniMessage(String text) {
+        if (text == null || text.isEmpty()) return text;
+        return PlainTextComponentSerializer.plainText().serialize(MiniMessage.miniMessage().deserialize(text));
     }
 
     /**


### PR DESCRIPTION
LuckPerms prefixes and PAPI expansions commonly return MiniMessage now (eg. <gradient:red:blue>Owner</gradient>). Because the chat format pattern itself is never reserialized to Discord markdown, those tags appeared in chat as literal text rather than the rendered prefix.

Add MessageUtil.stripMiniMessage which parses input as MiniMessage and serializes via PlainTextComponentSerializer so the tag syntax is removed while the underlying text is preserved. Apply it to the substituted format pattern in DiscordSRV.translateAndSendToDiscord, after PAPI substitution but before %message% is filled in (so the player's own message body is unaffected).

Closes DiscordSRV/DiscordSRV#1868