### PR TITLE
continue onPlayerAdvancementDone() upon message reflection failure

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerAdvancementDoneListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerAdvancementDoneListener.java
@@ -91,7 +91,7 @@ public class PlayerAdvancementDoneListener implements Listener {
             Method messageGetter = event.getClass().getMethod("message");
             if (messageGetter.invoke(event) == null) return;
         } catch (ReflectiveOperationException e) {
-            return;
+            // send advancement in chat as normal upon reflection failure
         }
 
         // respect invisibility plugins


### PR DESCRIPTION
Follow-on PR from #1881 

Addresses the later comment that we should silently ignore any reflection failure, and continue with the advancement message in chat as normal.