### PR TITLE
Return onPlayerAdvancementDone if advancement message is null

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerAdvancementDoneListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerAdvancementDoneListener.java
@@ -88,9 +88,9 @@ public class PlayerAdvancementDoneListener implements Listener {
 
         // return if message is null as plugins can set this to prevent the advancement being sent in chat
         try {
-            Method message = event.getClass().getMethod("message");
-            if (message.invoke(event) == null) return ;
-        } catch (ReflectiveOperationException e ) {
+            Method messageGetter = event.getClass().getMethod("message");
+            if (messageGetter.invoke(event) == null) return;
+        } catch (ReflectiveOperationException e) {
             return;
         }
 

--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerAdvancementDoneListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerAdvancementDoneListener.java
@@ -86,6 +86,14 @@ public class PlayerAdvancementDoneListener implements Listener {
         // return if advancement or player objects are knackered because this can apparently happen for some reason
         if (event.getAdvancement() == null || player == null) return;
 
+        // return if message is null as plugins can set this to prevent the advancement being sent in chat
+        try {
+            Method message = event.getClass().getMethod("message");
+            if (message.invoke(event) == null) return ;
+        } catch (ReflectiveOperationException e ) {
+            return;
+        }
+
         // respect invisibility plugins
         if (PlayerUtil.isVanished(player)) return;
 


### PR DESCRIPTION
As per the [Paper docs](https://jd.papermc.io/paper/26.2/org/bukkit/event/player/PlayerAdvancementDoneEvent.html), `message()` is a `@Nullable` Component, meaning that plugins can set this to `null` to prevent it being sent in Minecraft's ingame chat. 

DiscordSRV should recognise this way of preventing chat messages being sent about Advancements, and mirror the same behaviour.

